### PR TITLE
Pubsub conformance test updates

### DIFF
--- a/src/pubsub/tests/api.js
+++ b/src/pubsub/tests/api.js
@@ -76,7 +76,7 @@ module.exports = (common) => {
       const defer = pDefer()
 
       const handler = (msg) => {
-        expect(msg).to.exist()
+        expect(msg).to.exist
         defer.resolve()
       }
 

--- a/src/pubsub/tests/api.js
+++ b/src/pubsub/tests/api.js
@@ -76,7 +76,7 @@ module.exports = (common) => {
       const defer = pDefer()
 
       const handler = (msg) => {
-        expect(msg).to.exist
+        expect(msg).to.not.eql(undefined)
         defer.resolve()
       }
 

--- a/src/pubsub/tests/messages.js
+++ b/src/pubsub/tests/messages.js
@@ -10,6 +10,7 @@ const uint8ArrayFromString = require('uint8arrays/from-string')
 
 const { utils } = require('..')
 const PeerStreams = require('../peer-streams')
+const { SignaturePolicy } = require('../signature-policy')
 
 const topic = 'foo'
 const data = uint8ArrayFromString('bar')
@@ -31,24 +32,17 @@ module.exports = (common) => {
     })
 
     it('should emit normalized signed messages on publish', async () => {
+      pubsub.globalSignaturePolicy = SignaturePolicy.StrictSign
       sinon.spy(pubsub, '_emitMessage')
-      sinon.spy(utils, 'randomSeqno')
 
       await pubsub.publish(topic, data)
       expect(pubsub._emitMessage.callCount).to.eql(1)
 
       const [messageToEmit] = pubsub._emitMessage.getCall(0).args
 
-      const expected = utils.normalizeInRpcMessage(
-        await pubsub._buildMessage({
-          receivedFrom: pubsub.peerId.toB58String(),
-          from: pubsub.peerId.toB58String(),
-          data,
-          seqno: utils.randomSeqno.getCall(0).returnValue,
-          topicIDs: [topic]
-        }))
-
-      expect(messageToEmit).to.eql(expected)
+      expect(messageToEmit.seqno).to.not.be.undefined
+      expect(messageToEmit.key).to.not.be.undefined
+      expect(messageToEmit.signature).to.not.be.undefined
     })
 
     it('should drop unsigned messages', async () => {
@@ -83,18 +77,16 @@ module.exports = (common) => {
     })
 
     it('should not drop unsigned messages if strict signing is disabled', async () => {
+      pubsub.globalSignaturePolicy = SignaturePolicy.StrictNoSign
       sinon.spy(pubsub, '_emitMessage')
       sinon.spy(pubsub, '_publish')
       sinon.spy(pubsub, 'validate')
-      sinon.stub(pubsub, 'strictSigning').value(false)
 
       const peerStream = new PeerStreams({ id: await PeerId.create() })
       const rpc = {
         subscriptions: [],
         msgs: [{
-          from: peerStream.id.toBytes(),
           data,
-          seqno: utils.randomSeqno(),
           topicIDs: [topic]
         }]
       }

--- a/src/pubsub/tests/messages.js
+++ b/src/pubsub/tests/messages.js
@@ -40,9 +40,9 @@ module.exports = (common) => {
 
       const [messageToEmit] = pubsub._emitMessage.getCall(0).args
 
-      expect(messageToEmit.seqno).to.not.be.undefined
-      expect(messageToEmit.key).to.not.be.undefined
-      expect(messageToEmit.signature).to.not.be.undefined
+      expect(messageToEmit.seqno).to.not.eql(undefined)
+      expect(messageToEmit.key).to.not.eql(undefined)
+      expect(messageToEmit.signature).to.not.eql(undefined)
     })
 
     it('should drop unsigned messages', async () => {

--- a/src/pubsub/tests/multiple-nodes.js
+++ b/src/pubsub/tests/multiple-nodes.js
@@ -52,26 +52,20 @@ module.exports = (common) => {
           await common.teardown()
         })
 
-        it('subscribe to the topic on node a', () => {
+        it('subscribe to the topic on node a', async () => {
           const topic = 'Z'
-          const defer = pDefer()
 
           psA.subscribe(topic)
           expectSet(psA.subscriptions, [topic])
 
-          psB.once('pubsub:subscription-change', () => {
-            expect(psB.peers.size).to.equal(2)
+          await new Promise((resolve) => psB.once('pubsub:subscription-change', resolve))
+          expect(psB.peers.size).to.equal(2)
 
-            const aPeerId = psA.peerId.toB58String()
-            expectSet(psB.topics.get(topic), [aPeerId])
+          const aPeerId = psA.peerId.toB58String()
+          expectSet(psB.topics.get(topic), [aPeerId])
 
-            expect(psC.peers.size).to.equal(1)
-            expect(psC.topics.get(topic)).to.not.exist()
-
-            defer.resolve()
-          })
-
-          return defer.promise
+          expect(psC.peers.size).to.equal(1)
+          expect(psC.topics.get(topic)).to.not.exist
         })
 
         it('subscribe to the topic on node b', async () => {

--- a/src/pubsub/tests/multiple-nodes.js
+++ b/src/pubsub/tests/multiple-nodes.js
@@ -65,7 +65,7 @@ module.exports = (common) => {
           expectSet(psB.topics.get(topic), [aPeerId])
 
           expect(psC.peers.size).to.equal(1)
-          expect(psC.topics.get(topic)).to.not.exist
+          expect(psC.topics.get(topic)).to.eql(undefined)
         })
 
         it('subscribe to the topic on node b', async () => {

--- a/src/pubsub/utils.js
+++ b/src/pubsub/utils.js
@@ -40,7 +40,7 @@ exports.msgId = (from, seqno) => {
  * @returns {Uint8Array}
  * @private
  */
-exports.noSignMsgId = (data) => multihash.encode(data, 'sha2')
+exports.noSignMsgId = (data) => multihash.encode(data, 'sha2-256')
 
 /**
  * Check if any member of the first set is also a member


### PR DESCRIPTION
Sorry for the many insufficient PRs.
In the future, it may be wise to always open a PR in a 'consumer' of the interface being updated, in conjunction with the PR updating the interface, to make sure there are no surprises.
I've done that now, with https://github.com/ChainSafe/js-libp2p-gossipsub/pull/145 which should pass tests when using this PR.

This PR includes minimal changes required to fix the conformance tests.