### PR TITLE
feat: update pubsub getMsgId return type to Uint8Array

### DIFF
--- a/src/pubsub/index.d.ts
+++ b/src/pubsub/index.d.ts
@@ -184,9 +184,9 @@ declare class PubsubBaseProtocol {
      * The default msgID implementation
      * Child class can override this.
      * @param {RPC.Message} msg the message object
-     * @returns {string} message id as string
+     * @returns {Uint8Array} message id as bytes
      */
-    getMsgId(msg: any): string;
+    getMsgId(msg: any): Uint8Array;
     /**
      * Whether to accept a message from a peer
      * Override to create a graylist

--- a/src/pubsub/index.js
+++ b/src/pubsub/index.js
@@ -437,7 +437,7 @@ class PubsubBaseProtocol extends EventEmitter {
    * The default msgID implementation
    * Child class can override this.
    * @param {RPC.Message} msg the message object
-   * @returns {string} message id as string
+   * @returns {Uint8Array} message id as bytes
    */
   getMsgId (msg) {
     return utils.msgId(msg.from, msg.seqno)

--- a/src/pubsub/utils.d.ts
+++ b/src/pubsub/utils.d.ts
@@ -1,5 +1,5 @@
 export function randomSeqno(): Uint8Array;
-export function msgId(from: string, seqno: Uint8Array): string;
+export function msgId(from: string, seqno: Uint8Array): Uint8Array;
 export function anyMatch(a: any[] | Set<any>, b: any[] | Set<any>): boolean;
 export function ensureArray(maybeArray: any): any[];
 export function normalizeInRpcMessage(message: any, peerId: string): any;

--- a/src/pubsub/utils.js
+++ b/src/pubsub/utils.js
@@ -3,6 +3,7 @@
 const randomBytes = require('libp2p-crypto/src/random-bytes')
 const uint8ArrayToString = require('uint8arrays/to-string')
 const uint8ArrayFromString = require('uint8arrays/from-string')
+const PeerId = require('peer-id')
 exports = module.exports
 
 /**
@@ -20,11 +21,15 @@ exports.randomSeqno = () => {
  *
  * @param {string} from
  * @param {Uint8Array} seqno
- * @returns {string}
+ * @returns {Uint8Array}
  * @private
  */
 exports.msgId = (from, seqno) => {
-  return from + uint8ArrayToString(seqno, 'base16')
+  const fromBytes = PeerId.createFromB58String(from).id
+  const msgId = new Uint8Array(fromBytes.length + seqno.length)
+  msgId.set(fromBytes, 0)
+  msgId.set(seqno, fromBytes.length)
+  return msgId
 }
 
 /**

--- a/test/pubsub/utils.spec.js
+++ b/test/pubsub/utils.spec.js
@@ -15,15 +15,11 @@ describe('utils', () => {
     expect(first).to.not.eql(second)
   })
 
-  it('msgId', () => {
-    expect(utils.msgId('hello', uint8ArrayFromString('world'))).to.be.eql('hello776f726c64')
-  })
-
   it('msgId should not generate same ID for two different Uint8Arrays', () => {
     const peerId = 'QmPNdSYk5Rfpo5euNqwtyizzmKXMNHdXeLjTQhcN4yfX22'
     const msgId0 = utils.msgId(peerId, uint8ArrayFromString('15603533e990dfde', 'base16'))
     const msgId1 = utils.msgId(peerId, uint8ArrayFromString('15603533e990dfe0', 'base16'))
-    expect(msgId0).to.not.eql(msgId1)
+    expect(msgId0).to.not.deep.equal(msgId1)
   })
 
   it('anyMatch', () => {


### PR DESCRIPTION
See https://github.com/libp2p/specs/pull/285

BREAKING CHANGE:
new getMsgId return type is not backwards compatible with prior `string`
return type.