### PR TITLE
fix: specify connection direction

### DIFF
--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -19,7 +19,7 @@ const connectionSymbol = Symbol.for('@libp2p/interface-connection/connection')
  * @property {number} [close]
  *
  * @typedef {Object} ConectionStat
- * @property {string} direction - connection establishment direction ("inbound" or "outbound").
+ * @property {'inbound' | 'outbound'} direction - connection establishment direction
  * @property {Timeline} timeline - connection relevant events timestamp.
  * @property {string} [multiplexer] - connection multiplexing identifier.
  * @property {string} [encryption] - connection encryption method identifier.


### PR DESCRIPTION
The comment says it can be 'inbound' or 'outbound' so constrain the type to those values.