### PR TITLE
fix: pubsub publish message should be uint8array

### DIFF
--- a/src/pubsub/index.js
+++ b/src/pubsub/index.js
@@ -644,7 +644,7 @@ class PubsubBaseProtocol extends EventEmitter {
    *
    * @override
    * @param {string} topic
-   * @param {Buffer} message
+   * @param {Uint8Array} message
    * @returns {Promise<void>}
    */
   async publish (topic, message) {


### PR DESCRIPTION
In #74 we missed that pubsub.publish message param was a Buffer yet... Found this out integrating to `js-ipfs`