### PR TITLE
fix: reconnect should trigger topology on connect if protocol stored

### DIFF
--- a/src/topology/multicodec-topology.js
+++ b/src/topology/multicodec-topology.js
@@ -113,7 +113,7 @@ class MulticodecTopology extends Topology {
       return
     }
 
-    if (this.multicodecs.filter(multicodec => protocols.includes(multicodec)).length) {
+    if (this.multicodecs.find(multicodec => protocols.includes(multicodec))) {
       this.peers.add(peerId.toB58String())
       this._onConnect(peerId, connection)
     }

--- a/src/topology/multicodec-topology.js
+++ b/src/topology/multicodec-topology.js
@@ -43,11 +43,13 @@ class MulticodecTopology extends Topology {
     this._registrar = undefined
 
     this._onProtocolChange = this._onProtocolChange.bind(this)
+    this._onPeerConnect = this._onPeerConnect.bind(this)
   }
 
   set registrar (registrar) {
     this._registrar = registrar
     this._registrar.peerStore.on('change:protocols', this._onProtocolChange)
+    this._registrar.connectionManager.on('peer:connect', this._onPeerConnect)
 
     // Update topology peers
     this._updatePeers(this._registrar.peerStore.peers.values())
@@ -95,6 +97,25 @@ class MulticodecTopology extends Topology {
         this._updatePeers([peerData])
         return
       }
+    }
+  }
+
+  /**
+   * Verify if a new connected peer has a topology multicodec and call _onConnect.
+   * @param {Connection} connection
+   * @returns {void}
+   */
+  _onPeerConnect (connection) {
+    const peerId = connection.remotePeer
+    const protocols = this._registrar.peerStore.protoBook.get(peerId)
+
+    if (!protocols) {
+      return
+    }
+
+    if (this.multicodecs.filter(multicodec => protocols.includes(multicodec)).length) {
+      this.peers.add(peerId.toB58String())
+      this._onConnect(peerId, connection)
     }
   }
 }

--- a/src/topology/tests/multicodec-topology.js
+++ b/src/topology/tests/multicodec-topology.js
@@ -96,5 +96,38 @@ module.exports = (test) => {
       expect(topology._onDisconnect.callCount).to.equal(1)
       expect(topology._onDisconnect.calledWith(id2)).to.equal(true)
     })
+
+    it('should trigger "onConnect" when a peer connects and has one of the topology multicodecs in its known protocols', () => {
+      sinon.spy(topology, '_onConnect')
+      sinon.stub(topology._registrar.peerStore.protoBook, 'get').returns(topology.multicodecs)
+
+      topology._registrar.connectionManager.emit('peer:connect', {
+        remotePeer: id
+      })
+
+      expect(topology._onConnect.callCount).to.equal(1)
+    })
+
+    it('should not trigger "onConnect" when a peer connects and has none of the topology multicodecs in its known protocols', () => {
+      sinon.spy(topology, '_onConnect')
+      sinon.stub(topology._registrar.peerStore.protoBook, 'get').returns([])
+
+      topology._registrar.connectionManager.emit('peer:connect', {
+        remotePeer: id
+      })
+
+      expect(topology._onConnect.callCount).to.equal(0)
+    })
+
+    it('should not trigger "onConnect" when a peer connects and its protocols are not known', () => {
+      sinon.spy(topology, '_onConnect')
+      sinon.stub(topology._registrar.peerStore.protoBook, 'get').returns(undefined)
+
+      topology._registrar.connectionManager.emit('peer:connect', {
+        remotePeer: id
+      })
+
+      expect(topology._onConnect.callCount).to.equal(0)
+    })
   })
 }

--- a/test/topology/mock-peer-store.js
+++ b/test/topology/mock-peer-store.js
@@ -6,6 +6,9 @@ class MockPeerStore extends EventEmitter {
   constructor (peers) {
     super()
     this.peers = peers
+    this.protoBook = {
+      get: () => {}
+    }
   }
 
   get (peerId) {

--- a/test/topology/multicodec-topology.spec.js
+++ b/test/topology/multicodec-topology.spec.js
@@ -1,6 +1,8 @@
 /* eslint-env mocha */
 'use strict'
 
+const { EventEmitter } = require('events')
+
 const tests = require('../../src/topology/tests/multicodec-topology')
 const MulticodecTopology = require('../../src/topology/multicodec-topology')
 const MockPeerStore = require('./mock-peer-store')
@@ -23,9 +25,11 @@ describe('multicodec topology compliance tests', () => {
       if (!registrar) {
         const peers = new Map()
         const peerStore = new MockPeerStore(peers)
+        const connectionManager = new EventEmitter()
 
         registrar = {
           peerStore,
+          connectionManager,
           getConnection: () => { }
         }
       }


### PR DESCRIPTION
Considering a scenario where Peer A and B start, connect to each other using a multicodec topology. Then, Peer B restarts, it is still not connected to A. It will run the update peers: https://github.com/libp2p/js-libp2p-interfaces/blob/master/src/topology/multicodec-topology.js#L68 but it does not have a connection to A yet, so it will not call onConnect. After this, identify will run, but the protocols will not change and the protocol change handler will not be called.

Fixes https://github.com/libp2p/js-libp2p/issues/658