### PR TITLE
chore: add pubsub interface to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - [Crypto](./src/crypto)
 - [Peer Discovery](./src/peer-discovery)
 - [Peer Routing](./src/peer-routing)
+- [Pubsub](./src/pubsub)
 - [Record](./src/record)
 - [Stream Muxer](./src/stream-muxer)
 - [Topology](./src/topology)
@@ -30,6 +31,7 @@ For posterity, here are links to the original repositories for each of the inter
 - [Content Routing](https://github.com/libp2p/interface-content-routing)
 - [Peer Discovery](https://github.com/libp2p/interface-peer-discovery)
 - [Peer Routing](https://github.com/libp2p/interface-peer-routing)
+- [Pubsub](https://github.com/libp2p/js-libp2p-pubsub)
 - [Stream Muxer](https://github.com/libp2p/interface-stream-muxer)
 - [Transport](https://github.com/libp2p/interface-transport)
 


### PR DESCRIPTION
This PR adds the pubsub interface link to the readme, which was missing.