### PR TITLE
fix: allow pubsub rpc to be processed concurrently

### DIFF
--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -67,6 +67,7 @@
     "libp2p-crypto": "^0.19.5",
     "multiaddr": "^10.0.0",
     "multiformats": "^9.1.2",
+    "p-queue": "^6.6.2",
     "peer-id": "^0.15.0",
     "protobufjs": "^6.10.2",
     "uint8arrays": "^3.0.0"

--- a/packages/interfaces/src/pubsub/index.js
+++ b/packages/interfaces/src/pubsub/index.js
@@ -166,7 +166,7 @@ class PubsubBaseProtocol extends EventEmitter {
     this.topicValidators = new Map()
 
     /**
-     * @type {number}
+     * @type {Queue}
      */
     this.queue = new Queue({ concurrency: messageProcessingConcurrency })
 

--- a/packages/interfaces/src/pubsub/index.js
+++ b/packages/interfaces/src/pubsub/index.js
@@ -356,11 +356,15 @@ class PubsubBaseProtocol extends EventEmitter {
             const rpcBytes = data instanceof Uint8Array ? data : data.slice()
             const rpcMsg = this._decodeRpc(rpcBytes)
 
-            void (async () => {
+            // Since _processRpc may be overridden entirely in unsafe ways,
+            // the simplest/safest option here is to wrap in a function and capture all errors
+            // to prevent a top-level unhandled exception
+            // This processing of rpc messages should happen without awaiting full validation/execution of prior messages
+            ;(async () => {
               try {
                 await this._processRpc(idB58Str, peerStreams, rpcMsg)
-              } catch (e) {
-                this.log.err(e.message)
+              } catch (err) {
+                this.log.err(err)
               }
             })()
           }

--- a/packages/interfaces/src/pubsub/index.js
+++ b/packages/interfaces/src/pubsub/index.js
@@ -402,7 +402,7 @@ class PubsubBaseProtocol extends EventEmitter {
       await Promise.all(msgs.map(async (message) => {
         if (!(this.canRelayMessage || (message.topicIDs && message.topicIDs.some((topic) => this.subscriptions.has(topic))))) {
           this.log('received message we didn\'t subscribe to. Dropping.')
-          continue
+          return
         }
         const msg = utils.normalizeInRpcMessage(message, idB58Str)
         await this._processRpcMessage(msg)


### PR DESCRIPTION
https://github.com/libp2p/js-libp2p-interfaces/pull/103 subtlely changed the pubsub rpc/message processing pipeline from fully concurrent to fully sequential. This is subtle because it seems the only part of processing that may be asynchronous is message validation. So in many cases, when message validation is not heavy, or when few messages are received, no delay in rpc/message processing is detectable.

This PR restores the original behavior, of allowing rpc/messages to be processed concurrently, but with care of ensuring that errors are handled and will not propagate to a top-level unhandled exception.