### PR TITLE
feat: pubsub: add global signature policy

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "libp2p-tcp": "^0.15.0",
     "multiaddr": "^8.0.0",
     "multibase": "^3.0.0",
+    "multihashes": "^3.0.1",
     "p-defer": "^3.0.0",
     "p-limit": "^2.3.0",
     "p-wait-for": "^3.1.0",

--- a/src/pubsub/README.md
+++ b/src/pubsub/README.md
@@ -11,6 +11,9 @@ Table of Contents
     * [Extend interface](#extend-interface)
     * [Example](#example)
 * [API](#api)
+    * [Constructor](#constructor)
+      * [new Pubsub(options)](#new-pubsuboptions)
+          * [Parameters](#parameters)
     * [Start](#start)
       * [pubsub.start()](#pubsubstart)
           * [Returns](#returns)
@@ -19,24 +22,24 @@ Table of Contents
           * [Returns](#returns-1)
     * [Publish](#publish)
       * [pubsub.publish(topics, message)](#pubsubpublishtopics-message)
-          * [Parameters](#parameters)
+          * [Parameters](#parameters-1)
           * [Returns](#returns-2)
     * [Subscribe](#subscribe)
       * [pubsub.subscribe(topic)](#pubsubsubscribetopic)
-          * [Parameters](#parameters-1)
+          * [Parameters](#parameters-2)
     * [Unsubscribe](#unsubscribe)
       * [pubsub.unsubscribe(topic)](#pubsubunsubscribetopic)
-          * [Parameters](#parameters-2)
+          * [Parameters](#parameters-3)
     * [Get Topics](#get-topics)
       * [pubsub.getTopics()](#pubsubgettopics)
           * [Returns](#returns-3)
     * [Get Peers Subscribed to a topic](#get-peers-subscribed-to-a-topic)
       * [pubsub.getSubscribers(topic)](#pubsubgetsubscriberstopic)
-          * [Parameters](#parameters-3)
+          * [Parameters](#parameters-4)
           * [Returns](#returns-4)
     * [Validate](#validate)
       * [pubsub.validate(message)](#pubsubvalidatemessage)
-          * [Parameters](#parameters-4)
+          * [Parameters](#parameters-5)
       * [Returns](#returns-5)
 * [Test suite usage](#test-suite-usage)
 
@@ -109,8 +112,8 @@ The base class constructor configures the pubsub instance for use with a libp2p 
 |------|------|-------------|---------|
 | options.libp2p | `Libp2p` | libp2p instance | required, no default |
 | options.debugName | `string` | log namespace | required, no default |
-| options.multicodecs | `string \| Array<string>` | protocol identifiers | required, no default |
-| options.globalSignaturePolicy | `'StrictSign' \| 'StrictNoSign'` | signature policy to be globally applied | 'StrictSign' |
+| options.multicodecs | `string \| Array<string>` | protocol identifier(s) | required, no default |
+| options.globalSignaturePolicy | `'StrictSign' \| 'StrictNoSign'` | signature policy to be globally applied | `'StrictSign'` |
 | options.canRelayMessage | `boolean` | if can relay messages if not subscribed | `false` |
 | options.emitSelf | `boolean` | if `publish` should emit to self, if subscribed | `false` |
 

--- a/src/pubsub/errors.js
+++ b/src/pubsub/errors.js
@@ -1,7 +1,17 @@
 'use strict'
 
 exports.codes = {
+  /**
+   * Signature policy is invalid
+   */
+  ERR_INVALID_SIGNATURE_POLICY: 'ERR_INVALID_SIGNATURE_POLICY',
+  /**
+   * Signature policy is unhandled
+   */
+  ERR_UNHANDLED_SIGNATURE_POLICY: 'ERR_UNHANDLED_SIGNATURE_POLICY',
+
   // Strict signing codes
+
   /**
    * Message expected to have a `signature`, but doesn't
    */
@@ -14,7 +24,9 @@ exports.codes = {
    * Message `signature` is invalid
    */
   ERR_INVALID_SIGNATURE: 'ERR_INVALID_SIGNATURE',
+
   // Strict no-signing codes
+
   /**
    * Message expected to not have a `from`, but does
    */

--- a/src/pubsub/errors.js
+++ b/src/pubsub/errors.js
@@ -1,6 +1,35 @@
 'use strict'
 
 exports.codes = {
+  // Strict signing codes
+  /**
+   * Message expected to have a `signature`, but doesn't
+   */
   ERR_MISSING_SIGNATURE: 'ERR_MISSING_SIGNATURE',
-  ERR_INVALID_SIGNATURE: 'ERR_INVALID_SIGNATURE'
+  /**
+   * Message expected to have a `seqno`, but doesn't
+   */
+  ERR_MISSING_SEQNO: 'ERR_MISSING_SEQNO',
+  /**
+   * Message `signature` is invalid
+   */
+  ERR_INVALID_SIGNATURE: 'ERR_INVALID_SIGNATURE',
+  // Strict no-signing codes
+  /**
+   * Message expected to not have a `from`, but does
+   */
+  ERR_UNEXPECTED_FROM: 'ERR_UNEXPECTED_FROM',
+  /**
+   * Message expected to not have a `signature`, but does
+   */
+  ERR_UNEXPECTED_SIGNATURE: 'ERR_UNEXPECTED_SIGNATURE',
+  /**
+   * Message expected to not have a `key`, but does
+   */
+  ERR_UNEXPECTED_KEY: 'ERR_UNEXPECTED_KEY',
+  /**
+   * Message expected to not have a `seqno`, but does
+   */
+  ERR_UNEXPECTED_SEQNO: 'ERR_UNEXPECTED_SEQNO',
+
 }

--- a/src/pubsub/errors.js
+++ b/src/pubsub/errors.js
@@ -30,6 +30,5 @@ exports.codes = {
   /**
    * Message expected to not have a `seqno`, but does
    */
-  ERR_UNEXPECTED_SEQNO: 'ERR_UNEXPECTED_SEQNO',
-
+  ERR_UNEXPECTED_SEQNO: 'ERR_UNEXPECTED_SEQNO'
 }

--- a/src/pubsub/index.js
+++ b/src/pubsub/index.js
@@ -540,6 +540,7 @@ class PubsubBaseProtocol extends EventEmitter {
           throw errcode(new Error('Invalid message signature'), codes.ERR_INVALID_SIGNATURE)
         }
         break
+      default:
     }
     for (const topic of message.topicIDs) {
       const validatorFn = this.topicValidators.get(topic)
@@ -566,6 +567,7 @@ class PubsubBaseProtocol extends EventEmitter {
         return signMessage(this.peerId, utils.normalizeOutRpcMessage(message))
       case SignaturePolicy.StrictNoSign:
         return utils.normalizeOutRpcMessage(message)
+      default:
     }
   }
 

--- a/src/pubsub/index.js
+++ b/src/pubsub/index.js
@@ -442,7 +442,15 @@ class PubsubBaseProtocol extends EventEmitter {
    * @returns {Uint8Array} message id as bytes
    */
   getMsgId (msg) {
-    return utils.msgId(msg.from, msg.seqno)
+    const signaturePolicy = this.globalSignaturePolicy
+    switch (globalSignaturePolicy) {
+      case SignaturePolicy.StrictSign:
+        return utils.msgId(msg.from, msg.seqno)
+      case SignaturePolicy.StrictNoSign:
+        return utils.noSignMsgId(msg.data)
+      default:
+        throw errcode(new Error('Cannot get message id: unhandled signature policy: ' + signaturePolicy), codes.ERR_UNHANDLED_SIGNATURE_POLICY)
+    }
   }
 
   /**

--- a/src/pubsub/index.js
+++ b/src/pubsub/index.js
@@ -443,7 +443,7 @@ class PubsubBaseProtocol extends EventEmitter {
    */
   getMsgId (msg) {
     const signaturePolicy = this.globalSignaturePolicy
-    switch (globalSignaturePolicy) {
+    switch (signaturePolicy) {
       case SignaturePolicy.StrictSign:
         return utils.msgId(msg.from, msg.seqno)
       case SignaturePolicy.StrictNoSign:

--- a/src/pubsub/signature-policy.js
+++ b/src/pubsub/signature-policy.js
@@ -1,0 +1,26 @@
+/**
+ * Enum for Signature Policy
+ * Details how message signatures are produced/consumed
+ */
+exports.SignaturePolicy = {
+  /**
+   * On the producing side:
+   * * Build messages with the signature, key (from may be enough for certain inlineable public key types), from and seqno fields.
+   *
+	 * On the consuming side:
+   * * Enforce the fields to be present, reject otherwise.
+   * * Propagate only if the fields are valid and signature can be verified, reject otherwise.
+	 */
+  StrictSign: "StrictSign",
+	/**
+	 * On the producing side:
+   * * Build messages without the signature, key, from and seqno fields.
+   * * The corresponding protobuf key-value pairs are absent from the marshalled message, not just empty.
+   *
+	 * On the consuming side:
+   * * Enforce the fields to be absent, reject otherwise.
+   * * Propagate only if the fields are absent, reject otherwise.
+   * * A message_id function will not be able to use the above fields, and should instead rely on the data field. A commonplace strategy is to calculate a hash.
+   */
+  StrictNoSign: "StrictNoSign",
+}

--- a/src/pubsub/signature-policy.js
+++ b/src/pubsub/signature-policy.js
@@ -1,3 +1,5 @@
+'use strict'
+
 /**
  * Enum for Signature Policy
  * Details how message signatures are produced/consumed
@@ -7,20 +9,20 @@ exports.SignaturePolicy = {
    * On the producing side:
    * * Build messages with the signature, key (from may be enough for certain inlineable public key types), from and seqno fields.
    *
-	 * On the consuming side:
+   * On the consuming side:
    * * Enforce the fields to be present, reject otherwise.
    * * Propagate only if the fields are valid and signature can be verified, reject otherwise.
-	 */
-  StrictSign: "StrictSign",
-	/**
-	 * On the producing side:
+   */
+  StrictSign: 'StrictSign',
+  /**
+   * On the producing side:
    * * Build messages without the signature, key, from and seqno fields.
    * * The corresponding protobuf key-value pairs are absent from the marshalled message, not just empty.
    *
-	 * On the consuming side:
+   * On the consuming side:
    * * Enforce the fields to be absent, reject otherwise.
    * * Propagate only if the fields are absent, reject otherwise.
    * * A message_id function will not be able to use the above fields, and should instead rely on the data field. A commonplace strategy is to calculate a hash.
    */
-  StrictNoSign: "StrictNoSign",
+  StrictNoSign: 'StrictNoSign'
 }

--- a/src/pubsub/utils.js
+++ b/src/pubsub/utils.js
@@ -4,6 +4,7 @@ const randomBytes = require('libp2p-crypto/src/random-bytes')
 const uint8ArrayToString = require('uint8arrays/to-string')
 const uint8ArrayFromString = require('uint8arrays/from-string')
 const PeerId = require('peer-id')
+const multihash = require('multihashes')
 exports = module.exports
 
 /**
@@ -31,6 +32,15 @@ exports.msgId = (from, seqno) => {
   msgId.set(seqno, fromBytes.length)
   return msgId
 }
+
+/**
+ * Generate a message id, based on message `data`.
+ *
+ * @param {Uint8Array} data
+ * @returns {Uint8Array}
+ * @private
+ */
+exports.noSignMsgId = (data) => multihash.encode(data, 'sha2')
 
 /**
  * Check if any member of the first set is also a member

--- a/test/pubsub/message.spec.js
+++ b/test/pubsub/message.spec.js
@@ -6,7 +6,6 @@ const sinon = require('sinon')
 
 const PubsubBaseImpl = require('../../src/pubsub')
 const { SignaturePolicy } = require('../../src/pubsub/signature-policy')
-const { randomSeqno } = require('../../src/pubsub/utils')
 const {
   createPeerId,
   mockRegistrar

--- a/test/pubsub/topic-validators.spec.js
+++ b/test/pubsub/topic-validators.spec.js
@@ -12,6 +12,7 @@ const uint8ArrayFromString = require('uint8arrays/from-string')
 
 const { utils } = require('../../src/pubsub')
 const PeerStreams = require('../../src/pubsub/peer-streams')
+const { SignaturePolicy } = require('../../src/pubsub/signature-policy')
 
 const {
   createPeerId,
@@ -30,6 +31,8 @@ describe('topic validators', () => {
     pubsub = new PubsubImplementation(protocol, {
       peerId: peerId,
       registrar: mockRegistrar
+    }, {
+      globalSignaturePolicy: SignaturePolicy.StrictNoSign
     })
 
     pubsub.start()
@@ -42,8 +45,6 @@ describe('topic validators', () => {
   it('should filter messages by topic validator', async () => {
     // use _publish.callCount() to see if a message is valid or not
     sinon.spy(pubsub, '_publish')
-    // Disable strict signing
-    sinon.stub(pubsub, 'strictSigning').value(false)
     sinon.stub(pubsub.peers, 'get').returns({})
     const filteredTopic = 't'
     const peer = new PeerStreams({ id: await PeerId.create() })
@@ -59,9 +60,7 @@ describe('topic validators', () => {
     const validRpc = {
       subscriptions: [],
       msgs: [{
-        from: peer.id.toBytes(),
         data: uint8ArrayFromString('a message'),
-        seqno: utils.randomSeqno(),
         topicIDs: [filteredTopic]
       }]
     }
@@ -76,9 +75,7 @@ describe('topic validators', () => {
     const invalidRpc = {
       subscriptions: [],
       msgs: [{
-        from: peer.id.toBytes(),
         data: uint8ArrayFromString('a different message'),
-        seqno: utils.randomSeqno(),
         topicIDs: [filteredTopic]
       }]
     }
@@ -94,9 +91,7 @@ describe('topic validators', () => {
     const invalidRpc2 = {
       subscriptions: [],
       msgs: [{
-        from: peer.id.toB58String(),
         data: uint8ArrayFromString('a different message'),
-        seqno: utils.randomSeqno(),
         topicIDs: [filteredTopic]
       }]
     }

--- a/test/pubsub/topic-validators.spec.js
+++ b/test/pubsub/topic-validators.spec.js
@@ -10,7 +10,6 @@ const PeerId = require('peer-id')
 const uint8ArrayEquals = require('uint8arrays/equals')
 const uint8ArrayFromString = require('uint8arrays/from-string')
 
-const { utils } = require('../../src/pubsub')
 const PeerStreams = require('../../src/pubsub/peer-streams')
 const { SignaturePolicy } = require('../../src/pubsub/signature-policy')
 


### PR DESCRIPTION
See https://github.com/libp2p/specs/pull/294 and https://github.com/libp2p/specs/pull/299

Add a "global" signature policy to pubsub. This is a first-step towards having a "topic-specific" signature policy as described in the specs.
This "signature policy" replaces the ad-hoc options `signMessages` and `strictSigning` that were previously in use.

Only 'StrictSign' and 'StrictNoSign' signature policies are implemented, the 'LaxSign' and 'LaxNoSign' signature policies are not recommended and will be deprecated, so are not included.

BREAKING CHANGE:
`signMessages` and `strictSigning` pubsub configuration options replaced
with a `globalSignaturePolicy` option