### PR TITLE
fix: typedefs for MulticodecTopology

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "aegir lint",
     "build": "aegir build",
     "pregenerate:types": "rimraf './src/**/*.d.ts'",
-    "generate:types": "tsc",
+    "generate:types": "tsc --build",
     "test": "aegir test",
     "test:node": "aegir test --target node",
     "test:browser": "aegir test --target browser",
@@ -69,7 +69,7 @@
     "aegir": "^25.0.0",
     "it-handshake": "^1.0.1",
     "rimraf": "^3.0.2",
-    "typescript": "^4.1.2"
+    "typescript": "^4.0.5"
   },
   "contributors": [
     "Alan Shaw <alan.shaw@protocol.ai>",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "abortable-iterator": "^3.0.0",
     "chai": "^4.2.0",
     "chai-checkmark": "^1.0.1",
-    "class-is": "^1.1.0",
     "debug": "^4.1.1",
     "delay": "^4.3.0",
     "detect-node": "^2.0.4",
@@ -70,7 +69,7 @@
     "aegir": "^25.0.0",
     "it-handshake": "^1.0.1",
     "rimraf": "^3.0.2",
-    "typescript": "3.7.5"
+    "typescript": "^4.1.2"
   },
   "contributors": [
     "Alan Shaw <alan.shaw@protocol.ai>",

--- a/src/connection/connection.d.ts
+++ b/src/connection/connection.d.ts
@@ -1,10 +1,16 @@
-declare const _exports: typeof Connection;
-export = _exports;
+export = Connection;
 /**
  * An implementation of the js-libp2p connection.
  * Any libp2p transport should use an upgrader to return this connection.
  */
 declare class Connection {
+    /**
+     * Checks if the given value is a `Connection` instance.
+     *
+     * @param {any} other
+     * @returns {other is Connection}
+     */
+    static isConnection(other: any): other is Connection;
     /**
      * Creates an instance of Connection.
      * @param {object} properties properties of the connection.
@@ -24,10 +30,10 @@ declare class Connection {
      * @param {string} [properties.stat.encryption] connection encryption method identifier.
      */
     constructor({ localAddr, remoteAddr, localPeer, remotePeer, newStream, close, getStreams, stat }: {
-        localAddr?: import("multiaddr");
-        remoteAddr?: import("multiaddr");
-        localPeer: import("peer-id");
-        remotePeer: import("peer-id");
+        localAddr: multiaddr;
+        remoteAddr: multiaddr;
+        localPeer: PeerId;
+        remotePeer: PeerId;
         newStream: Function;
         close: Function;
         getStreams: () => any[];
@@ -37,35 +43,35 @@ declare class Connection {
                 open: string;
                 upgraded: string;
             };
-            multiplexer?: string;
-            encryption?: string;
+            multiplexer: string;
+            encryption: string;
         };
     });
     /**
      * Connection identifier.
      */
-    id: any;
+    id: string;
     /**
      * Observed multiaddr of the local peer
      */
-    localAddr: import("multiaddr");
+    localAddr: multiaddr;
     /**
      * Observed multiaddr of the remote peer
      */
-    remoteAddr: import("multiaddr");
+    remoteAddr: multiaddr;
     /**
      * Local peer id.
      */
-    localPeer: import("peer-id");
+    localPeer: PeerId;
     /**
      * Remote peer id.
      */
-    remotePeer: import("peer-id");
+    remotePeer: PeerId;
     /**
      * Connection metadata.
      */
     _stat: {
-        status: string;
+        status: "open";
         direction: string;
         timeline: {
             open: string;
@@ -95,12 +101,13 @@ declare class Connection {
      * @type {string[]}
      */
     tags: string[];
+    get [Symbol.toStringTag](): string;
     /**
      * Get connection metadata
      * @this {Connection}
      */
     get stat(): {
-        status: string;
+        status: "open";
         direction: string;
         timeline: {
             open: string;
@@ -133,7 +140,7 @@ declare class Connection {
      */
     addStream(muxedStream: any, { protocol, metadata }: {
         protocol: string;
-        metadata: any;
+        metadata: object;
     }): void;
     /**
      * Remove stream registry after it is closed.
@@ -146,4 +153,8 @@ declare class Connection {
      */
     close(): Promise<void>;
     _closing: any;
+    get [connectionSymbol](): boolean;
 }
+import multiaddr = require("multiaddr");
+import PeerId = require("peer-id");
+declare const connectionSymbol: unique symbol;

--- a/src/connection/connection.d.ts
+++ b/src/connection/connection.d.ts
@@ -30,8 +30,8 @@ declare class Connection {
      * @param {string} [properties.stat.encryption] connection encryption method identifier.
      */
     constructor({ localAddr, remoteAddr, localPeer, remotePeer, newStream, close, getStreams, stat }: {
-        localAddr: multiaddr;
-        remoteAddr: multiaddr;
+        localAddr: multiaddr | undefined;
+        remoteAddr: multiaddr | undefined;
         localPeer: PeerId;
         remotePeer: PeerId;
         newStream: Function;
@@ -43,8 +43,8 @@ declare class Connection {
                 open: string;
                 upgraded: string;
             };
-            multiplexer: string;
-            encryption: string;
+            multiplexer: string | undefined;
+            encryption: string | undefined;
         };
     });
     /**
@@ -54,11 +54,11 @@ declare class Connection {
     /**
      * Observed multiaddr of the local peer
      */
-    localAddr: multiaddr;
+    localAddr: multiaddr | undefined;
     /**
      * Observed multiaddr of the remote peer
      */
-    remoteAddr: multiaddr;
+    remoteAddr: multiaddr | undefined;
     /**
      * Local peer id.
      */
@@ -77,8 +77,8 @@ declare class Connection {
             open: string;
             upgraded: string;
         };
-        multiplexer?: string;
-        encryption?: string;
+        multiplexer?: string | undefined;
+        encryption?: string | undefined;
     };
     /**
      * Reference to the new stream function of the multiplexer
@@ -113,8 +113,8 @@ declare class Connection {
             open: string;
             upgraded: string;
         };
-        multiplexer?: string;
-        encryption?: string;
+        multiplexer?: string | undefined;
+        encryption?: string | undefined;
     };
     /**
      * Get all the streams of the muxer.

--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -1,4 +1,5 @@
 'use strict'
+/* eslint-disable valid-jsdoc */
 
 const PeerId = require('peer-id')
 const multiaddr = require('multiaddr')
@@ -143,7 +144,7 @@ class Connection {
     return 'Connection'
   }
 
-  get [connectionSymbol]() {
+  get [connectionSymbol] () {
     return true
   }
 
@@ -153,7 +154,7 @@ class Connection {
    * @param {any} other
    * @returns {other is Connection}
    */
-  static isConnection(other) {
+  static isConnection (other) {
     return Boolean(other && other[connectionSymbol])
   }
 
@@ -245,6 +246,5 @@ class Connection {
     this.stat.status = Status.CLOSED
   }
 }
-
 
 module.exports = Connection

--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -2,9 +2,10 @@
 
 const PeerId = require('peer-id')
 const multiaddr = require('multiaddr')
-const withIs = require('class-is')
 const errCode = require('err-code')
 const Status = require('./status')
+
+const connectionSymbol = Symbol.for('@libp2p/interface-connection/connection')
 
 function validateArgs (localAddr, localPeer, remotePeer, newStream, close, getStreams, stat) {
   if (localAddr && !multiaddr.isMultiaddr(localAddr)) {
@@ -138,6 +139,24 @@ class Connection {
     this.tags = []
   }
 
+  get [Symbol.toStringTag] () {
+    return 'Connection'
+  }
+
+  get [connectionSymbol]() {
+    return true
+  }
+
+  /**
+   * Checks if the given value is a `Connection` instance.
+   *
+   * @param {any} other
+   * @returns {other is Connection}
+   */
+  static isConnection(other) {
+    return Boolean(other && other[connectionSymbol])
+  }
+
   /**
    * Get connection metadata
    * @this {Connection}
@@ -227,8 +246,5 @@ class Connection {
   }
 }
 
-/**
- * @module
- * @type {typeof Connection}
- */
-module.exports = withIs(Connection, { className: 'Connection', symbolName: '@libp2p/interface-connection/connection' })
+
+module.exports = Connection

--- a/src/connection/status.d.ts
+++ b/src/connection/status.d.ts
@@ -1,3 +1,3 @@
-export declare const OPEN: string;
-export declare const CLOSING: string;
-export declare const CLOSED: string;
+export const OPEN: 'open';
+export const CLOSING: 'closing';
+export const CLOSED: 'closed';

--- a/src/connection/status.js
+++ b/src/connection/status.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  OPEN: 'open',
-  CLOSING: 'closing',
-  CLOSED: 'closed'
+  OPEN: /** @type {'open'} */('open'),
+  CLOSING: /** @type {'closing'} */('closing'),
+  CLOSED: /** @type {'closed'} */('closed')
 }

--- a/src/pubsub/errors.d.ts
+++ b/src/pubsub/errors.d.ts
@@ -1,11 +1,11 @@
 export namespace codes {
-    export const ERR_INVALID_SIGNATURE_POLICY: string;
-    export const ERR_UNHANDLED_SIGNATURE_POLICY: string;
-    export const ERR_MISSING_SIGNATURE: string;
-    export const ERR_MISSING_SEQNO: string;
-    export const ERR_INVALID_SIGNATURE: string;
-    export const ERR_UNEXPECTED_FROM: string;
-    export const ERR_UNEXPECTED_SIGNATURE: string;
-    export const ERR_UNEXPECTED_KEY: string;
-    export const ERR_UNEXPECTED_SEQNO: string;
+    const ERR_INVALID_SIGNATURE_POLICY: string;
+    const ERR_UNHANDLED_SIGNATURE_POLICY: string;
+    const ERR_MISSING_SIGNATURE: string;
+    const ERR_MISSING_SEQNO: string;
+    const ERR_INVALID_SIGNATURE: string;
+    const ERR_UNEXPECTED_FROM: string;
+    const ERR_UNEXPECTED_SIGNATURE: string;
+    const ERR_UNEXPECTED_KEY: string;
+    const ERR_UNEXPECTED_SEQNO: string;
 }

--- a/src/pubsub/index.d.ts
+++ b/src/pubsub/index.d.ts
@@ -29,11 +29,14 @@ declare class PubsubBaseProtocol {
      */
     constructor({ debugName, multicodecs, libp2p, globalSignaturePolicy, canRelayMessage, emitSelf }: {
         debugName: string;
-        multicodecs: string | string[];
+        multicodecs: Array<string> | string;
         libp2p: any;
-        globalSignaturePolicy?: any;
-        canRelayMessage?: boolean;
-        emitSelf?: boolean;
+        globalSignaturePolicy: {
+            StrictSign: "StrictSign";
+            StrictNoSign: string;
+        };
+        canRelayMessage: boolean;
+        emitSelf: boolean;
     });
     log: any;
     /**
@@ -91,7 +94,7 @@ declare class PubsubBaseProtocol {
      * Topic validators are functions with the following input:
      * @type {Map<string, validator>}
      */
-    topicValidators: Map<string, validator>;
+    topicValidators: Map<string, (arg0: string, arg1: InMessage) => Promise<void>>;
     _registrarId: any;
     /**
      * On an inbound stream opened.
@@ -101,25 +104,21 @@ declare class PubsubBaseProtocol {
      * @param {DuplexIterableStream} props.stream
      * @param {Connection} props.connection connection
      */
-    _onIncomingStream({ protocol, stream, connection }: {
-        protocol: string;
-        stream: any;
-        connection: any;
-    }): void;
+    private _onIncomingStream;
     /**
      * Registrar notifies an established connection with pubsub protocol.
      * @private
      * @param {PeerId} peerId remote peer-id
      * @param {Connection} conn connection to the peer
      */
-    _onPeerConnected(peerId: import("peer-id"), conn: any): Promise<void>;
+    private _onPeerConnected;
     /**
      * Registrar notifies a closing connection with pubsub protocol.
      * @private
      * @param {PeerId} peerId peerId
      * @param {Error} err error for connection end
      */
-    _onPeerDisconnected(peerId: import("peer-id"), err: Error): void;
+    private _onPeerDisconnected;
     /**
      * Register the pubsub protocol onto the libp2p node.
      * @returns {void}
@@ -137,14 +136,14 @@ declare class PubsubBaseProtocol {
      * @param {string} protocol
      * @returns {PeerStreams}
      */
-    _addPeer(peerId: import("peer-id"), protocol: string): import("./peer-streams");
+    private _addPeer;
     /**
      * Notifies the router that a peer has been disconnected.
      * @private
      * @param {PeerId} peerId
      * @returns {PeerStreams | undefined}
      */
-    _removePeer(peerId: import("peer-id")): import("./peer-streams");
+    private _removePeer;
     /**
      * Responsible for processing each RPC message received by other peers.
      * @param {string} idB58Str peer id string in base58
@@ -152,7 +151,7 @@ declare class PubsubBaseProtocol {
      * @param {PeerStreams} peerStreams PubSub peer
      * @returns {Promise<void>}
      */
-    _processMessages(idB58Str: string, stream: any, peerStreams: import("./peer-streams")): Promise<void>;
+    _processMessages(idB58Str: string, stream: any, peerStreams: PeerStreams): Promise<void>;
     /**
      * Handles an rpc request from a peer
      * @param {String} idB58Str
@@ -160,7 +159,7 @@ declare class PubsubBaseProtocol {
      * @param {RPC} rpc
      * @returns {boolean}
      */
-    _processRpc(idB58Str: string, peerStreams: import("./peer-streams"), rpc: any): boolean;
+    _processRpc(idB58Str: string, peerStreams: PeerStreams, rpc: any): boolean;
     /**
      * Handles a subscription change from a peer
      * @param {string} id
@@ -236,13 +235,13 @@ declare class PubsubBaseProtocol {
      * @param {Message} message
      * @returns {Promise<Message>}
      */
-    _buildMessage(message: any): Promise<any>;
+    private _buildMessage;
     /**
      * Get a list of the peer-ids that are subscribed to one topic.
      * @param {string} topic
      * @returns {Array<string>}
      */
-    getSubscribers(topic: string): string[];
+    getSubscribers(topic: string): Array<string>;
     /**
      * Publishes messages to all subscribed peers
      * @override
@@ -279,16 +278,12 @@ declare class PubsubBaseProtocol {
      * @override
      * @returns {Array<String>}
      */
-    getTopics(): string[];
+    getTopics(): Array<string>;
 }
 declare namespace PubsubBaseProtocol {
     export { message, utils, SignaturePolicy, InMessage, PeerId };
 }
 type PeerId = import("peer-id");
-/**
- * Topic validator function
- */
-type validator = (arg0: string, arg1: InMessage) => Promise<void>;
 type InMessage = {
     from?: string;
     receivedFrom: string;
@@ -298,12 +293,10 @@ type InMessage = {
     signature?: Uint8Array;
     key?: Uint8Array;
 };
+import PeerStreams = require("./peer-streams");
 /**
  * @type {typeof import('./message')}
  */
 declare const message: typeof import('./message');
-declare const utils: typeof import("./utils");
-declare const SignaturePolicy: {
-    StrictSign: string;
-    StrictNoSign: string;
-};
+import utils = require("./utils");
+import { SignaturePolicy } from "./signature-policy";

--- a/src/pubsub/index.d.ts
+++ b/src/pubsub/index.d.ts
@@ -34,9 +34,9 @@ declare class PubsubBaseProtocol {
         globalSignaturePolicy: {
             StrictSign: "StrictSign";
             StrictNoSign: string;
-        };
-        canRelayMessage: boolean;
-        emitSelf: boolean;
+        } | undefined;
+        canRelayMessage: boolean | undefined;
+        emitSelf: boolean | undefined;
     });
     log: any;
     /**
@@ -285,13 +285,13 @@ declare namespace PubsubBaseProtocol {
 }
 type PeerId = import("peer-id");
 type InMessage = {
-    from?: string;
+    from?: string | undefined;
     receivedFrom: string;
     topicIDs: string[];
-    seqno?: Uint8Array;
+    seqno?: Uint8Array | undefined;
     data: Uint8Array;
-    signature?: Uint8Array;
-    key?: Uint8Array;
+    signature?: Uint8Array | undefined;
+    key?: Uint8Array | undefined;
 };
 import PeerStreams = require("./peer-streams");
 /**

--- a/src/pubsub/index.js
+++ b/src/pubsub/index.js
@@ -23,33 +23,13 @@ const {
 } = require('./message/sign')
 
 /**
- * @typedef {Object} InMessage
- * @property {string} [from]
- * @property {string} receivedFrom
- * @property {string[]} topicIDs
- * @property {Uint8Array} [seqno]
- * @property {Uint8Array} data
- * @property {Uint8Array} [signature]
- * @property {Uint8Array} [key]
- *
- * @typedef PeerId
- * @type import('peer-id')
- */
-
-/**
 * PubsubBaseProtocol handles the peers and connections logic for pubsub routers
 * and specifies the API that pubsub routers should have.
 */
 class PubsubBaseProtocol extends EventEmitter {
   /**
-   * @param {Object} props
-   * @param {String} props.debugName log namespace
-   * @param {Array<string>|string} props.multicodecs protocol identificers to connect
-   * @param {Libp2p} props.libp2p
-   * @param {SignaturePolicy} [props.globalSignaturePolicy = SignaturePolicy.StrictSign] defines how signatures should be handled
-   * @param {boolean} [props.canRelayMessage = false] if can relay messages not subscribed
-   * @param {boolean} [props.emitSelf = false] if publish should emit to self, if subscribed
    * @abstract
+   * @param {Options} options
    */
   constructor ({
     debugName,
@@ -206,7 +186,8 @@ class PubsubBaseProtocol extends EventEmitter {
 
   /**
    * On an inbound stream opened.
-   * @private
+   *
+   * @protected
    * @param {Object} props
    * @param {string} props.protocol
    * @param {DuplexIterableStream} props.stream
@@ -223,7 +204,8 @@ class PubsubBaseProtocol extends EventEmitter {
 
   /**
    * Registrar notifies an established connection with pubsub protocol.
-   * @private
+   *
+   * @protected
    * @param {PeerId} peerId remote peer-id
    * @param {Connection} conn connection to the peer
    */
@@ -245,7 +227,8 @@ class PubsubBaseProtocol extends EventEmitter {
 
   /**
    * Registrar notifies a closing connection with pubsub protocol.
-   * @private
+   *
+   * @protected
    * @param {PeerId} peerId peerId
    * @param {Error} err error for connection end
    */
@@ -258,7 +241,8 @@ class PubsubBaseProtocol extends EventEmitter {
 
   /**
    * Notifies the router that a peer has been connected
-   * @private
+   *
+   * @protected
    * @param {PeerId} peerId
    * @param {string} protocol
    * @returns {PeerStreams}
@@ -288,7 +272,8 @@ class PubsubBaseProtocol extends EventEmitter {
 
   /**
    * Notifies the router that a peer has been disconnected.
-   * @private
+   *
+   * @protected
    * @param {PeerId} peerId
    * @returns {PeerStreams | undefined}
    */
@@ -564,7 +549,8 @@ class PubsubBaseProtocol extends EventEmitter {
   /**
    * Normalizes the message and signs it, if signing is enabled.
    * Should be used by the routers to create the message to send.
-   * @private
+   *
+   * @protected
    * @param {Message} message
    * @returns {Promise<Message>}
    */
@@ -697,6 +683,27 @@ class PubsubBaseProtocol extends EventEmitter {
   }
 }
 
+/**
+ * @typedef {Object} Options
+ * @property {string} [debugName] - log namespace
+ * @property {string[]|string} [multicodecs] - protocol identificers to connect
+ * @property {Libp2p} libp2p
+ * @property {SignaturePolicyType} [globalSignaturePolicy = SignaturePolicy.StrictSign] - defines how signatures should be handled
+ * @property {boolean} [canRelayMessage = false] - if can relay messages not subscribed
+ * @property {boolean} [emitSelf = false] - if publish should emit to self, if subscribed
+ *
+ * @typedef {Object} InMessage
+ * @property {string} [from]
+ * @property {string} receivedFrom
+ * @property {string[]} topicIDs
+ * @property {Uint8Array} [seqno]
+ * @property {Uint8Array} data
+ * @property {Uint8Array} [signature]
+ * @property {Uint8Array} [key]
+ *
+ * @typedef {import('peer-id')} PeerId
+ * @typedef {import('./signature-policy').SignaturePolicyType} SignaturePolicyType
+ */
 module.exports = PubsubBaseProtocol
 module.exports.message = message
 module.exports.utils = utils

--- a/src/pubsub/index.js
+++ b/src/pubsub/index.js
@@ -1,4 +1,5 @@
 'use strict'
+/* eslint-disable valid-jsdoc */
 
 const debug = require('debug')
 const EventEmitter = require('events')

--- a/src/pubsub/message/index.d.ts
+++ b/src/pubsub/message/index.d.ts
@@ -1,5 +1,4 @@
-export var rpc: any;
-export var td: any;
-export var RPC: any;
-export var Message: any;
-export var SubOpts: any;
+declare const rpcProto: any;
+declare const topicDescriptorProto: any;
+export const RPC: any;
+export { rpcProto as rpc, topicDescriptorProto as td };

--- a/src/pubsub/message/sign.d.ts
+++ b/src/pubsub/message/sign.d.ts
@@ -13,7 +13,7 @@ export function messagePublicKey(message: any): Promise<any>;
  * @param {Message} message
  * @returns {Promise<Message>}
  */
-export function signMessage(peerId: import("peer-id"), message: any): Promise<any>;
+export function signMessage(peerId: PeerId, message: any): Promise<any>;
 export const SignPrefix: any;
 /**
  * Verifies the signature of the given message
@@ -21,3 +21,4 @@ export const SignPrefix: any;
  * @returns {Promise<Boolean>}
  */
 export function verifySignature(message: any): Promise<boolean>;
+import PeerId = require("peer-id");

--- a/src/pubsub/peer-streams.d.ts
+++ b/src/pubsub/peer-streams.d.ts
@@ -21,7 +21,7 @@ declare class PeerStreams {
      * @param {string} properties.protocol
      */
     constructor({ id, protocol }: {
-        id: import("peer-id");
+        id: PeerId;
         protocol: string;
     });
     /**
@@ -38,19 +38,19 @@ declare class PeerStreams {
      * @private
      * @type {DuplexIterableStream}
      */
-    _rawOutboundStream: DuplexIterableStream;
+    private _rawOutboundStream;
     /**
      * The raw inbound stream, as retrieved from the callback from libp2p.handle
      * @private
      * @type {DuplexIterableStream}
      */
-    _rawInboundStream: DuplexIterableStream;
+    private _rawInboundStream;
     /**
      * An AbortController for controlled shutdown of the inbound stream
      * @private
      * @type {typeof AbortController}
      */
-    _inboundAbortController: typeof AbortController;
+    private _inboundAbortController;
     /**
      * Write stream -- its preferable to use the write method
      * @type {import('it-pushable').Pushable<Uint8Array>>}
@@ -106,8 +106,7 @@ declare namespace PeerStreams {
 }
 type DuplexIterableStream = {
     sink: Sink;
-    source: () => AsyncIterator<Uint8Array, any, undefined>;
+    source: () => AsyncIterator<Uint8Array>;
 };
-declare const AbortController: typeof import("abort-controller");
-type Sink = (source: Uint8Array) => Promise<Uint8Array>;
 type PeerId = import("peer-id");
+type Sink = (source: Uint8Array) => Promise<Uint8Array>;

--- a/src/pubsub/peer-streams.d.ts
+++ b/src/pubsub/peer-streams.d.ts
@@ -35,22 +35,25 @@ declare class PeerStreams {
     protocol: string;
     /**
      * The raw outbound stream, as retrieved from conn.newStream
-     * @private
+     *
+     * @protected
      * @type {DuplexIterableStream}
      */
-    private _rawOutboundStream;
+    protected _rawOutboundStream: DuplexIterableStream;
     /**
      * The raw inbound stream, as retrieved from the callback from libp2p.handle
-     * @private
+     *
+     * @protected
      * @type {DuplexIterableStream}
      */
-    private _rawInboundStream;
+    protected _rawInboundStream: DuplexIterableStream;
     /**
      * An AbortController for controlled shutdown of the inbound stream
-     * @private
+     *
+     * @protected
      * @type {typeof AbortController}
      */
-    private _inboundAbortController;
+    protected _inboundAbortController: typeof AbortController;
     /**
      * Write stream -- its preferable to use the write method
      * @type {import('it-pushable').Pushable<Uint8Array>>}
@@ -108,5 +111,6 @@ type DuplexIterableStream = {
     sink: Sink;
     source: () => AsyncIterator<Uint8Array>;
 };
+import AbortController = require("abort-controller");
 type PeerId = import("peer-id");
 type Sink = (source: Uint8Array) => Promise<Uint8Array>;

--- a/src/pubsub/peer-streams.js
+++ b/src/pubsub/peer-streams.js
@@ -48,19 +48,22 @@ class PeerStreams extends EventEmitter {
     this.protocol = protocol
     /**
      * The raw outbound stream, as retrieved from conn.newStream
-     * @private
+     *
+     * @protected
      * @type {DuplexIterableStream}
      */
     this._rawOutboundStream = null
     /**
      * The raw inbound stream, as retrieved from the callback from libp2p.handle
-     * @private
+     *
+     * @protected
      * @type {DuplexIterableStream}
      */
     this._rawInboundStream = null
     /**
      * An AbortController for controlled shutdown of the inbound stream
-     * @private
+     *
+     * @protected
      * @type {typeof AbortController}
      */
     this._inboundAbortController = null

--- a/src/pubsub/signature-policy.d.ts
+++ b/src/pubsub/signature-policy.d.ts
@@ -1,4 +1,5 @@
+export type SignaturePolicyType = "StrictSign" | "StrictNoSign";
 export namespace SignaturePolicy {
     const StrictSign: 'StrictSign';
-    const StrictNoSign: string;
+    const StrictNoSign: 'StrictNoSign';
 }

--- a/src/pubsub/signature-policy.d.ts
+++ b/src/pubsub/signature-policy.d.ts
@@ -1,4 +1,4 @@
 export namespace SignaturePolicy {
-    export const StrictSign: string;
-    export const StrictNoSign: string;
+    const StrictSign: 'StrictSign';
+    const StrictNoSign: string;
 }

--- a/src/pubsub/signature-policy.js
+++ b/src/pubsub/signature-policy.js
@@ -4,7 +4,7 @@
  * Enum for Signature Policy
  * Details how message signatures are produced/consumed
  */
-exports.SignaturePolicy = {
+const SignaturePolicy = {
   /**
    * On the producing side:
    * * Build messages with the signature, key (from may be enough for certain inlineable public key types), from and seqno fields.
@@ -24,5 +24,10 @@ exports.SignaturePolicy = {
    * * Propagate only if the fields are absent, reject otherwise.
    * * A message_id function will not be able to use the above fields, and should instead rely on the data field. A commonplace strategy is to calculate a hash.
    */
-  StrictNoSign: /** @type {'StrictNoSign'} */ 'StrictNoSign'
+  StrictNoSign: /** @type {'StrictNoSign'} */ ('StrictNoSign')
 }
+exports.SignaturePolicy = SignaturePolicy
+
+/**
+ * @typedef {SignaturePolicy[keyof SignaturePolicy]} SignaturePolicyType
+ */

--- a/src/pubsub/signature-policy.js
+++ b/src/pubsub/signature-policy.js
@@ -13,7 +13,7 @@ exports.SignaturePolicy = {
    * * Enforce the fields to be present, reject otherwise.
    * * Propagate only if the fields are valid and signature can be verified, reject otherwise.
    */
-  StrictSign: 'StrictSign',
+  StrictSign: /** @type {'StrictSign'} */ ('StrictSign'),
   /**
    * On the producing side:
    * * Build messages without the signature, key, from and seqno fields.
@@ -24,5 +24,5 @@ exports.SignaturePolicy = {
    * * Propagate only if the fields are absent, reject otherwise.
    * * A message_id function will not be able to use the above fields, and should instead rely on the data field. A commonplace strategy is to calculate a hash.
    */
-  StrictNoSign: 'StrictNoSign'
+  StrictNoSign: /** @type {'StrictNoSign'} */ 'StrictNoSign'
 }

--- a/src/pubsub/utils.d.ts
+++ b/src/pubsub/utils.d.ts
@@ -1,7 +1,13 @@
 export function randomSeqno(): Uint8Array;
 export function msgId(from: string, seqno: Uint8Array): Uint8Array;
 export function noSignMsgId(data: Uint8Array): Uint8Array;
-export function anyMatch(a: any[] | Set<any>, b: any[] | Set<any>): boolean;
-export function ensureArray(maybeArray: any): any[];
-export function normalizeInRpcMessage(message: any, peerId: string): any;
-export function normalizeOutRpcMessage(message: any): any;
+export function anyMatch(a: Set<any> | any[], b: Set<any> | any[]): boolean;
+export function ensureArray<T>(maybeArray: T | T[]): T[];
+export function normalizeInRpcMessage<T extends unknown>(message: T, peerId?: string): T & {
+    from?: string;
+    peerId?: string;
+};
+export function normalizeOutRpcMessage<T extends unknown>(message: T): T & {
+    from?: Uint8Array;
+    data?: Uint8Array;
+};

--- a/src/pubsub/utils.d.ts
+++ b/src/pubsub/utils.d.ts
@@ -3,11 +3,11 @@ export function msgId(from: string, seqno: Uint8Array): Uint8Array;
 export function noSignMsgId(data: Uint8Array): Uint8Array;
 export function anyMatch(a: Set<any> | any[], b: Set<any> | any[]): boolean;
 export function ensureArray<T>(maybeArray: T | T[]): T[];
-export function normalizeInRpcMessage<T extends unknown>(message: T, peerId?: string): T & {
-    from?: string;
-    peerId?: string;
+export function normalizeInRpcMessage<T extends Object>(message: T, peerId?: string | undefined): T & {
+    from?: string | undefined;
+    peerId?: string | undefined;
 };
-export function normalizeOutRpcMessage<T extends unknown>(message: T): T & {
-    from?: Uint8Array;
-    data?: Uint8Array;
+export function normalizeOutRpcMessage<T extends Object>(message: T): T & {
+    from?: Uint8Array | undefined;
+    data?: Uint8Array | undefined;
 };

--- a/src/pubsub/utils.d.ts
+++ b/src/pubsub/utils.d.ts
@@ -3,11 +3,11 @@ export function msgId(from: string, seqno: Uint8Array): Uint8Array;
 export function noSignMsgId(data: Uint8Array): Uint8Array;
 export function anyMatch(a: Set<any> | any[], b: Set<any> | any[]): boolean;
 export function ensureArray<T>(maybeArray: T | T[]): T[];
-export function normalizeInRpcMessage<T extends Object>(message: T, peerId?: string | undefined): T & {
+export function normalizeInRpcMessage<T extends unknown>(message: T, peerId?: string | undefined): T & {
     from?: string | undefined;
     peerId?: string | undefined;
 };
-export function normalizeOutRpcMessage<T extends Object>(message: T): T & {
+export function normalizeOutRpcMessage<T extends unknown>(message: T): T & {
     from?: Uint8Array | undefined;
     data?: Uint8Array | undefined;
 };

--- a/src/pubsub/utils.js
+++ b/src/pubsub/utils.js
@@ -71,8 +71,9 @@ exports.anyMatch = (a, b) => {
 /**
  * Make everything an array.
  *
- * @param {any} maybeArray
- * @returns {Array}
+ * @template T
+ * @param {T|T[]} maybeArray
+ * @returns {T[]}
  * @private
  */
 exports.ensureArray = (maybeArray) => {
@@ -85,9 +86,11 @@ exports.ensureArray = (maybeArray) => {
 
 /**
  * Ensures `message.from` is base58 encoded
- * @param {object} message
- * @param {String} peerId
- * @return {object}
+ *
+ * @template {Object} T
+ * @param {T} message
+ * @param {string} [peerId]
+ * @return {T & {from?: string, peerId?: string }}
  */
 exports.normalizeInRpcMessage = (message, peerId) => {
   const m = Object.assign({}, message)
@@ -101,8 +104,10 @@ exports.normalizeInRpcMessage = (message, peerId) => {
 }
 
 /**
- * @param {object} message
- * @return {object}
+ * @template {Object} T
+ * 
+ * @param {T} message
+ * @return {T & {from?: Uint8Array, data?: Uint8Array}}
  */
 exports.normalizeOutRpcMessage = (message) => {
   const m = Object.assign({}, message)

--- a/src/pubsub/utils.js
+++ b/src/pubsub/utils.js
@@ -1,4 +1,5 @@
 'use strict'
+/* eslint-disable valid-jsdoc */
 
 const randomBytes = require('libp2p-crypto/src/random-bytes')
 const uint8ArrayToString = require('uint8arrays/to-string')
@@ -105,7 +106,7 @@ exports.normalizeInRpcMessage = (message, peerId) => {
 
 /**
  * @template {Object} T
- * 
+ *
  * @param {T} message
  * @return {T & {from?: Uint8Array, data?: Uint8Array}}
  */

--- a/src/topology/index.d.ts
+++ b/src/topology/index.d.ts
@@ -8,22 +8,9 @@ declare class Topology {
      */
     static isTopology(other: any): other is Topology;
     /**
-     * @param {Object} props
-     * @param {number} [props.min] minimum needed connections (default: 0)
-     * @param {number} [props.max] maximum needed connections (default: Infinity)
-     * @param {Object} [props.handlers]
-     * @param {function} [props.handlers.onConnect] protocol "onConnect" handler
-     * @param {function} [props.handlers.onDisconnect] protocol "onDisconnect" handler
-     * @constructor
+     * @param {Options} options
      */
-    constructor({ min, max, handlers }: {
-        min: number | undefined;
-        max: number | undefined;
-        handlers: {
-            onConnect?: Function | undefined;
-            onDisconnect?: Function | undefined;
-        } | undefined;
-    });
+    constructor({ min, max, handlers }: Options);
     min: number;
     max: number;
     _onConnect: Function;
@@ -48,4 +35,28 @@ declare class Topology {
     disconnect(peerId: import("peer-id")): void;
     get [topologySymbol](): boolean;
 }
+declare namespace Topology {
+    export { Options, Handlers };
+}
 declare const topologySymbol: unique symbol;
+type Options = {
+    /**
+     * - minimum needed connections.
+     */
+    min?: number | undefined;
+    /**
+     * - maximum needed connections.
+     */
+    max?: number | undefined;
+    handlers?: Handlers | undefined;
+};
+type Handlers = {
+    /**
+     * - protocol "onConnect" handler
+     */
+    onConnect?: Function | undefined;
+    /**
+     * - protocol "onDisconnect" handler
+     */
+    onDisconnect?: Function | undefined;
+};

--- a/src/topology/index.d.ts
+++ b/src/topology/index.d.ts
@@ -17,12 +17,12 @@ declare class Topology {
      * @constructor
      */
     constructor({ min, max, handlers }: {
-        min: number;
-        max: number;
+        min: number | undefined;
+        max: number | undefined;
         handlers: {
-            onConnect: Function;
-            onDisconnect: Function;
-        };
+            onConnect?: Function | undefined;
+            onDisconnect?: Function | undefined;
+        } | undefined;
     });
     min: number;
     max: number;

--- a/src/topology/index.d.ts
+++ b/src/topology/index.d.ts
@@ -1,10 +1,16 @@
-declare const _exports: Topology;
-export = _exports;
+export = Topology;
 declare class Topology {
     /**
+     * Checks if the given value is a Topology instance.
+     *
+     * @param {any} other
+     * @returns {other is Topology}
+     */
+    static isTopology(other: any): other is Topology;
+    /**
      * @param {Object} props
-     * @param {number} props.min minimum needed connections (default: 0)
-     * @param {number} props.max maximum needed connections (default: Infinity)
+     * @param {number} [props.min] minimum needed connections (default: 0)
+     * @param {number} [props.max] maximum needed connections (default: Infinity)
      * @param {Object} [props.handlers]
      * @param {function} [props.handlers.onConnect] protocol "onConnect" handler
      * @param {function} [props.handlers.onDisconnect] protocol "onDisconnect" handler
@@ -13,9 +19,9 @@ declare class Topology {
     constructor({ min, max, handlers }: {
         min: number;
         max: number;
-        handlers?: {
-            onConnect?: Function;
-            onDisconnect?: Function;
+        handlers: {
+            onConnect: Function;
+            onDisconnect: Function;
         };
     });
     min: number;
@@ -27,6 +33,7 @@ declare class Topology {
      * @type {Set<string>}
      */
     peers: Set<string>;
+    get [Symbol.toStringTag](): string;
     set registrar(arg: any);
     _registrar: any;
     /**
@@ -39,4 +46,6 @@ declare class Topology {
      * @returns {void}
      */
     disconnect(peerId: import("peer-id")): void;
+    get [topologySymbol](): boolean;
 }
+declare const topologySymbol: unique symbol;

--- a/src/topology/index.js
+++ b/src/topology/index.js
@@ -1,4 +1,5 @@
 'use strict'
+/* eslint-disable valid-jsdoc */
 
 const noop = () => {}
 const topologySymbol = Symbol.for('@libp2p/js-interfaces/topology')
@@ -33,10 +34,10 @@ class Topology {
   }
 
   get [Symbol.toStringTag] () {
-      return 'Topology'
+    return 'Topology'
   }
 
-  get [topologySymbol]() {
+  get [topologySymbol] () {
     return true
   }
 
@@ -46,7 +47,7 @@ class Topology {
    * @param {any} other
    * @returns {other is Topology}
    */
-  static isTopology(other) {
+  static isTopology (other) {
     return Boolean(other && other[topologySymbol])
   }
 

--- a/src/topology/index.js
+++ b/src/topology/index.js
@@ -6,13 +6,7 @@ const topologySymbol = Symbol.for('@libp2p/js-interfaces/topology')
 
 class Topology {
   /**
-   * @param {Object} props
-   * @param {number} [props.min] minimum needed connections (default: 0)
-   * @param {number} [props.max] maximum needed connections (default: Infinity)
-   * @param {Object} [props.handlers]
-   * @param {function} [props.handlers.onConnect] protocol "onConnect" handler
-   * @param {function} [props.handlers.onDisconnect] protocol "onDisconnect" handler
-   * @constructor
+   * @param {Options} options
    */
   constructor ({
     min = 0,
@@ -69,5 +63,16 @@ class Topology {
     this._onDisconnect(peerId)
   }
 }
+
+/**
+ * @typedef {Object} Options
+ * @property {number} [min=0] - minimum needed connections.
+ * @property {number} [max=Infinity] - maximum needed connections.
+ * @property {Handlers} [handlers]
+ *
+ * @typedef {Object} Handlers
+ * @property {Function} [onConnect] - protocol "onConnect" handler
+ * @property {Function} [onDisconnect] - protocol "onDisconnect" handler
+ */
 
 module.exports = Topology

--- a/src/topology/index.js
+++ b/src/topology/index.js
@@ -1,13 +1,13 @@
 'use strict'
 
-const withIs = require('class-is')
 const noop = () => {}
+const topologySymbol = Symbol.for('@libp2p/js-interfaces/topology')
 
 class Topology {
   /**
    * @param {Object} props
-   * @param {number} props.min minimum needed connections (default: 0)
-   * @param {number} props.max maximum needed connections (default: Infinity)
+   * @param {number} [props.min] minimum needed connections (default: 0)
+   * @param {number} [props.max] maximum needed connections (default: Infinity)
    * @param {Object} [props.handlers]
    * @param {function} [props.handlers.onConnect] protocol "onConnect" handler
    * @param {function} [props.handlers.onDisconnect] protocol "onDisconnect" handler
@@ -32,6 +32,24 @@ class Topology {
     this.peers = new Set()
   }
 
+  get [Symbol.toStringTag] () {
+      return 'Topology'
+  }
+
+  get [topologySymbol]() {
+    return true
+  }
+
+  /**
+   * Checks if the given value is a Topology instance.
+   *
+   * @param {any} other
+   * @returns {other is Topology}
+   */
+  static isTopology(other) {
+    return Boolean(other && other[topologySymbol])
+  }
+
   set registrar (registrar) {
     this._registrar = registrar
   }
@@ -51,8 +69,4 @@ class Topology {
   }
 }
 
-/**
- * @module
- * @type {Topology}
- */
-module.exports = withIs(Topology, { className: 'Topology', symbolName: '@libp2p/js-interfaces/topology' })
+module.exports = Topology

--- a/src/topology/multicodec-topology.d.ts
+++ b/src/topology/multicodec-topology.d.ts
@@ -1,5 +1,12 @@
 export = MulticodecTopology;
-declare class MulticodecTopology {
+declare class MulticodecTopology extends Topology {
+    /**
+     * Checks if the given value is a `MulticodecTopology` instance.
+     *
+     * @param {any} other
+     * @returns {other is MulticodecTopology}
+     */
+    static isMulticodecTopology(other: any): other is MulticodecTopology;
     /**
      * @param {Object} props
      * @param {number} [props.min] minimum needed connections (default: 0)
@@ -11,16 +18,15 @@ declare class MulticodecTopology {
      * @constructor
      */
     constructor({ min, max, multicodecs, handlers }: {
-        min?: number;
-        max?: number;
-        multicodecs: string[];
+        min: number;
+        max: number;
+        multicodecs: Array<string>;
         handlers: {
             onConnect: Function;
             onDisconnect: Function;
         };
     });
     multicodecs: string[];
-    _registrar: any;
     /**
      * Check if a new peer support the multicodecs for this topology.
      * @param {Object} props
@@ -29,7 +35,7 @@ declare class MulticodecTopology {
      */
     _onProtocolChange({ peerId, protocols }: {
         peerId: any;
-        protocols: string[];
+        protocols: Array<string>;
     }): void;
     /**
      * Verify if a new connected peer has a topology multicodec and call _onConnect.
@@ -37,15 +43,17 @@ declare class MulticodecTopology {
      * @returns {void}
      */
     _onPeerConnect(connection: any): void;
-    set registrar(arg: any);
     /**
      * Update topology.
      * @param {Array<{id: PeerId, multiaddrs: Array<Multiaddr>, protocols: Array<string>}>} peerDataIterable
      * @returns {void}
      */
-    _updatePeers(peerDataIterable: {
+    _updatePeers(peerDataIterable: Array<{
         id: any;
-        multiaddrs: any[];
-        protocols: string[];
-    }[]): void;
+        multiaddrs: Array<any>;
+        protocols: Array<string>;
+    }>): void;
+    get [multicodecTopologySymbol](): boolean;
 }
+import Topology = require(".");
+declare const multicodecTopologySymbol: unique symbol;

--- a/src/topology/multicodec-topology.d.ts
+++ b/src/topology/multicodec-topology.d.ts
@@ -18,8 +18,8 @@ declare class MulticodecTopology extends Topology {
      * @constructor
      */
     constructor({ min, max, multicodecs, handlers }: {
-        min: number;
-        max: number;
+        min: number | undefined;
+        max: number | undefined;
         multicodecs: Array<string>;
         handlers: {
             onConnect: Function;
@@ -34,7 +34,7 @@ declare class MulticodecTopology extends Topology {
      * @param {Array<string>} props.protocols
      */
     _onProtocolChange({ peerId, protocols }: {
-        peerId: any;
+        peerId: PeerId;
         protocols: Array<string>;
     }): void;
     /**
@@ -42,18 +42,22 @@ declare class MulticodecTopology extends Topology {
      * @param {Connection} connection
      * @returns {void}
      */
-    _onPeerConnect(connection: any): void;
+    _onPeerConnect(connection: Connection): void;
     /**
      * Update topology.
      * @param {Array<{id: PeerId, multiaddrs: Array<Multiaddr>, protocols: Array<string>}>} peerDataIterable
      * @returns {void}
      */
     _updatePeers(peerDataIterable: Array<{
-        id: any;
-        multiaddrs: Array<any>;
+        id: PeerId;
+        multiaddrs: Array<Multiaddr>;
         protocols: Array<string>;
     }>): void;
-    get [multicodecTopologySymbol](): boolean;
+}
+declare namespace MulticodecTopology {
+    export { PeerId, Multiaddr, Connection };
 }
 import Topology = require(".");
-declare const multicodecTopologySymbol: unique symbol;
+type PeerId = import("peer-id");
+type Connection = typeof import("../connection");
+type Multiaddr = import("multiaddr");

--- a/src/topology/multicodec-topology.d.ts
+++ b/src/topology/multicodec-topology.d.ts
@@ -1,10 +1,9 @@
-declare const _exports: MulticodecTopology;
-export = _exports;
+export = MulticodecTopology;
 declare class MulticodecTopology {
     /**
      * @param {Object} props
-     * @param {number} props.min minimum needed connections (default: 0)
-     * @param {number} props.max maximum needed connections (default: Infinity)
+     * @param {number} [props.min] minimum needed connections (default: 0)
+     * @param {number} [props.max] maximum needed connections (default: Infinity)
      * @param {Array<string>} props.multicodecs protocol multicodecs
      * @param {Object} props.handlers
      * @param {function} props.handlers.onConnect protocol "onConnect" handler
@@ -12,8 +11,8 @@ declare class MulticodecTopology {
      * @constructor
      */
     constructor({ min, max, multicodecs, handlers }: {
-        min: number;
-        max: number;
+        min?: number;
+        max?: number;
         multicodecs: string[];
         handlers: {
             onConnect: Function;

--- a/src/topology/multicodec-topology.d.ts
+++ b/src/topology/multicodec-topology.d.ts
@@ -8,24 +8,9 @@ declare class MulticodecTopology extends Topology {
      */
     static isMulticodecTopology(other: any): other is MulticodecTopology;
     /**
-     * @param {Object} props
-     * @param {number} [props.min] minimum needed connections (default: 0)
-     * @param {number} [props.max] maximum needed connections (default: Infinity)
-     * @param {Array<string>} props.multicodecs protocol multicodecs
-     * @param {Object} props.handlers
-     * @param {function} props.handlers.onConnect protocol "onConnect" handler
-     * @param {function} props.handlers.onDisconnect protocol "onDisconnect" handler
-     * @constructor
+     * @param {TopologyOptions & MulticodecOptions} props
      */
-    constructor({ min, max, multicodecs, handlers }: {
-        min: number | undefined;
-        max: number | undefined;
-        multicodecs: Array<string>;
-        handlers: {
-            onConnect: Function;
-            onDisconnect: Function;
-        };
-    });
+    constructor({ min, max, multicodecs, handlers }: TopologyOptions & MulticodecOptions);
     multicodecs: string[];
     /**
      * Check if a new peer support the multicodecs for this topology.
@@ -53,11 +38,41 @@ declare class MulticodecTopology extends Topology {
         multiaddrs: Array<Multiaddr>;
         protocols: Array<string>;
     }>): void;
+    get [multicodecTopologySymbol](): boolean;
 }
 declare namespace MulticodecTopology {
-    export { PeerId, Multiaddr, Connection };
+    export { PeerId, Multiaddr, Connection, TopologyOptions, MulticodecOptions, Handlers };
 }
 import Topology = require(".");
 type PeerId = import("peer-id");
 type Connection = typeof import("../connection");
 type Multiaddr = import("multiaddr");
+declare const multicodecTopologySymbol: unique symbol;
+type TopologyOptions = {
+    /**
+     * - minimum needed connections.
+     */
+    min?: number | undefined;
+    /**
+     * - maximum needed connections.
+     */
+    max?: number | undefined;
+    handlers?: Topology.Handlers | undefined;
+};
+type MulticodecOptions = {
+    /**
+     * - protocol multicodecs
+     */
+    multicodecs: string[];
+    handlers: Required<Handlers>;
+};
+type Handlers = {
+    /**
+     * - protocol "onConnect" handler
+     */
+    onConnect?: Function | undefined;
+    /**
+     * - protocol "onDisconnect" handler
+     */
+    onDisconnect?: Function | undefined;
+};

--- a/src/topology/multicodec-topology.js
+++ b/src/topology/multicodec-topology.js
@@ -6,14 +6,7 @@ const multicodecTopologySymbol = Symbol.for('@libp2p/js-interfaces/topology/mult
 
 class MulticodecTopology extends Topology {
   /**
-   * @param {Object} props
-   * @param {number} [props.min] minimum needed connections (default: 0)
-   * @param {number} [props.max] maximum needed connections (default: Infinity)
-   * @param {Array<string>} props.multicodecs protocol multicodecs
-   * @param {Object} props.handlers
-   * @param {function} props.handlers.onConnect protocol "onConnect" handler
-   * @param {function} props.handlers.onDisconnect protocol "onDisconnect" handler
-   * @constructor
+   * @param {TopologyOptions & MulticodecOptions} props
    */
   constructor ({
     min,
@@ -143,5 +136,10 @@ class MulticodecTopology extends Topology {
  * @typedef {import('peer-id')} PeerId
  * @typedef {import('multiaddr')} Multiaddr
  * @typedef {import('../connection')} Connection
+ * @typedef {import('.').Options} TopologyOptions
+ * @typedef {Object} MulticodecOptions
+ * @property {string[]} multicodecs - protocol multicodecs
+ * @property {Required<Handlers>} handlers
+ * @typedef {import('.').Handlers} Handlers
  */
 module.exports = MulticodecTopology

--- a/src/topology/multicodec-topology.js
+++ b/src/topology/multicodec-topology.js
@@ -124,6 +124,7 @@ class MulticodecTopology extends Topology {
    * @returns {void}
    */
   _onPeerConnect (connection) {
+    // @ts-ignore - remotePeer does not existist on Connection
     const peerId = connection.remotePeer
     const protocols = this._registrar.peerStore.protoBook.get(peerId)
 
@@ -138,4 +139,9 @@ class MulticodecTopology extends Topology {
   }
 }
 
+/**
+ * @typedef {import('peer-id')} PeerId
+ * @typedef {import('multiaddr')} Multiaddr
+ * @typedef {import('../connection')} Connection
+ */
 module.exports = MulticodecTopology

--- a/src/topology/multicodec-topology.js
+++ b/src/topology/multicodec-topology.js
@@ -1,8 +1,8 @@
 'use strict'
+/* eslint-disable valid-jsdoc */
 
 const Topology = require('./index')
 const multicodecTopologySymbol = Symbol.for('@libp2p/js-interfaces/topology/multicodec-topology')
-
 
 class MulticodecTopology extends Topology {
   /**
@@ -50,7 +50,7 @@ class MulticodecTopology extends Topology {
     return 'Topology'
   }
 
-  get [multicodecTopologySymbol]() {
+  get [multicodecTopologySymbol] () {
     return true
   }
 
@@ -60,7 +60,7 @@ class MulticodecTopology extends Topology {
    * @param {any} other
    * @returns {other is MulticodecTopology}
    */
-  static isMulticodecTopology(other) {
+  static isMulticodecTopology (other) {
     return Boolean(other && other[multicodecTopologySymbol])
   }
 

--- a/src/topology/multicodec-topology.js
+++ b/src/topology/multicodec-topology.js
@@ -1,14 +1,14 @@
 'use strict'
 
-const withIs = require('class-is')
-
 const Topology = require('./index')
+const multicodecTopologySymbol = Symbol.for('@libp2p/js-interfaces/topology/multicodec-topology')
+
 
 class MulticodecTopology extends Topology {
   /**
    * @param {Object} props
-   * @param {number} props.min minimum needed connections (default: 0)
-   * @param {number} props.max maximum needed connections (default: Infinity)
+   * @param {number} [props.min] minimum needed connections (default: 0)
+   * @param {number} [props.max] maximum needed connections (default: Infinity)
    * @param {Array<string>} props.multicodecs protocol multicodecs
    * @param {Object} props.handlers
    * @param {function} props.handlers.onConnect protocol "onConnect" handler
@@ -44,6 +44,24 @@ class MulticodecTopology extends Topology {
 
     this._onProtocolChange = this._onProtocolChange.bind(this)
     this._onPeerConnect = this._onPeerConnect.bind(this)
+  }
+
+  get [Symbol.toStringTag] () {
+    return 'Topology'
+  }
+
+  get [multicodecTopologySymbol]() {
+    return true
+  }
+
+  /**
+   * Checks if the given value is a `MulticodecTopology` instance.
+   *
+   * @param {any} other
+   * @returns {other is MulticodecTopology}
+   */
+  static isMulticodecTopology(other) {
+    return Boolean(other && other[multicodecTopologySymbol])
   }
 
   set registrar (registrar) {
@@ -120,8 +138,4 @@ class MulticodecTopology extends Topology {
   }
 }
 
-/**
- * @module
- * @type {MulticodecTopology}
- */
-module.exports = withIs(MulticodecTopology, { className: 'MulticodecTopology', symbolName: '@libp2p/js-interfaces/topology/multicodec-topology' })
+module.exports = MulticodecTopology

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,20 @@
     // Tells TypeScript to read JS files, as
     // normally they are ignored as source files
     "allowJs": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": false,
+    "noImplicitAny": false, 
+    "noImplicitThis": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": false,
+    "strictFunctionTypes": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "strictBindCallApply": true,
     "strict": true,
+    "alwaysStrict": true,
+    "stripInternal": true,
     // Generate d.ts files
     "declaration": true,
     // This compiler run should

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     // Tells TypeScript to read JS files, as
     // normally they are ignored as source files
     "allowJs": true,
+    "strict": true,
     // Generate d.ts files
     "declaration": true,
     // This compiler run should


### PR DESCRIPTION
Without this change https://github.com/ipfs/js-ipfs-bitswap/pull/261 fails type-check with a following error:

```

src/network.js:50:26 - error TS2351: This expression is not constructable.
  Type 'MulticodecTopology' has no construct signatures.

50     const topology = new MulticodecTopology({
                            ~~~~~~~~~~~~~~~~~~


Found 1 error.

```

That is because typedefs claim that exported value is an instance of `MulticodecTopology` while it actually exports the class. `min` and `max` are also optionals.