### PR TITLE
pubsub: fix typescript types

### DIFF
--- a/src/pubsub/errors.d.ts
+++ b/src/pubsub/errors.d.ts
@@ -1,4 +1,11 @@
 export namespace codes {
+    export const ERR_INVALID_SIGNATURE_POLICY: string;
+    export const ERR_UNHANDLED_SIGNATURE_POLICY: string;
     export const ERR_MISSING_SIGNATURE: string;
+    export const ERR_MISSING_SEQNO: string;
     export const ERR_INVALID_SIGNATURE: string;
+    export const ERR_UNEXPECTED_FROM: string;
+    export const ERR_UNEXPECTED_SIGNATURE: string;
+    export const ERR_UNEXPECTED_KEY: string;
+    export const ERR_UNEXPECTED_SEQNO: string;
 }

--- a/src/pubsub/index.d.ts
+++ b/src/pubsub/index.d.ts
@@ -22,18 +22,16 @@ declare class PubsubBaseProtocol {
      * @param {String} props.debugName log namespace
      * @param {Array<string>|string} props.multicodecs protocol identificers to connect
      * @param {Libp2p} props.libp2p
-     * @param {boolean} [props.signMessages = true] if messages should be signed
-     * @param {boolean} [props.strictSigning = true] if message signing should be required
+     * @param {SignaturePolicy} [props.globalSignaturePolicy = SignaturePolicy.StrictSign] defines how signatures should be handled
      * @param {boolean} [props.canRelayMessage = false] if can relay messages not subscribed
      * @param {boolean} [props.emitSelf = false] if publish should emit to self, if subscribed
      * @abstract
      */
-    constructor({ debugName, multicodecs, libp2p, signMessages, strictSigning, canRelayMessage, emitSelf }: {
+    constructor({ debugName, multicodecs, libp2p, globalSignaturePolicy, canRelayMessage, emitSelf }: {
         debugName: string;
         multicodecs: string | string[];
         libp2p: any;
-        signMessages?: boolean;
-        strictSigning?: boolean;
+        globalSignaturePolicy?: any;
         canRelayMessage?: boolean;
         emitSelf?: boolean;
     });
@@ -66,12 +64,12 @@ declare class PubsubBaseProtocol {
      * @type {Map<string, import('./peer-streams')>}
      */
     peers: Map<string, import('./peer-streams')>;
-    signMessages: boolean;
     /**
-     * If message signing should be required for incoming messages
-     * @type {boolean}
+     * The signature policy to follow by default
+     *
+     * @type {string}
      */
-    strictSigning: boolean;
+    globalSignaturePolicy: string;
     /**
      * If router can relay received messages, even if not subscribed
      * @type {boolean}
@@ -284,7 +282,7 @@ declare class PubsubBaseProtocol {
     getTopics(): string[];
 }
 declare namespace PubsubBaseProtocol {
-    export { message, utils, InMessage, PeerId };
+    export { message, utils, SignaturePolicy, InMessage, PeerId };
 }
 type PeerId = import("peer-id");
 /**
@@ -305,3 +303,7 @@ type InMessage = {
  */
 declare const message: typeof import('./message');
 declare const utils: typeof import("./utils");
+declare const SignaturePolicy: {
+    StrictSign: string;
+    StrictNoSign: string;
+};

--- a/src/pubsub/index.js
+++ b/src/pubsub/index.js
@@ -116,7 +116,7 @@ class PubsubBaseProtocol extends EventEmitter {
     /**
      * The signature policy to follow by default
      *
-     * @type {SignaturePolicy}
+     * @type {string}
      */
     this.globalSignaturePolicy = globalSignaturePolicy
 

--- a/src/pubsub/signature-policy.d.ts
+++ b/src/pubsub/signature-policy.d.ts
@@ -1,0 +1,4 @@
+export namespace SignaturePolicy {
+    export const StrictSign: string;
+    export const StrictNoSign: string;
+}

--- a/src/pubsub/utils.d.ts
+++ b/src/pubsub/utils.d.ts
@@ -1,5 +1,6 @@
 export function randomSeqno(): Uint8Array;
 export function msgId(from: string, seqno: Uint8Array): Uint8Array;
+export function noSignMsgId(data: Uint8Array): Uint8Array;
 export function anyMatch(a: any[] | Set<any>, b: any[] | Set<any>): boolean;
 export function ensureArray(maybeArray: any): any[];
 export function normalizeInRpcMessage(message: any, peerId: string): any;


### PR DESCRIPTION
Unfortunately, #66, as merged, had several errors with the typescript types:
- the globalSignaturePolicy type was set as `SignaturePolicy`, rather than `string`
  - the idea is that `SignaturePolicy` is the "type" of the enum, which is how this would be described if this was written in typescript. Unfortunately, this type was not exported so there was a type mismatch.
- the checked-in typescript declaration files were not updated

This PR rectifies both issues