### PR TITLE
chore: peer discovery should emit peer id

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "it-goodbye": "^2.0.1",
     "libp2p-tcp": "^0.14.1",
     "multiaddr": "^7.1.0",
+    "p-defer": "^3.0.0",
     "p-limit": "^2.2.1",
     "p-wait-for": "^3.1.0",
     "peer-id": "^0.13.3",

--- a/src/peer-discovery/README.md
+++ b/src/peer-discovery/README.md
@@ -69,6 +69,14 @@ It returns a `Promise`
 
 ### discoverying peers
 
-- `discovery.on('peer', (peerInfo) => {})`
+A discovery service must have a `_onPeer` function which just emits `peer` events with the `PeerId` of the discovered peer.
 
-Everytime a peer is discovered by a discovery service, it emmits a `peer` event with the discover peer's [PeerInfo](https://github.com/libp2p/js-peer-info).
+```js
+_onPeer (peerId) {
+  this.emit('peer', peerId)
+}
+```
+
+- `discovery.on('peer', (peerId) => {})`
+
+Everytime a peer is discovered by a discovery service, it emmits a `peer` event with the discover peer's [PeerId](https://github.com/libp2p/js-peer-id).

--- a/src/peer-discovery/tests/index.js
+++ b/src/peer-discovery/tests/index.js
@@ -1,6 +1,14 @@
 /* eslint-env mocha */
 'use strict'
 
+const chai = require('chai')
+const expect = chai.expect
+chai.use(require('dirty-chai'))
+
+const PeerId = require('peer-id')
+
+const pDefer = require('p-defer')
+
 module.exports = (common) => {
   describe('interface-peer-discovery', () => {
     let discovery
@@ -29,6 +37,20 @@ module.exports = (common) => {
     it('should not fail to start the service if it is already started', async () => {
       await discovery.start()
       await discovery.start()
+    })
+
+    it('should emit an event with the discovered PeerId when _onPeer is called', async () => {
+      const deferred = pDefer()
+      const peerId = await PeerId.create({ bits: 512 })
+
+      discovery.on('peer', (id) => {
+        expect(PeerId.isPeerId(id)).to.eql(true)
+        deferred.resolve()
+      })
+
+      discovery._onPeer(peerId)
+
+      await deferred.promise
     })
   })
 }

--- a/test/peer-discovery/mock-discovery.js
+++ b/test/peer-discovery/mock-discovery.js
@@ -3,7 +3,6 @@
 const { EventEmitter } = require('events')
 
 const PeerId = require('peer-id')
-const PeerInfo = require('peer-info')
 
 /**
  * Emits 'peer' events on discovery.
@@ -33,14 +32,17 @@ class MockDiscovery extends EventEmitter {
     this._isRunning = false
   }
 
+  _onPeer (peerId) {
+    this.emit('peer', peerId)
+  }
+
   async _discoverPeer () {
     if (!this._isRunning) return
 
     const peerId = await PeerId.create({ bits: 512 })
-    const peerInfo = new PeerInfo(peerId)
 
     this._timer = setTimeout(() => {
-      this.emit('peer', peerInfo)
+      this._onPeer(peerId)
     }, this.options.discoveryDelay || 1000)
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: peer discovery event param is a PeerId instance instead of a PeerInfo instance

Context: https://github.com/libp2p/js-peer-info/issues/85

I added `_onPeer` as a mandatory function to be implemented, so that we can test the event emitted uniformly. Any better ideas to make it?