### PR TITLE
fix: update dialer tests

### DIFF
--- a/packages/libp2p-connection/test/index.spec.ts
+++ b/packages/libp2p-connection/test/index.spec.ts
@@ -58,7 +58,7 @@ describe('connection tests', () => {
         const id = `${streamId++}`
         const stream: MuxedStream = {
           ...pair<Uint8Array>(),
-          close: async () => await stream.sink([]),
+          close: async () => await stream.sink(async function * () {}()),
           id,
           abort: () => {},
           reset: () => {},

--- a/packages/libp2p-interfaces-compliance-tests/src/transport/dial-test.ts
+++ b/packages/libp2p-interfaces-compliance-tests/src/transport/dial-test.ts
@@ -29,7 +29,7 @@ export default (common: TestSetup<TransportTestFixtures, SetupArgs>) => {
     })
 
     beforeEach(async () => {
-      listener = transport.createListener({}, (conn) => pipe(conn, conn))
+      listener = transport.createListener({})
       return await listener.listen(addrs[0])
     })
 

--- a/packages/libp2p-interfaces-compliance-tests/src/transport/dial-test.ts
+++ b/packages/libp2p-interfaces-compliance-tests/src/transport/dial-test.ts
@@ -35,22 +35,23 @@ export default (common: TestSetup<TransportTestFixtures, SetupArgs>) => {
 
     afterEach(async () => {
       sinon.restore()
+      connector.restore()
       return await listener.close()
     })
 
     it('simple', async () => {
       const upgradeSpy = sinon.spy(upgrader, 'upgradeOutbound')
       const conn = await transport.dial(addrs[0])
-
+      const { stream } = await conn.newStream(['/hello'])
       const s = goodbye({ source: ['hey'], sink: collect })
 
-      const result = await pipe(s, conn, s)
+      const result = await pipe(s, stream, s)
 
       expect(upgradeSpy.callCount).to.equal(1)
-      // @ts-expect-error upgrader.upgradeOutbound returns a Connection, not Promise<Connection>
-      expect(upgradeSpy.returned(conn)).to.equal(true)
+      await expect(upgradeSpy.getCall(0).returnValue).to.eventually.equal(conn)
       expect(result.length).to.equal(1)
       expect(result[0].toString()).to.equal('hey')
+      await conn.close()
     })
 
     it('can close connections', async () => {
@@ -58,39 +59,26 @@ export default (common: TestSetup<TransportTestFixtures, SetupArgs>) => {
       const conn = await transport.dial(addrs[0])
 
       expect(upgradeSpy.callCount).to.equal(1)
-      // @ts-expect-error upgrader.upgradeOutbound returns a Connection, not Promise<Connection>
-      expect(upgradeSpy.returned(conn)).to.equal(true)
+      await expect(upgradeSpy.getCall(0).returnValue).to.eventually.equal(conn)
       await conn.close()
       expect(isValidTick(conn.stat.timeline.close)).to.equal(true)
     })
 
     it('to non existent listener', async () => {
       const upgradeSpy = sinon.spy(upgrader, 'upgradeOutbound')
-      try {
-        await transport.dial(addrs[1])
-      } catch (_) {
-        expect(upgradeSpy.callCount).to.equal(0)
-        // Success: expected an error to be throw
-        return
-      }
-      expect.fail('Did not throw error attempting to connect to non-existent listener')
+
+      await expect(transport.dial(addrs[1])).to.eventually.be.rejected()
+      expect(upgradeSpy.callCount).to.equal(0)
     })
 
     it('abort before dialing throws AbortError', async () => {
       const upgradeSpy = sinon.spy(upgrader, 'upgradeOutbound')
       const controller = new AbortController()
       controller.abort()
-      const socket = transport.dial(addrs[0], { signal: controller.signal })
+      const conn = transport.dial(addrs[0], { signal: controller.signal })
 
-      try {
-        await socket
-      } catch (err: any) {
-        expect(upgradeSpy.callCount).to.equal(0)
-        expect(err.code).to.eql(AbortError.code)
-        expect(err.type).to.eql(AbortError.type)
-        return
-      }
-      expect.fail('Did not throw error with code ' + AbortError.code)
+      await expect(conn).to.eventually.be.rejected().with.property('code', AbortError.code)
+      expect(upgradeSpy.callCount).to.equal(0)
     })
 
     it('abort while dialing throws AbortError', async () => {
@@ -100,91 +88,11 @@ export default (common: TestSetup<TransportTestFixtures, SetupArgs>) => {
       connector.delay(100)
 
       const controller = new AbortController()
-      const socket = transport.dial(addrs[0], { signal: controller.signal })
+      const conn = transport.dial(addrs[0], { signal: controller.signal })
       setTimeout(() => controller.abort(), 50)
 
-      try {
-        await socket
-      } catch (err: any) {
-        expect(upgradeSpy.callCount).to.equal(0)
-        expect(err.code).to.eql(AbortError.code)
-        expect(err.type).to.eql(AbortError.type)
-        return
-      } finally {
-        connector.restore()
-      }
-      expect.fail('Did not throw error with code ' + AbortError.code)
-    })
-
-    it('abort while reading throws AbortError', async () => {
-      // Add a delay to the response from the server
-      async function * delayedResponse (source: AsyncIterable<Uint8Array>) {
-        for await (const val of source) {
-          await new Promise((resolve) => setTimeout(resolve, 1000))
-          yield val
-        }
-      }
-      const delayedListener = transport.createListener({}, (conn) => {
-        void pipe(conn, delayedResponse, conn)
-      })
-      await delayedListener.listen(addrs[1])
-
-      // Create an abort signal and dial the socket
-      const controller = new AbortController()
-      const socket = await transport.dial(addrs[1], { signal: controller.signal })
-
-      try {
-        // Set a timeout to abort before the server responds
-        setTimeout(() => controller.abort(), 100)
-
-        // An AbortError should be thrown before the pipe completes
-        const s = goodbye({ source: ['hey'], sink: collect })
-        await pipe(s, socket, s)
-      } catch (err: any) {
-        expect(err.code).to.eql(AbortError.code)
-        expect(err.type).to.eql(AbortError.type)
-        return
-      } finally {
-        await delayedListener.close()
-      }
-      expect.fail('Did not throw error with code ' + AbortError.code)
-    })
-
-    it('abort while writing does not throw AbortError', async () => {
-      // Record values received by the listener
-      const recorded: string[] = []
-      async function * recorderTransform (source: AsyncIterable<string>) {
-        for await (const val of source) {
-          recorded.push(val)
-          yield val
-        }
-      }
-      const recordListener = transport.createListener({}, (conn) => {
-        void pipe(conn, recorderTransform, conn)
-      })
-      await recordListener.listen(addrs[1])
-
-      // Create an abort signal and dial the socket
-      const controller = new AbortController()
-      const socket = await transport.dial(addrs[1], { signal: controller.signal })
-
-      // Set a timeout to abort before writing has completed
-      setTimeout(() => controller.abort(), 100)
-
-      try {
-        // The pipe should write to the socket until aborted
-        await pipe(
-          async function * () {
-            yield 'hey'
-            await new Promise((resolve) => setTimeout(resolve, 200))
-            yield 'there'
-          },
-          socket)
-        expect(recorded.length).to.eql(1)
-        expect(recorded[0].toString()).to.eql('hey')
-      } finally {
-        await recordListener.close()
-      }
+      await expect(conn).to.eventually.be.rejected().with.property('code', AbortError.code)
+      expect(upgradeSpy.callCount).to.equal(0)
     })
   })
 }

--- a/packages/libp2p-interfaces-compliance-tests/src/transport/listen-test.ts
+++ b/packages/libp2p-interfaces-compliance-tests/src/transport/listen-test.ts
@@ -42,9 +42,6 @@ export default (common: TestSetup<TransportTestFixtures, SetupArgs>) => {
 
       const listener = transport.createListener({}, (conn) => {
         listenerConns.push(conn)
-        // @ts-expect-error upgrader.upgradeOutbound returns a Connection, not Promise<Connection>
-        expect(upgradeSpy.returned(conn)).to.equal(true)
-        pipe(conn, conn)
       })
 
       // Listen

--- a/packages/libp2p-interfaces-compliance-tests/src/transport/utils/index.ts
+++ b/packages/libp2p-interfaces-compliance-tests/src/transport/utils/index.ts
@@ -81,7 +81,7 @@ async function createConnection (maConn: MultiaddrConnection, direction: 'inboun
     streams,
     newStream: async (protocols) => {
       if (protocols.length === 0) {
-        throw new Error('protocols must have a lenth')
+        throw new Error('protocols must have a length')
       }
 
       const echo = pair()

--- a/packages/libp2p-interfaces-compliance-tests/test/connection/index.spec.ts
+++ b/packages/libp2p-interfaces-compliance-tests/test/connection/index.spec.ts
@@ -43,7 +43,7 @@ describe('compliance tests', () => {
           const stream: MuxedStream = {
             ...pair(),
             close: async () => {
-              await stream.sink([])
+              await stream.sink(async function * () {}())
               connection.removeStream(stream.id)
             },
             id,

--- a/packages/libp2p-interfaces/src/stream-muxer/index.ts
+++ b/packages/libp2p-interfaces/src/stream-muxer/index.ts
@@ -41,8 +41,8 @@ export interface MuxedStream<T = Uint8Array> extends AsyncIterable<T> {
   close: () => void
   abort: () => void
   reset: () => void
-  sink: (source: AsyncIterable<T> | Iterable<T>) => Promise<void>
-  source: AsyncIterable<T> | Iterable<T>
+  sink: (source: AsyncIterable<T>) => Promise<void>
+  source: AsyncIterable<T>
   timeline: MuxedTimeline
   id: string
 }

--- a/packages/libp2p-interfaces/src/transport/index.ts
+++ b/packages/libp2p-interfaces/src/transport/index.ts
@@ -66,7 +66,7 @@ export interface MultiaddrConnectionTimeline {
 }
 
 export interface MultiaddrConnection<T = Uint8Array> {
-  sink: (source: AsyncIterable<T> | Iterable<T>) => Promise<void>
+  sink: (source: AsyncIterable<T>) => Promise<void>
   source: AsyncIterable<T>
   close: (err?: Error) => Promise<void>
   conn: unknown

--- a/packages/libp2p-interfaces/src/transport/index.ts
+++ b/packages/libp2p-interfaces/src/transport/index.ts
@@ -67,7 +67,7 @@ export interface MultiaddrConnectionTimeline {
 
 export interface MultiaddrConnection<T = Uint8Array> {
   sink: (source: AsyncIterable<T> | Iterable<T>) => Promise<void>
-  source: AsyncIterable<T> | Iterable<T>
+  source: AsyncIterable<T>
   close: (err?: Error) => Promise<void>
   conn: unknown
   remoteAddr: Multiaddr


### PR DESCRIPTION
The `mockUpgrader` is supposed to accept a `MultiaddrConnection` and return a `Connection`, but it just passes through the `MultiaddrConnection`.

This is a problem as the two types are not compatible.  This shows up in our code as our tests treat `Connection`s as if they are something you can pass to `it-pipe` but they are not, you have to get a `MuxedStream` from `conn.netStream([str])` for that.

This PR fixes up the `mockUpgrader` to return something compatible with the `Connection` interface.  It also removes a few of the dialer tests that were only testing the newly introduced mock code.