### PR TITLE
feat: support for stream muxer closeRead and closeWrite

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "it-pipe": "^1.1.0",
     "it-pushable": "^1.4.2",
     "libp2p-crypto": "^0.19.0",
-    "libp2p-tcp": "^0.15.3",
     "multiaddr": "^9.0.1",
     "multibase": "^4.0.2",
     "multihashes": "^4.0.2",

--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -212,6 +212,8 @@ class Connection {
    * @returns {Promise<void>}
    */
   async close () {
+    this.streams.map(s => s.close && s.close())
+
     if (this.stat.status === CLOSED) {
       return
     }

--- a/src/stream-muxer/tests/close-test.js
+++ b/src/stream-muxer/tests/close-test.js
@@ -3,6 +3,10 @@
 /* eslint max-nested-callbacks: ["error", 8] */
 'use strict'
 
+const chai = require('chai')
+const expect = chai.expect
+chai.use(require('dirty-chai'))
+
 const pair = require('it-pair/duplex')
 const { pipe } = require('it-pipe')
 const { consume } = require('streaming-iterables')
@@ -110,6 +114,70 @@ module.exports = (common) => {
 
       // These should now all resolve without error
       await Promise.all(streamResults)
+    })
+
+    it('can close a stream for writing', (done) => {
+      const p = pair()
+      const dialer = new Muxer()
+      const data = [randomBuffer(), randomBuffer()]
+
+      const listener = new Muxer(async stream => {
+        // Immediate close for write
+        await stream.closeWrite()
+        
+        const results = await pipe(stream, async (source) => {
+          const data = []
+          for await (const chunk of source) {
+            data.push(chunk.slice())
+          }
+          return data
+        })        
+        expect(results).to.eql(data)
+
+        try {
+          await stream.sink([randomBuffer()])
+        } catch (err) {
+          expect(err).to.exist()
+          return done()
+        }
+        expect.fail('should not support writing to closed writer')
+      })
+
+      pipe(p[0], dialer, p[0])
+      pipe(p[1], listener, p[1])
+
+      const stream = dialer.newStream()
+      stream.sink(data)
+    })
+
+    it('can close a stream for reading', (done) => {
+      const p = pair()
+      const dialer = new Muxer()
+      const data = [randomBuffer(), randomBuffer()]
+
+      const listener = new Muxer(async stream => {
+        const results = await pipe(stream, async (source) => {
+          const data = []
+          for await (const chunk of source) {
+            data.push(chunk.slice())
+          }
+          return data
+        })        
+        expect(results).to.eql(data)
+        done()
+      })
+
+      pipe(p[0], dialer, p[0])
+      pipe(p[1], listener, p[1])
+
+      const stream = dialer.newStream()  
+      stream.closeRead() 
+
+      // Source should be done
+      ;(async () => {
+        expect(await stream.source.next()).to.eql({ done: true })  
+        stream.sink(data)
+      })()        
     })
   })
 }

--- a/src/stream-muxer/tests/close-test.js
+++ b/src/stream-muxer/tests/close-test.js
@@ -124,14 +124,14 @@ module.exports = (common) => {
       const listener = new Muxer(async stream => {
         // Immediate close for write
         await stream.closeWrite()
-        
+
         const results = await pipe(stream, async (source) => {
           const data = []
           for await (const chunk of source) {
             data.push(chunk.slice())
           }
           return data
-        })        
+        })
         expect(results).to.eql(data)
 
         try {
@@ -162,7 +162,7 @@ module.exports = (common) => {
             data.push(chunk.slice())
           }
           return data
-        })        
+        })
         expect(results).to.eql(data)
         done()
       })
@@ -170,14 +170,14 @@ module.exports = (common) => {
       pipe(p[0], dialer, p[0])
       pipe(p[1], listener, p[1])
 
-      const stream = dialer.newStream()  
-      stream.closeRead() 
+      const stream = dialer.newStream()
+      stream.closeRead()
 
       // Source should be done
       ;(async () => {
-        expect(await stream.source.next()).to.eql({ done: true })  
+        expect(await stream.source.next()).to.eql({ done: true })
         stream.sink(data)
-      })()        
+      })()
     })
   })
 }

--- a/src/stream-muxer/tests/close-test.js
+++ b/src/stream-muxer/tests/close-test.js
@@ -10,7 +10,6 @@ chai.use(require('dirty-chai'))
 const pair = require('it-pair/duplex')
 const { pipe } = require('it-pipe')
 const { consume } = require('streaming-iterables')
-const { Multiaddr } = require('multiaddr')
 const { source: abortable } = require('abortable-iterator')
 const AbortController = require('abort-controller').default
 const uint8arrayFromString = require('uint8arrays/from-string')


### PR DESCRIPTION
This adds tests for closeRead and closeWrite on the muxer streams.


Also:
- Removed `libp2p-tcp` in favor of `it-pair` to avoid circular deps
- `Connection.close()` will now close its internal streams to avoid lingering streams.

BREAKING CHANGE: This adds closeWrite and closeRead checks in the tests, which will cause test failures for muxers that dont implement those.