### PR TITLE
feat: muxed stream close read and write

### DIFF
--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -220,6 +220,8 @@ class Connection {
 
     this.stat.status = CLOSING
 
+    await Promise.all(this.streams.map(s => s.close && s.close()))
+
     // Close raw connection
     this._closing = await this._close()
 

--- a/src/connection/tests/connection.js
+++ b/src/connection/tests/connection.js
@@ -3,9 +3,7 @@
 
 'use strict'
 
-const chai = require('chai')
-const expect = chai.expect
-chai.use(require('dirty-chai'))
+const { expect } = require('aegir/utils/chai')
 const sinon = require('sinon')
 const Status = require('../status')
 

--- a/src/stream-muxer/types.d.ts
+++ b/src/stream-muxer/types.d.ts
@@ -39,7 +39,9 @@ export type MuxedTimeline = {
 }
 
 export interface MuxedStream extends AsyncIterable<Uint8Array | BufferList> {
-  close: () => void;
+  close: () => Promise<void>;
+  closeRead: () => Promise<void>;
+  closeWrite: () => Promise<void>;
   abort: () => void;
   reset: () => void;
   sink: Sink;


### PR DESCRIPTION
__ Created new PR with changes from #67 on top of current master branch __

This adds tests for closeRead and closeWrite on the muxer streams.

Also:

- Removed libp2p-tcp in favor of it-pair to avoid circular deps
- Connection.close() will now close its internal streams to avoid lingering streams.

BREAKING CHANGE: This adds closeWrite and closeRead checks in the tests, which will cause test failures for muxers that dont implement those.

Closes #67 