### PR TITLE
chore: update content and peer routing interfaces removing peer-info

### DIFF
--- a/src/content-routing/README.md
+++ b/src/content-routing/README.md
@@ -30,6 +30,32 @@ TBD
 
 A valid (read: that follows this abstraction) Content Routing module must implement the following API.
 
-### `.findProviders`
+### findProviders
 
-### `.provide`
+- `findProviders(peerId)`
+
+Find peers in the network that can provide a specific value, given a key.
+
+**Parameters**
+- [CID](https://github.com/multiformats/js-cid)
+
+**Returns**
+
+It returns an `AsyncIterable` containing the identification and addresses of the peers providing the given key, as follows:
+
+`AsyncIterable<{ id: CID, addrs: Multiaddr[] }>`
+
+### provide
+
+- `provide(cid)`
+
+Announce to the network that we are providing the given value.
+
+**Parameters**
+- [CID](https://github.com/multiformats/js-cid)
+
+**Returns**
+
+It returns a promise that is resolved on the success of the operation.
+
+`Promise<void>`

--- a/src/content-routing/README.md
+++ b/src/content-routing/README.md
@@ -32,7 +32,7 @@ A valid (read: that follows this abstraction) Content Routing module must implem
 
 ### findProviders
 
-- `findProviders(peerId)`
+- `findProviders(cid)`
 
 Find peers in the network that can provide a specific value, given a key.
 
@@ -43,7 +43,7 @@ Find peers in the network that can provide a specific value, given a key.
 
 It returns an `AsyncIterable` containing the identification and addresses of the peers providing the given key, as follows:
 
-`AsyncIterable<{ id: CID, addrs: Multiaddr[] }>`
+`AsyncIterable<{ id: PeerId, addrs: Multiaddr[] }>`
 
 ### provide
 

--- a/src/peer-routing/README.md
+++ b/src/peer-routing/README.md
@@ -30,12 +30,17 @@ TBD
 
 A valid (read: that follows this abstraction) Peer Routing module must implement the following API.
 
-### `.findPeers` - Find peers 'responsible' or 'closest' to a given key
+### findPeer
 
-- `Node.js` peerRouting.findPeers(key, function (err, peersPriorityQueue) {})
+- `findPeer(peerId)`
 
-In a peer to peer context, the concept of 'responsability' or 'closeness' for a given key translates to having a way to find deterministically or that at least there is a significant overlap between searches, the same group of peers when searching for the same given key.
+Query the network for all multiaddresses associated with a `PeerId`.
 
-This method will query the network (route it) and return a Priority Queue datastructe with a list of PeerInfo objects, ordered by 'closeness'.
+**Parameters**
+- [peerId](https://github.com/libp2p/js-peer-id).
 
-key is a multihash
+**Returns**
+
+It returns a the `peer-id` [cid](https://github.com/multiformats/js-cid) together with the known peers [multiaddrs](https://github.com/multiformats/js-multiaddr), as follows:
+
+`Promise<{ id: CID, addrs: Multiaddr[] }>`

--- a/src/peer-routing/README.md
+++ b/src/peer-routing/README.md
@@ -43,4 +43,4 @@ Query the network for all multiaddresses associated with a `PeerId`.
 
 It returns the [peerId](https://github.com/libp2p/js-peer-id) together with the known peers [multiaddrs](https://github.com/multiformats/js-multiaddr), as follows:
 
-`Promise<{ id: CID, addrs: Multiaddr[] }>`
+`Promise<{ id: PeerId, addrs: Multiaddr[] }>`

--- a/src/peer-routing/README.md
+++ b/src/peer-routing/README.md
@@ -41,6 +41,6 @@ Query the network for all multiaddresses associated with a `PeerId`.
 
 **Returns**
 
-It returns a the `peer-id` [cid](https://github.com/multiformats/js-cid) together with the known peers [multiaddrs](https://github.com/multiformats/js-multiaddr), as follows:
+It returns the [peerId](https://github.com/libp2p/js-peer-id) together with the known peers [multiaddrs](https://github.com/multiformats/js-multiaddr), as follows:
 
 `Promise<{ id: CID, addrs: Multiaddr[] }>`


### PR DESCRIPTION
In the context of deprecating `peer-info` as described on [libp2p/js-libp2p#589](https://github.com/libp2p/js-libp2p/issues/589), this PR removes the `peer-info` usage on the `content-routing` and `peer-routing` interfaces.

- `findPeer`

Returns `Promise<{ id: CID, addrs: Multiaddr[] }>` instead of a `PeerInfo`

- `findProviders`

Returns `AsyncIterable<{ id: CID, addrs: Multiaddr[] }>` instead of `AsyncIterable<PeerInfo>`

BREAKING CHANGE: content-routing and peer-routing APIs return an object with relevant properties instead of peer-info