### PR TITLE
feat: add public and private key interfaces

### DIFF
--- a/packages/interfaces/src/crypto/types.d.ts
+++ b/packages/interfaces/src/crypto/types.d.ts
@@ -22,3 +22,35 @@ export type SecureOutbound = {
   remoteEarlyData: Buffer;
   remotePeer: PeerId;
 }
+
+export interface PublicKey {
+  readonly bytes: Uint8Array
+  verify: (data: Uint8Array, sig: Uint8Array) => Promise<boolean>
+  marshal: () => Uint8Array
+  equals: (key: PublicKey) => boolean
+  hash: () => Promise<Uint8Array>
+}
+
+/**
+ * Generic private key interface
+ */
+export interface PrivateKey {
+  readonly public: PublicKey
+  readonly bytes: Uint8Array
+  sign: (data: Uint8Array) => Promise<Uint8Array>
+  marshal: () => Uint8Array
+  equals: (key: PrivateKey) => boolean
+  hash: () => Promise<Uint8Array>
+  /**
+   * Gets the ID of the key.
+   *
+   * The key id is the base58 encoding of the SHA-256 multihash of its public key.
+   * The public key is a protobuf encoding containing a type and the DER encoding
+   * of the PKCS SubjectPublicKeyInfo.
+   */
+  id: () => Promise<string>
+  /**
+   * Exports the password protected key in the format specified.
+   */
+  export: (password: string, format?: 'pkcs-8' | string) => Promise<string>
+}


### PR DESCRIPTION
Add PublicKey and PrivateKey from libp2p-crypto so we can depend
on the interface here without pulling in all of libp2p-crypto.