### PR TITLE
chore: discovery should not use once

### DIFF
--- a/src/peer-discovery/tests/index.js
+++ b/src/peer-discovery/tests/index.js
@@ -49,7 +49,7 @@ module.exports = (common) => {
       const defer = pDefer()
       await discovery.start()
 
-      discovery.once('peer', ({ id, multiaddrs }) => {
+      discovery.on('peer', ({ id, multiaddrs }) => {
         expect(id).to.exist()
         expect(PeerId.isPeerId(id)).to.eql(true)
         expect(multiaddrs).to.exist()
@@ -63,7 +63,7 @@ module.exports = (common) => {
     })
 
     it('should not receive a peer event before start', async () => {
-      discovery.once('peer', () => {
+      discovery.on('peer', () => {
         throw new Error('should not receive a peer event before start')
       })
 
@@ -75,14 +75,14 @@ module.exports = (common) => {
 
       await discovery.start()
 
-      discovery.once('peer', () => {
+      discovery.on('peer', () => {
         deferStart.resolve()
       })
 
       await deferStart.promise
       await discovery.stop()
 
-      discovery.once('peer', () => {
+      discovery.on('peer', () => {
         throw new Error('should not receive a peer event after stop')
       })
 


### PR DESCRIPTION
After checking failures on `peer-discovery` tests for https://github.com/libp2p/js-libp2p-pubsub-peer-discovery/pull/5 I realized that emittery `.once()` returns a promise and does not support a listener callback, like in node.

As a consequence of this inconsistency, we should probably use `.on()` since we are already removing all the listeners on afterEach