### PR TITLE
Close read write

### DIFF
--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -222,6 +222,8 @@ class Connection {
 
     this.stat.status = CLOSING
 
+    await Promise.all(this.streams.map(s => s.close && s.close()))
+
     // Close raw connection
     this._closing = await this._close()
 

--- a/src/connection/tests/connection.js
+++ b/src/connection/tests/connection.js
@@ -3,9 +3,7 @@
 
 'use strict'
 
-const chai = require('chai')
-const expect = chai.expect
-chai.use(require('dirty-chai'))
+const { expect } = require('aegir/utils/chai')
 const sinon = require('sinon')
 const Status = require('../status')
 

--- a/src/stream-muxer/tests/close-test.js
+++ b/src/stream-muxer/tests/close-test.js
@@ -156,7 +156,7 @@ module.exports = (common) => {
         // Write some data before closing
         await stream.sink([randomBuffer()])
 
-Close after write
+        // Close after write
         await stream.closeWrite()
 
         const results = await pipe(stream, async (source) => {

--- a/src/stream-muxer/tests/close-test.js
+++ b/src/stream-muxer/tests/close-test.js
@@ -29,13 +29,6 @@ const infiniteRandom = {
   }
 }
 
-const oneBufferAndWait = {
-  [Symbol.asyncIterator]: async function * () {
-    yield randomBuffer()
-    await new Promise(() => {})
-  }
-}
-
 module.exports = (common) => {
   describe('close', () => {
     let Muxer
@@ -198,10 +191,9 @@ module.exports = (common) => {
 
       const listener = new Muxer(async stream => {
         // Write some data before closing
-        stream.sink(oneBufferAndWait)
+        stream.sink(infiniteRandom)
 
         // Immediate close for write
-        await pause(10)
         await stream.closeWrite()
 
         const results = await pipe(stream, async (source) => {

--- a/src/stream-muxer/tests/close-test.js
+++ b/src/stream-muxer/tests/close-test.js
@@ -156,7 +156,7 @@ module.exports = (common) => {
         // Write some data before closing
         await stream.sink([randomBuffer()])
 
-        // Immediate close for write
+Close after write
         await stream.closeWrite()
 
         const results = await pipe(stream, async (source) => {
@@ -193,7 +193,6 @@ module.exports = (common) => {
         // Write some data before closing
         stream.sink(infiniteRandom)
 
-        // Immediate close for write
         await stream.closeWrite()
 
         const results = await pipe(stream, async (source) => {

--- a/src/stream-muxer/types.d.ts
+++ b/src/stream-muxer/types.d.ts
@@ -39,7 +39,9 @@ export type MuxedTimeline = {
 }
 
 export interface MuxedStream extends AsyncIterable<Uint8Array | BufferList> {
-  close: () => void;
+  close: () => Promise<void>;
+  closeRead: () => Promise<void>;
+  closeWrite: () => Promise<void>;
   abort: () => void;
   reset: () => void;
   sink: Sink;


### PR DESCRIPTION
See https://github.com/libp2p/js-libp2p-mplex/pull/122

BREAKING CHANGE: This adds closeWrite and closeRead checks in the tests, which will cause test failures for muxers that dont implement those.

Closes #67 and #90 