### PR TITLE
feat: add ContentRoutingStorage interface

### DIFF
--- a/packages/interfaces/src/content-routing/types.d.ts
+++ b/packages/interfaces/src/content-routing/types.d.ts
@@ -11,4 +11,9 @@ export interface ContentRouting {
   findProviders (cid: CID, options: Object): AsyncIterable<{ id: PeerId, multiaddrs: Multiaddr[] }>;
 }
 
+export interface ContentRoutingStorage {
+  put (key: Uint8Array, value: Uint8Array, options?: Object): Promise<void>
+  get (key: Uint8Array, options?: Object): Promise<Uint8Array>
+}
+
 export default ContentRouting;


### PR DESCRIPTION
This adds a `ContentRoutingStorage` interface with `put` and `get` methods for storing key/value data either with the DHT or via delegated routing (and maybe pubsub? I'm not sure if pubsub routing has k/v storage).

The idea is that instead of directly hitting the dht in js-libp2p [here](https://github.com/libp2p/js-libp2p/blob/master/src/content-routing/index.js#L99), we can loop through all the routers and do something like this:

```js
    // try using all routers that support the `put` operation.
    // if more than one support it, the first to resolve will be used
    const promises = []
    for (const router of this.routers) {
      if ('put' in router && typeof router.put === 'function') {
        promises.push(router.put(key, value, options))
      }
    }
    
    return raceToSuccess(promises)
```

Where `raceToSuccess` returns the first promise to resolve, or fails if all promises fail. The DHT already conforms to this new interface, and https://github.com/libp2p/js-libp2p-delegated-content-routing/pull/54 will add it to the delegated routing module.

Open to suggestions on the interface name 😄

