### PR TITLE
fix: replace remaining Buffer usage with Uint8Array

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "abort-controller": "^3.0.0",
     "abortable-iterator": "^3.0.0",
-    "buffer": "^5.6.0",
     "chai": "^4.2.0",
     "chai-checkmark": "^1.0.1",
     "class-is": "^1.1.0",
@@ -53,7 +52,8 @@
     "p-wait-for": "^3.1.0",
     "peer-id": "^0.14.0",
     "sinon": "^9.0.2",
-    "streaming-iterables": "^5.0.2"
+    "streaming-iterables": "^5.0.2",
+    "uint8arrays": "^1.1.0"
   },
   "devDependencies": {
     "aegir": "^25.0.0",

--- a/src/crypto/tests/index.js
+++ b/src/crypto/tests/index.js
@@ -1,16 +1,18 @@
 /* eslint-env mocha */
 'use strict'
 
-const { Buffer } = require('buffer')
-const duplexPair = require('it-pair/duplex')
-const pipe = require('it-pipe')
-const peers = require('../../utils/peers')
-const { UnexpectedPeerError } = require('../errors')
-const PeerId = require('peer-id')
-const { collect } = require('streaming-iterables')
 const chai = require('chai')
 const expect = chai.expect
 chai.use(require('dirty-chai'))
+
+const duplexPair = require('it-pair/duplex')
+const pipe = require('it-pipe')
+const PeerId = require('peer-id')
+const { collect } = require('streaming-iterables')
+const uint8arrayFromString = require('uint8arrays/from-string')
+
+const peers = require('../../utils/peers')
+const { UnexpectedPeerError } = require('../errors')
 
 module.exports = (common) => {
   describe('interface-crypto', () => {
@@ -55,7 +57,7 @@ module.exports = (common) => {
       pipe(inboundResult.conn, inboundResult.conn)
 
       // Send some data and collect the result
-      const input = Buffer.from('data to encrypt')
+      const input = uint8arrayFromString('data to encrypt')
       const result = await pipe(
         [input],
         outboundResult.conn,

--- a/src/record/README.md
+++ b/src/record/README.md
@@ -7,7 +7,7 @@ The record represents the data that will be stored inside the **envelope** when 
 
 Taking into account that a record might be used in different contexts, an **envelope** signature made for a specific purpose **must not** be considered valid for a different purpose. Accordingly, each record has a short and descriptive string representing the record use case, known as **domain**. The data to be signed will be prepended with the domain string, in order to create a domain signature.
 
-A record can also contain a Buffer codec (ideally registered as a [multicodec](https://github.com/multiformats/multicodec)). This codec will prefix the record data in the **envelope** , so that it can be deserialized deterministically.
+A record can also contain a Uint8Array codec (ideally registered as a [multicodec](https://github.com/multiformats/multicodec)). This codec will prefix the record data in the **envelope** , so that it can be deserialized deterministically.
 
 ## Usage
 
@@ -30,10 +30,11 @@ describe('your record', () => {
 ```js
 const multicodec = require('multicodec')
 const Record = require('libp2p-interfaces/src/record')
+const fromString = require('uint8arrays/from-string')
 // const Protobuf = require('./record.proto')
 
 const ENVELOPE_DOMAIN_PEER_RECORD = 'libp2p-peer-record'
-const ENVELOPE_PAYLOAD_TYPE_PEER_RECORD = Buffer.from('0301', 'hex')
+const ENVELOPE_PAYLOAD_TYPE_PEER_RECORD = fromString('0301', 'hex')
 
 class PeerRecord extends Record {
   constructor (peerId, multiaddrs, seqNumber) {

--- a/src/record/index.js
+++ b/src/record/index.js
@@ -9,7 +9,7 @@ class Record {
   /**
    * @constructor
    * @param {String} domain signature domain
-   * @param {Buffer} codec identifier of the type of record
+   * @param {Uint8Array} codec identifier of the type of record
    */
   constructor (domain, codec) {
     this.domain = domain

--- a/src/record/tests/index.js
+++ b/src/record/tests/index.js
@@ -24,7 +24,7 @@ module.exports = (test) => {
 
     it('is able to marshal', () => {
       const rawData = record.marshal()
-      expect(Buffer.isBuffer(rawData)).to.eql(true)
+      expect(rawData).to.be.an.instanceof(Uint8Array)
     })
 
     it('is able to compare two records', () => {

--- a/src/stream-muxer/tests/close-test.js
+++ b/src/stream-muxer/tests/close-test.js
@@ -2,7 +2,6 @@
 /* eslint max-nested-callbacks: ["error", 8] */
 'use strict'
 
-const { Buffer } = require('buffer')
 const pair = require('it-pair/duplex')
 const pipe = require('it-pipe')
 const { consume } = require('streaming-iterables')
@@ -10,6 +9,7 @@ const Tcp = require('libp2p-tcp')
 const multiaddr = require('multiaddr')
 const abortable = require('abortable-iterator')
 const AbortController = require('abort-controller')
+const uint8arrayFromString = require('uint8arrays/from-string')
 
 const mh = multiaddr('/ip4/127.0.0.1/tcp/0')
 
@@ -18,7 +18,7 @@ function pause (ms) {
 }
 
 function randomBuffer () {
-  return Buffer.from(Math.random().toString())
+  return uint8arrayFromString(Math.random().toString())
 }
 
 const infiniteRandom = {

--- a/src/transport/tests/listen-test.js
+++ b/src/transport/tests/listen-test.js
@@ -2,7 +2,6 @@
 /* eslint-env mocha */
 'use strict'
 
-const { Buffer } = require('buffer')
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const expect = chai.expect
@@ -11,6 +10,7 @@ const sinon = require('sinon')
 
 const pWaitFor = require('p-wait-for')
 const pipe = require('it-pipe')
+const uint8arrayFromString = require('uint8arrays/from-string')
 const { isValidTick } = require('./utils')
 
 module.exports = (common) => {
@@ -76,7 +76,7 @@ module.exports = (common) => {
       // Wait for the data send and close to finish
       await Promise.all([
         pipe(
-          [Buffer.from('Some data that is never handled')],
+          [uint8arrayFromString('Some data that is never handled')],
           socket1
         ),
         // Closer the listener (will take a couple of seconds to time out)


### PR DESCRIPTION
This replaces the remaining usages of Buffer with Uint8Array.

BREAKING CHANGE: this changes the API of records and updates several tests to use Uint8Arrays

required by https://github.com/libp2p/js-libp2p/pull/730