### PR TITLE
chore: remove peer-info usage on topology

### DIFF
--- a/src/topology/README.md
+++ b/src/topology/README.md
@@ -56,8 +56,8 @@ const toplogy = new MulticodecTopology({
   max: 50,
   multicodecs: ['/echo/1.0.0'],
   handlers: {
-    onConnect: (peerInfo, conn) => {},
-    onDisconnect: (peerInfo) => {}
+    onConnect: (peerId, conn) => {},
+    onDisconnect: (peerId) => {}
   }
 })
 ```
@@ -69,8 +69,8 @@ The `MulticodecTopology` extends the `Topology`, which makes the `Topology` API 
 ###  Topology
 
 - `Topology`
-  - `peers<Map<string, PeerInfo>>`: A Map of peers belonging to the topology.
-  - `disconnect<function(PeerInfo)>`: Called when a peer has been disconnected
+  - `peers<Map<string, PeerId>>`: A Map of peers belonging to the topology.
+  - `disconnect<function(PeerId)>`: Called when a peer has been disconnected
 
 #### Constructor
 
@@ -79,8 +79,8 @@ const toplogy = new Topology({
   min: 0,
   max: 50,
   handlers: {
-    onConnect: (peerInfo, conn) => {},
-    onDisconnect: (peerInfo) => {}
+    onConnect: (peerId, conn) => {},
+    onDisconnect: (peerId) => {}
   }
 })
 ```
@@ -95,27 +95,27 @@ const toplogy = new Topology({
 
 #### Set a peer
 
-- `topology.peers.set(id, peerInfo)`
+- `topology.peers.set(id, peerId)`
 
 Add a peer to the topology.
 
 **Parameters**
 - `id` is the `string` that identifies the peer to add.
-- `peerInfo` is the [PeerInfo][peer-info] of the peer to add.
+- `peerId` is the [PeerId][peer-id] of the peer to add.
 
 #### Notify about a peer disconnected event
 
-- `topology.disconnect(peerInfo)`
+- `topology.disconnect(peerId)`
 
 **Parameters**
-- `peerInfo` is the [PeerInfo][peer-info] of the peer disconnected.
+- `peerId` is the [PeerIid][peer-id] of the peer disconnected.
 
 ###  Multicodec Topology
 
 - `MulticodecTopology`
   - `registrar<Registrar>`: The `Registrar` of the topology. This is set by the `Registrar` during registration.
-  - `peers<Map<string, PeerInfo>>`: The Map of peers that belong to the topology
-  - `disconnect<function(PeerInfo)>`: Disconnects a peer from the topology.
+  - `peers<Map<string, PeerId>>`: The Map of peers that belong to the topology
+  - `disconnect<function(PeerId)>`: Disconnects a peer from the topology.
 
 #### Constructor
 
@@ -125,8 +125,8 @@ const toplogy = new MulticodecTopology({
   max: 50,
   multicodecs: ['/echo/1.0.0'],
   handlers: {
-    onConnect: (peerInfo, conn) => {},
-    onDisconnect: (peerInfo) => {}
+    onConnect: (peerId, conn) => {},
+    onDisconnect: (peerId) => {}
   }
 })
 ```

--- a/src/topology/README.md
+++ b/src/topology/README.md
@@ -108,7 +108,7 @@ Add a peer to the topology.
 - `topology.disconnect(peerId)`
 
 **Parameters**
-- `peerId` is the [PeerIid][peer-id] of the peer disconnected.
+- `peerId` is the [PeerId][peer-id] of the peer disconnected.
 
 ###  Multicodec Topology
 
@@ -139,3 +139,5 @@ const toplogy = new MulticodecTopology({
   - `handlers` is an optional `Object` containing the handler called when a peer is connected or disconnected.
     - `onConnect` is a `function` called everytime a peer is connected in the topology context.
     - `onDisconnect` is a `function` called everytime a peer is disconnected in the topology context.
+
+[peer-id]: https://github.com/libp2p/js-peer-id

--- a/src/topology/index.js
+++ b/src/topology/index.js
@@ -26,6 +26,7 @@ class Topology {
     this._onConnect = handlers.onConnect || noop
     this._onDisconnect = handlers.onDisconnect || noop
 
+    // TODO: can this be a set?
     this.peers = new Map()
   }
 
@@ -35,11 +36,11 @@ class Topology {
 
   /**
    * Notify about peer disconnected event.
-   * @param {PeerInfo} peerInfo
+   * @param {PeerId} peerId
    * @returns {void}
    */
-  disconnect (peerInfo) {
-    this._onDisconnect(peerInfo)
+  disconnect (peerId) {
+    this._onDisconnect(peerId)
   }
 }
 

--- a/src/topology/index.js
+++ b/src/topology/index.js
@@ -26,8 +26,11 @@ class Topology {
     this._onConnect = handlers.onConnect || noop
     this._onDisconnect = handlers.onDisconnect || noop
 
-    // TODO: can this be a set?
-    this.peers = new Map()
+    /**
+     * Set of peers that support the protocol.
+     * @type {Set<string>}
+     */
+    this.peers = new Set()
   }
 
   set registrar (registrar) {

--- a/src/topology/multicodec-topology.js
+++ b/src/topology/multicodec-topology.js
@@ -55,14 +55,14 @@ class MulticodecTopology extends Topology {
 
   /**
    * Update topology.
-   * @param {Array<PeerData>} peerDataIterable
+   * @param {Array<{id: PeerId, multiaddrs: Array<Multiaddr>}>} peerDataIterable
    * @returns {void}
    */
   _updatePeers (peerDataIterable) {
     for (const peerData of peerDataIterable) {
       if (this.multicodecs.filter(multicodec => peerData.protocols.includes(multicodec)).length) {
         // Add the peer regardless of whether or not there is currently a connection
-        this.peers.set(peerData.id.toB58String(), peerData.id)
+        this.peers.add(peerData.id.toB58String())
         // If there is a connection, call _onConnect
         const connection = this._registrar.getConnection(peerData.id)
         connection && this._onConnect(peerData.id, connection)
@@ -80,11 +80,11 @@ class MulticodecTopology extends Topology {
    * @param {Array<string>} props.protocols
    */
   _onProtocolChange ({ peerId, protocols }) {
-    const existingPeer = this.peers.get(peerId.toB58String())
+    const hadPeer = this.peers.has(peerId.toB58String())
     const hasProtocol = protocols.filter(protocol => this.multicodecs.includes(protocol))
 
     // Not supporting the protocol anymore?
-    if (existingPeer && hasProtocol.length === 0) {
+    if (hadPeer && hasProtocol.length === 0) {
       this._onDisconnect(peerId)
     }
 

--- a/src/topology/multicodec-topology.js
+++ b/src/topology/multicodec-topology.js
@@ -55,20 +55,20 @@ class MulticodecTopology extends Topology {
 
   /**
    * Update topology.
-   * @param {Array<{id: PeerId, multiaddrs: Array<Multiaddr>}>} peerDataIterable
+   * @param {Array<{id: PeerId, multiaddrs: Array<Multiaddr>, protocols: Array<string>}>} peerDataIterable
    * @returns {void}
    */
   _updatePeers (peerDataIterable) {
-    for (const peerData of peerDataIterable) {
-      if (this.multicodecs.filter(multicodec => peerData.protocols.includes(multicodec)).length) {
+    for (const { id, protocols } of peerDataIterable) {
+      if (this.multicodecs.filter(multicodec => protocols.includes(multicodec)).length) {
         // Add the peer regardless of whether or not there is currently a connection
-        this.peers.add(peerData.id.toB58String())
+        this.peers.add(id.toB58String())
         // If there is a connection, call _onConnect
-        const connection = this._registrar.getConnection(peerData.id)
-        connection && this._onConnect(peerData.id, connection)
+        const connection = this._registrar.getConnection(id)
+        connection && this._onConnect(id, connection)
       } else {
         // Remove any peers we might be tracking that are no longer of value to us
-        this.peers.delete(peerData.id.toB58String())
+        this.peers.delete(id.toB58String())
       }
     }
   }

--- a/src/topology/tests/multicodec-topology.js
+++ b/src/topology/tests/multicodec-topology.js
@@ -8,19 +8,18 @@ chai.use(require('dirty-chai'))
 const sinon = require('sinon')
 
 const PeerId = require('peer-id')
-const PeerInfo = require('peer-info')
+
 const peers = require('../../utils/peers')
 
 module.exports = (test) => {
   describe('multicodec topology', () => {
-    let topology, peer
+    let topology, id
 
     beforeEach(async () => {
       topology = await test.setup()
       if (!topology) throw new Error('missing multicodec topology')
 
-      const id = await PeerId.createFromJSON(peers[0])
-      peer = await PeerInfo.create(id)
+      id = await PeerId.createFromJSON(peers[0])
     })
 
     afterEach(async () => {
@@ -38,7 +37,7 @@ module.exports = (test) => {
 
     it('should trigger "onDisconnect" on peer disconnected', () => {
       sinon.spy(topology, '_onDisconnect')
-      topology.disconnect(peer)
+      topology.disconnect(id)
 
       expect(topology._onDisconnect.callCount).to.equal(1)
     })
@@ -47,13 +46,16 @@ module.exports = (test) => {
       sinon.spy(topology, '_updatePeers')
       expect(topology.peers.size).to.eql(0)
 
-      const id2 = await PeerId.createFromJSON(peers[1])
-      const peer2 = await PeerInfo.create(id2)
-      topology.multicodecs.forEach((m) => peer2.protocols.add(m))
-
       const peerStore = topology._registrar.peerStore
+
+      const id2 = await PeerId.createFromJSON(peers[1])
+      peerStore.peers.set(id2.toB58String(), {
+        id: id2,
+        protocols: Array.from(topology.multicodecs)
+      })
+
       peerStore.emit('change:protocols', {
-        peerInfo: peer2,
+        peerId: id2,
         protocols: Array.from(topology.multicodecs)
       })
 
@@ -65,28 +67,34 @@ module.exports = (test) => {
       sinon.spy(topology, '_onDisconnect')
       expect(topology.peers.size).to.eql(0)
 
-      const id2 = await PeerId.createFromJSON(peers[1])
-      const peer2 = await PeerInfo.create(id2)
-      topology.multicodecs.forEach((m) => peer2.protocols.add(m))
-
       const peerStore = topology._registrar.peerStore
+
+      const id2 = await PeerId.createFromJSON(peers[1])
+      peerStore.peers.set(id2.toB58String(), {
+        id: id2,
+        protocols: Array.from(topology.multicodecs)
+      })
+
       peerStore.emit('change:protocols', {
-        peerInfo: peer2,
+        peerId: id2,
         protocols: Array.from(topology.multicodecs)
       })
 
       expect(topology.peers.size).to.eql(1)
 
-      topology.multicodecs.forEach((m) => peer2.protocols.delete(m))
+      peerStore.peers.set(id2.toB58String(), {
+        id: id2,
+        protocols: []
+      })
       // Peer does not support the protocol anymore
       peerStore.emit('change:protocols', {
-        peerInfo: peer2,
+        peerId: id2,
         protocols: []
       })
 
       expect(topology.peers.size).to.eql(1)
       expect(topology._onDisconnect.callCount).to.equal(1)
-      expect(topology._onDisconnect.calledWith(peer2)).to.equal(true)
+      expect(topology._onDisconnect.calledWith(id2)).to.equal(true)
     })
   })
 }

--- a/src/topology/tests/topology.js
+++ b/src/topology/tests/topology.js
@@ -8,19 +8,17 @@ chai.use(require('dirty-chai'))
 const sinon = require('sinon')
 
 const PeerId = require('peer-id')
-const PeerInfo = require('peer-info')
 const peers = require('../../utils/peers')
 
 module.exports = (test) => {
   describe('topology', () => {
-    let topology, peer
+    let topology, id
 
     beforeEach(async () => {
       topology = await test.setup()
       if (!topology) throw new Error('missing multicodec topology')
 
-      const id = await PeerId.createFromJSON(peers[0])
-      peer = await PeerInfo.create(id)
+      id = await PeerId.createFromJSON(peers[0])
     })
 
     afterEach(async () => {
@@ -38,7 +36,7 @@ module.exports = (test) => {
 
     it('should trigger "onDisconnect" on peer disconnected', () => {
       sinon.spy(topology, '_onDisconnect')
-      topology.disconnect(peer)
+      topology.disconnect(id)
 
       expect(topology._onDisconnect.callCount).to.equal(1)
     })

--- a/test/topology/mock-peer-store.js
+++ b/test/topology/mock-peer-store.js
@@ -7,6 +7,10 @@ class MockPeerStore extends EventEmitter {
     super()
     this.peers = peers
   }
+
+  get (peerId) {
+    return this.peers.get(peerId.toB58String())
+  }
 }
 
 module.exports = MockPeerStore

--- a/test/topology/multicodec-topology.spec.js
+++ b/test/topology/multicodec-topology.spec.js
@@ -21,7 +21,8 @@ describe('multicodec topology compliance tests', () => {
       })
 
       if (!registrar) {
-        const peerStore = new MockPeerStore([])
+        const peers = new Map()
+        const peerStore = new MockPeerStore(peers)
 
         registrar = {
           peerStore,


### PR DESCRIPTION
In the context of deprecating `peer-info` as described on [libp2p/js-libp2p#589](https://github.com/libp2p/js-libp2p/issues/589), this PR removes the `peer-info` usage on topology.

This changes have impact on pubsub modules, as well as the dht

BREAKING CHANGE: topology api now uses peer-id instead of peer-info