### PR TITLE
feat: add raw connection and transport tag to Connection interface

### DIFF
--- a/src/connection/README.md
+++ b/src/connection/README.md
@@ -48,6 +48,7 @@ A valid connection (one that follows this abstraction), must implement the follo
 - type: `Connection`
 ```js
 new Connection({
+  rawConn,
   localAddr,
   remoteAddr,
   localPeer,
@@ -63,9 +64,11 @@ new Connection({
     },
     multiplexer,
     encryption
-  }
+  },
+  transportTag
 })
 ```
+  - `<any> conn.rawConn`
   - `<Multiaddr> conn.localAddr`
   - `<Multiaddr> conn.remoteAddr`
   - `<PeerId> conn.localPeer`
@@ -77,6 +80,7 @@ new Connection({
   - `<void> conn.removeStream(id)`
   - `<Stream> conn.addStream(stream, protocol, metadata)`
   - `Promise<> conn.close()`
+  - `<string> conn.transportTag`
 
 It can be obtained as follows:
 
@@ -84,6 +88,7 @@ It can be obtained as follows:
 const { Connection } = require('interface-connection')
 
 const conn = new Connection({
+  rawConn: maConn.conn,
   localAddr: maConn.localAddr,
   remoteAddr: maConn.remoteAddr,
   localPeer: this._peerId,
@@ -99,16 +104,19 @@ const conn = new Connection({
     },
     multiplexer,
     encryption
-  }
+  },
+  transportTag: maConn.transportTag
 })
 ```
 
 #### Creating a connection instance
 
-- `JavaScript` - `const conn = new Connection({localAddr, remoteAddr, localPeer, remotePeer, newStream, close, getStreams, direction, multiplexer, encryption})`
+- `JavaScript` - `const conn = new Connection({rawConn, localAddr, remoteAddr, localPeer, remotePeer, newStream, close, getStreams, direction, multiplexer, encryption, transportTag})`
 
 Creates a new Connection instance.
 
+`rawConn` is the optional `object` raw connection used by the transport internally.
+`localAddr` is the optional [multiaddr](https://github.com/multiformats/multiaddr) address used by the local peer to reach the remote.
 `localAddr` is the optional [multiaddr](https://github.com/multiformats/multiaddr) address used by the local peer to reach the remote.
 `remoteAddr` is the optional [multiaddr](https://github.com/multiformats/multiaddr) address used to communicate with the remote peer.
 `localPeer` is the [PeerId](https://github.com/libp2p/js-peer-id) of the local peer.
@@ -122,6 +130,7 @@ Creates a new Connection instance.
 - `multiplexer` is a `string` with the connection multiplexing codec (optional).
 - `encryption` is a `string` with the connection encryption method identifier (optional).
 - `status` is a `string` indicating the overall status of the connection. It is one of [`'open'`, `'closing'`, `'closed'`]
+`transportTag` is an optional string used to identify the transport class the connection uses.
 
 #### Create a new stream
 

--- a/src/connection/README.md
+++ b/src/connection/README.md
@@ -117,7 +117,6 @@ Creates a new Connection instance.
 
 `rawConn` is the optional `object` raw connection used by the transport internally.
 `localAddr` is the optional [multiaddr](https://github.com/multiformats/multiaddr) address used by the local peer to reach the remote.
-`localAddr` is the optional [multiaddr](https://github.com/multiformats/multiaddr) address used by the local peer to reach the remote.
 `remoteAddr` is the optional [multiaddr](https://github.com/multiformats/multiaddr) address used to communicate with the remote peer.
 `localPeer` is the [PeerId](https://github.com/libp2p/js-peer-id) of the local peer.
 `remotePeer` is the [PeerId](https://github.com/libp2p/js-peer-id) of the remote peer.

--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -34,7 +34,7 @@ const connectionSymbol = Symbol.for('@libp2p/interface-connection/connection')
  * @property {() => Promise<void>} close - close raw connection function.
  * @property {() => MuxedStream[]} getStreams - get streams from muxer function.
  * @property {ConectionStat} stat - metadata of the connection.
- * @property {string} transportTag - transport identifier
+ * @property {string} [transportTag] - transport identifier
  *
  * @typedef {Object} StreamData
  * @property {string} protocol - the protocol used by the stream

--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -25,6 +25,7 @@ const connectionSymbol = Symbol.for('@libp2p/interface-connection/connection')
  * @property {string} [encryption] - connection encryption method identifier.
  *
  * @typedef {Object} ConnectionOptions
+ * @property {Object} [rawConn] - raw connection
  * @property {multiaddr} [localAddr] - local multiaddr of the connection if known.
  * @property {multiaddr} remoteAddr - remote multiaddr of the connection.
  * @property {PeerId} localPeer - local peer-id.
@@ -51,13 +52,18 @@ class Connection {
    * @class
    * @param {ConnectionOptions} options
    */
-  constructor ({ localAddr, remoteAddr, localPeer, remotePeer, newStream, close, getStreams, stat }) {
-    validateArgs(localAddr, localPeer, remotePeer, newStream, close, getStreams, stat)
+  constructor ({ rawConn, localAddr, remoteAddr, localPeer, remotePeer, newStream, close, getStreams, stat }) {
+    validateArgs(rawConn, localAddr, localPeer, remotePeer, newStream, close, getStreams, stat)
 
     /**
      * Connection identifier.
      */
     this.id = (parseInt(String(Math.random() * 1e9))).toString(36) + Date.now()
+
+    /**
+     * The raw connection
+     */
+    this.rawConn = rawConn
 
     /**
      * Observed multiaddr of the local peer
@@ -230,7 +236,7 @@ class Connection {
 
 module.exports = Connection
 
-function validateArgs (localAddr, localPeer, remotePeer, newStream, close, getStreams, stat) {
+function validateArgs (rawConn, localAddr, localPeer, remotePeer, newStream, close, getStreams, stat) {
   if (localAddr && !multiaddr.isMultiaddr(localAddr)) {
     throw errCode(new Error('localAddr must be an instance of multiaddr'), 'ERR_INVALID_PARAMETERS')
   }

--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -34,6 +34,7 @@ const connectionSymbol = Symbol.for('@libp2p/interface-connection/connection')
  * @property {() => Promise<void>} close - close raw connection function.
  * @property {() => MuxedStream[]} getStreams - get streams from muxer function.
  * @property {ConectionStat} stat - metadata of the connection.
+ * @property {string} transportTag - transport identifier
  *
  * @typedef {Object} StreamData
  * @property {string} protocol - the protocol used by the stream
@@ -52,8 +53,8 @@ class Connection {
    * @class
    * @param {ConnectionOptions} options
    */
-  constructor ({ rawConn, localAddr, remoteAddr, localPeer, remotePeer, newStream, close, getStreams, stat }) {
-    validateArgs(rawConn, localAddr, localPeer, remotePeer, newStream, close, getStreams, stat)
+  constructor ({ rawConn, localAddr, remoteAddr, localPeer, remotePeer, newStream, close, getStreams, stat, transportTag = '' }) {
+    validateArgs(rawConn, localAddr, localPeer, remotePeer, newStream, close, getStreams, stat, transportTag)
 
     /**
      * Connection identifier.
@@ -84,6 +85,8 @@ class Connection {
      * Remote peer id.
      */
     this.remotePeer = remotePeer
+
+    this.transportTag = transportTag
 
     /**
      * Connection metadata.
@@ -236,7 +239,7 @@ class Connection {
 
 module.exports = Connection
 
-function validateArgs (rawConn, localAddr, localPeer, remotePeer, newStream, close, getStreams, stat) {
+function validateArgs (rawConn, localAddr, localPeer, remotePeer, newStream, close, getStreams, stat, transportTag) {
   if (localAddr && !multiaddr.isMultiaddr(localAddr)) {
     throw errCode(new Error('localAddr must be an instance of multiaddr'), 'ERR_INVALID_PARAMETERS')
   }

--- a/src/transport/README.md
+++ b/src/transport/README.md
@@ -116,7 +116,7 @@ The `Upgrader` methods take a [MultiaddrConnection](#multiaddrconnection) and wi
   - `timeline<object>`: A hash map of connection time events
     - `open<number>`: The time in ticks the connection was opened
     - `close<number>`: The time in ticks the connection was closed
-  - `transportTag`: An optional string used to identify the transport class the connection uses.
+  - `[transportTag]`: An optional string used to identify the transport class the connection uses.
 
 ### Creating a transport instance
 

--- a/src/transport/README.md
+++ b/src/transport/README.md
@@ -116,6 +116,7 @@ The `Upgrader` methods take a [MultiaddrConnection](#multiaddrconnection) and wi
   - `timeline<object>`: A hash map of connection time events
     - `open<number>`: The time in ticks the connection was opened
     - `close<number>`: The time in ticks the connection was closed
+  - `transportTag`: An optional string used to identify the transport class the connection uses.
 
 ### Creating a transport instance
 

--- a/src/transport/README.md
+++ b/src/transport/README.md
@@ -116,7 +116,7 @@ The `Upgrader` methods take a [MultiaddrConnection](#multiaddrconnection) and wi
   - `timeline<object>`: A hash map of connection time events
     - `open<number>`: The time in ticks the connection was opened
     - `close<number>`: The time in ticks the connection was closed
-  - `[transportTag]`: An optional string used to identify the transport class the connection uses.
+  - `[transportTag<string>]`: An optional string used to identify the transport class the connection uses.
 
 ### Creating a transport instance
 

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -68,4 +68,5 @@ export type MultiaddrConnection = {
   remoteAddr: Multiaddr;
   localAddr?: Multiaddr;
   timeline: MultiaddrConnectionTimeline;
+  transportTag?: string;
 }


### PR DESCRIPTION
Adds the ability to optionally expose the raw connection of a transport as well as to provide a transport identifier tag in the Connection interface.

Changes:

`MultiaddrConnection` type now has optional `transportTag` parameter
`Connection` class now has optional `rawConn` and `transportTag` parameters

Solves in part https://github.com/libp2p/js-libp2p/issues/838