### PR TITLE
feat: record interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - [Crypto](./src/crypto)
 - [Peer Discovery](./src/peer-discovery)
 - [Peer Routing](./src/peer-routing)
+- [Record](./src/record)
 - [Stream Muxer](./src/stream-muxer)
 - [Topology](./src/topology)
 - [Transport](./src/transport)

--- a/src/record/README.md
+++ b/src/record/README.md
@@ -1,0 +1,75 @@
+interface-record
+==================
+
+A libp2p node needs to store data in a public location (e.g. a DHT), or rely on potentially untrustworthy intermediaries to relay information. Libp2p provides an all-purpose data container called **envelope**, which includes a signature of the data, so that it its authenticity can be verified.
+
+The record represents the data that will be stored inside the **envelope** when distributing records across the network. The `interface-record` aims to guarantee that any type of record created is compliant with the libp2p **envelope**.
+
+Taking into account that a record might be used in different contexts, an **envelope** signature made for a specific purpose **must not** be considered valid for a different purpose. Accordingly, each record has a short and descriptive string representing the record use case, known as **domain**. The data to be signed will be prepended with the domain string, in order to create a domain signature.
+
+A record can also contain a Buffer codec (ideally registered as a [multicodec](https://github.com/multiformats/multicodec)). This codec will prefix the record data in the **envelope** , so that it can be deserialized deterministically.
+
+## Usage
+
+```js
+const tests = require('libp2p-interfaces/src/record/tests')
+describe('your record', () => {
+  tests({
+    async setup () {
+      return YourRecord
+    },
+    async teardown () {
+      // cleanup resources created by setup()
+    }
+  })
+})
+```
+
+## Create Record
+
+```js
+const multicodec = require('multicodec')
+const Record = require('libp2p-interfaces/src/record')
+// const Protobuf = require('./record.proto')
+
+const ENVELOPE_DOMAIN_PEER_RECORD = 'libp2p-peer-record'
+const ENVELOPE_PAYLOAD_TYPE_PEER_RECORD = Buffer.from('0301', 'hex')
+
+class PeerRecord extends Record {
+  constructor (peerId, multiaddrs, seqNumber) {
+    super (ENVELOPE_DOMAIN_PEER_RECORD, ENVELOPE_PAYLOAD_TYPE_PEER_RECORD)
+  }
+
+  marshal () {
+    // Implement and return using Protobuf
+  }
+
+  isEqual (other) {
+    // Verify
+  }
+}
+```
+
+## API
+
+### marshal
+
+- `record.marshal()`
+
+Marshal a record to be used in a libp2p envelope.
+
+**Returns**
+
+It returns a `Protobuf` containing the record data.
+
+### isEqual
+
+- `record.isEqual(other)`
+
+Verifies if the other Record is identical to this one.
+
+**Parameters**
+- other is a `Record` to compare with the current instance.
+
+**Returns**
+- `boolean`

--- a/src/record/README.md
+++ b/src/record/README.md
@@ -44,7 +44,7 @@ class PeerRecord extends Record {
     // Implement and return using Protobuf
   }
 
-  isEqual (other) {
+  equals (other) {
     // Verify
   }
 }
@@ -62,9 +62,9 @@ Marshal a record to be used in a libp2p envelope.
 
 It returns a `Protobuf` containing the record data.
 
-### isEqual
+### equals
 
-- `record.isEqual(other)`
+- `record.equals(other)`
 
 Verifies if the other Record is identical to this one.
 

--- a/src/record/index.js
+++ b/src/record/index.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const errcode = require('err-code')
+
+/**
+ * Record is the base implementation of a record that can be used as the payload of a libp2p envelope.
+ */
+class Record {
+  /**
+   * @constructor
+   * @param {String} domain signature domain
+   * @param {Buffer} codec identifier of the type of record
+   */
+  constructor (domain, codec) {
+    this.domain = domain
+    this.codec = codec
+  }
+
+  /**
+   * Marshal a record to be used in an envelope.
+   */
+  marshal () {
+    throw errcode(new Error('marshal must be implemented by the subclass'), 'ERR_NOT_IMPLEMENTED')
+  }
+
+  /**
+   * Verifies if the other provided Record is identical to this one.
+   * @param {Record} other
+   */
+  isEqual (other) {
+    throw errcode(new Error('isEqual must be implemented by the subclass'), 'ERR_NOT_IMPLEMENTED')
+  }
+}
+
+module.exports = Record

--- a/src/record/index.js
+++ b/src/record/index.js
@@ -27,8 +27,8 @@ class Record {
    * Verifies if the other provided Record is identical to this one.
    * @param {Record} other
    */
-  isEqual (other) {
-    throw errcode(new Error('isEqual must be implemented by the subclass'), 'ERR_NOT_IMPLEMENTED')
+  equals (other) {
+    throw errcode(new Error('equals must be implemented by the subclass'), 'ERR_NOT_IMPLEMENTED')
   }
 }
 

--- a/src/record/tests/index.js
+++ b/src/record/tests/index.js
@@ -1,0 +1,35 @@
+/* eslint-env mocha */
+
+'use strict'
+
+const chai = require('chai')
+const expect = chai.expect
+chai.use(require('dirty-chai'))
+
+module.exports = (test) => {
+  describe('record', () => {
+    let record
+
+    beforeEach(async () => {
+      record = await test.setup()
+      if (!record) throw new Error('missing record')
+    })
+
+    afterEach(() => test.teardown())
+
+    it('has domain and codec', () => {
+      expect(record.domain).to.exist()
+      expect(record.codec).to.exist()
+    })
+
+    it('is able to marshal', () => {
+      const rawData = record.marshal()
+      expect(Buffer.isBuffer(rawData)).to.eql(true)
+    })
+
+    it('is able to compare two records', () => {
+      const isEqual = record.isEqual(record)
+      expect(isEqual).to.eql(true)
+    })
+  })
+}

--- a/src/record/tests/index.js
+++ b/src/record/tests/index.js
@@ -28,8 +28,8 @@ module.exports = (test) => {
     })
 
     it('is able to compare two records', () => {
-      const isEqual = record.isEqual(record)
-      expect(isEqual).to.eql(true)
+      const equals = record.equals(record)
+      expect(equals).to.eql(true)
     })
   })
 }


### PR DESCRIPTION
This PR adds the `record-interface`.

The `record-interface` primary goal is to guarantee that any record implementation will be compliant with the expectations of a libp2p **envelope**.

`js-libp2p` will start by having a single implementation of the `record-interface`, known as a `peer-record`. This implementations will be used to share peers' multiaddrs across the network with security guarantees, thanks to the libp2p envelope where the records will be wrapped into.

Open questions:
- Should we have tests for the unmarshal operation in the interface tests? I think that we should have the unmarshal and then rely on `isEqual` to verify if the unmarshal operation resulted in the same content as before the marshal

A record implementation will now look as follows:
```js
class PeerRecord extends Record {
  // ....
}

PeerRecord.createFromProtobuf = (buf) => {
  // ...
}

module.exports = PeerRecord
```
The `createFromProtobuf` will return an instance of the Peer Record.

References:
- https://github.com/libp2p/specs/pull/217
- https://github.com/libp2p/go-libp2p-core/blob/master/record/record.go
