### PR TITLE
Added events when peers connect or disconnect

### DIFF
--- a/packages/libp2p-interfaces/src/pubsub/index.ts
+++ b/packages/libp2p-interfaces/src/pubsub/index.ts
@@ -77,9 +77,18 @@ interface SubscriptionChangeEvent {
   peerId: PeerId
   subscriptions: Subscription[]
 }
+interface PeerConnectEvent {
+  peerId: PeerId
+}
+
+interface PeerDisconnectEvent {
+  peerId: PeerId
+}
 
 interface PubSubEvents {
-  'pubsub:subscription-change': SubscriptionChangeEvent
+  'pubsub:subscription-change': SubscriptionChangeEvent,
+  'pubsub:peer-connect': PeerConnectEvent,
+  'pubsub:peer-disconnect': PeerDisconnectEvent
 }
 
 export interface PubSub extends EventEmitter {

--- a/packages/libp2p-pubsub/src/index.ts
+++ b/packages/libp2p-pubsub/src/index.ts
@@ -220,6 +220,7 @@ export abstract class PubsubBaseProtocol extends EventEmitter implements PubSub,
 
     // else create a new peer streams
     this.log('new peer', id)
+    this.emit('pubsub:peer-connect', { peerId })
 
     const peerStreams = new PeerStreams({
       id: peerId,
@@ -246,6 +247,7 @@ export abstract class PubsubBaseProtocol extends EventEmitter implements PubSub,
 
     // delete peer streams
     this.log('delete peer', id)
+    this.emit('pubsub:peer-disconnect', { peerId })
     this.peers.delete(id)
 
     // remove peer from topics map

--- a/packages/libp2p-pubsub/src/index.ts
+++ b/packages/libp2p-pubsub/src/index.ts
@@ -220,8 +220,6 @@ export abstract class PubsubBaseProtocol extends EventEmitter implements PubSub,
 
     // else create a new peer streams
     this.log('new peer', id)
-    this.emit('pubsub:peer-connect', { peerId })
-
     const peerStreams = new PeerStreams({
       id: peerId,
       protocol
@@ -230,6 +228,8 @@ export abstract class PubsubBaseProtocol extends EventEmitter implements PubSub,
     this.peers.set(id, peerStreams)
     peerStreams.once('close', () => this._removePeer(peerId))
 
+    this.emit('pubsub:peer-connect', { peerId })
+    
     return peerStreams
   }
 
@@ -247,14 +247,13 @@ export abstract class PubsubBaseProtocol extends EventEmitter implements PubSub,
 
     // delete peer streams
     this.log('delete peer', id)
-    this.emit('pubsub:peer-disconnect', { peerId })
     this.peers.delete(id)
 
     // remove peer from topics map
     for (const peers of this.topics.values()) {
       peers.delete(id)
     }
-
+    this.emit('pubsub:peer-disconnect', { peerId })
     return peerStreams
   }
 


### PR DESCRIPTION
I think it would be usefull to emit peer connect and peer disconnect events. 

Currently libs  like pfs-pubsub-room do polling to generate these events. 
https://github.com/ipfs-shipyard/ipfs-pubsub-room/blob/8c00b4fbfa7cbd47889fe035dfa9ac23638d9b58/src/index.js#L34

But its far more efficient to just emit the events where they occur rather then polling them few steps up the stack.

I know there is already a event for when the subscription changes. But from what i've gathered that event is only emitted when the peer changes the subscription but not if a connect/disconnect happen. Connection is terminated without propper tear down. 