### PR TITLE
publish(msg): return a set of peers this message sent to

### DIFF
--- a/packages/libp2p-interfaces/src/pubsub/index.ts
+++ b/packages/libp2p-interfaces/src/pubsub/index.ts
@@ -95,7 +95,7 @@ export interface PubSub extends EventEmitter {
   subscribe: (topic: string) => void
   getSubscribers: (topic: string) => string[]
   unsubscribe: (topic: string) => void
-  publish: (topic: string, data: Uint8Array) => Promise<void>
+  publish: (topic: string, data: Uint8Array) => Promise<Set<string> | undefined>
   validate: (message: Message) => Promise<void>
 
   on: (<U extends keyof PubSubEvents> (event: U, listener: (event: PubSubEvents[U]) => void) => this) &

--- a/packages/libp2p-interfaces/src/pubsub/index.ts
+++ b/packages/libp2p-interfaces/src/pubsub/index.ts
@@ -95,7 +95,7 @@ export interface PubSub extends EventEmitter {
   subscribe: (topic: string) => void
   getSubscribers: (topic: string) => string[]
   unsubscribe: (topic: string) => void
-  publish: (topic: string, data: Uint8Array) => Promise<Set<string> | undefined>
+  publish: (topic: string, data: Uint8Array) => Promise<Set<string>>
   validate: (message: Message) => Promise<void>
 
   on: (<U extends keyof PubSubEvents> (event: U, listener: (event: PubSubEvents[U]) => void) => this) &

--- a/packages/libp2p-interfaces/src/pubsub/index.ts
+++ b/packages/libp2p-interfaces/src/pubsub/index.ts
@@ -95,7 +95,7 @@ export interface PubSub extends EventEmitter {
   subscribe: (topic: string) => void
   getSubscribers: (topic: string) => string[]
   unsubscribe: (topic: string) => void
-  publish: (topic: string, data: Uint8Array) => Promise<Set<string>>
+  publish: (topic: string, data: Uint8Array) => Promise<number>
   validate: (message: Message) => Promise<void>
 
   on: (<U extends keyof PubSubEvents> (event: U, listener: (event: PubSubEvents[U]) => void) => this) &

--- a/packages/libp2p-pubsub/src/index.ts
+++ b/packages/libp2p-pubsub/src/index.ts
@@ -569,7 +569,7 @@ export abstract class PubsubBaseProtocol extends EventEmitter implements PubSub,
    * For example, a Floodsub implementation might simply publish each message to each topic for every peer
    * Return a set of peers that this message sent to
    */
-  abstract _publish (message: Message): Promise<Set<string> | undefined>
+  abstract _publish (message: Message): Promise<Set<string>>
 
   /**
    * Subscribes to a given topic.

--- a/packages/libp2p-pubsub/src/index.ts
+++ b/packages/libp2p-pubsub/src/index.ts
@@ -537,8 +537,9 @@ export abstract class PubsubBaseProtocol extends EventEmitter implements PubSub,
 
   /**
    * Publishes messages to all subscribed peers
+   * Return a set of peers that this message sent to or nothing
    */
-  async publish (topic: string, message: Uint8Array) {
+  async publish (topic: string, message: Uint8Array): Promise<Set<string> | undefined> {
     if (!this.started) {
       throw new Error('Pubsub has not started')
     }
@@ -560,14 +561,15 @@ export abstract class PubsubBaseProtocol extends EventEmitter implements PubSub,
     this.emitSelf && this._emitMessage(msg)
 
     // send to all the other peers
-    await this._publish(msg)
+    return await this._publish(msg)
   }
 
   /**
    * Overriding the implementation of publish should handle the appropriate algorithms for the publish/subscriber implementation.
    * For example, a Floodsub implementation might simply publish each message to each topic for every peer
+   * Return a set of peers that this message sent to or nothing
    */
-  abstract _publish (message: Message): Promise<void>
+  abstract _publish (message: Message): Promise<Set<string> | undefined>
 
   /**
    * Subscribes to a given topic.

--- a/packages/libp2p-pubsub/src/index.ts
+++ b/packages/libp2p-pubsub/src/index.ts
@@ -537,9 +537,9 @@ export abstract class PubsubBaseProtocol extends EventEmitter implements PubSub,
 
   /**
    * Publishes messages to all subscribed peers
-   * Return a set of peers that this message sent to
+   * Return number of peers that this message sent to
    */
-  async publish (topic: string, message: Uint8Array): Promise<Set<string>> {
+  async publish (topic: string, message: Uint8Array): Promise<number> {
     if (!this.started) {
       throw new Error('Pubsub has not started')
     }
@@ -567,9 +567,9 @@ export abstract class PubsubBaseProtocol extends EventEmitter implements PubSub,
   /**
    * Overriding the implementation of publish should handle the appropriate algorithms for the publish/subscriber implementation.
    * For example, a Floodsub implementation might simply publish each message to each topic for every peer
-   * Return a set of peers that this message sent to
+   * Return number of peers that this message sent to
    */
-  abstract _publish (message: Message): Promise<Set<string>>
+  abstract _publish (message: Message): Promise<number>
 
   /**
    * Subscribes to a given topic.

--- a/packages/libp2p-pubsub/src/index.ts
+++ b/packages/libp2p-pubsub/src/index.ts
@@ -537,9 +537,9 @@ export abstract class PubsubBaseProtocol extends EventEmitter implements PubSub,
 
   /**
    * Publishes messages to all subscribed peers
-   * Return a set of peers that this message sent to or nothing
+   * Return a set of peers that this message sent to
    */
-  async publish (topic: string, message: Uint8Array): Promise<Set<string> | undefined> {
+  async publish (topic: string, message: Uint8Array): Promise<Set<string>> {
     if (!this.started) {
       throw new Error('Pubsub has not started')
     }
@@ -567,7 +567,7 @@ export abstract class PubsubBaseProtocol extends EventEmitter implements PubSub,
   /**
    * Overriding the implementation of publish should handle the appropriate algorithms for the publish/subscriber implementation.
    * For example, a Floodsub implementation might simply publish each message to each topic for every peer
-   * Return a set of peers that this message sent to or nothing
+   * Return a set of peers that this message sent to
    */
   abstract _publish (message: Message): Promise<Set<string> | undefined>
 

--- a/packages/libp2p-pubsub/test/instance.spec.ts
+++ b/packages/libp2p-pubsub/test/instance.spec.ts
@@ -8,7 +8,7 @@ import type { PeerId } from 'libp2p-interfaces/peer-id'
 import type { Message } from 'libp2p-interfaces/pubsub'
 
 class PubsubProtocol extends PubsubBaseProtocol {
-  async _publish (message: Message): Promise<Set<string>> {
+  async _publish (message: Message): Promise<number> {
     throw new Error('Method not implemented.')
   }
 }

--- a/packages/libp2p-pubsub/test/instance.spec.ts
+++ b/packages/libp2p-pubsub/test/instance.spec.ts
@@ -8,7 +8,7 @@ import type { PeerId } from 'libp2p-interfaces/peer-id'
 import type { Message } from 'libp2p-interfaces/pubsub'
 
 class PubsubProtocol extends PubsubBaseProtocol {
-  async _publish (message: Message): Promise<void> {
+  async _publish (message: Message): Promise<Set<string> | undefined> {
     throw new Error('Method not implemented.')
   }
 }

--- a/packages/libp2p-pubsub/test/instance.spec.ts
+++ b/packages/libp2p-pubsub/test/instance.spec.ts
@@ -8,7 +8,7 @@ import type { PeerId } from 'libp2p-interfaces/peer-id'
 import type { Message } from 'libp2p-interfaces/pubsub'
 
 class PubsubProtocol extends PubsubBaseProtocol {
-  async _publish (message: Message): Promise<Set<string> | undefined> {
+  async _publish (message: Message): Promise<Set<string>> {
     throw new Error('Method not implemented.')
   }
 }

--- a/packages/libp2p-pubsub/test/lifesycle.spec.ts
+++ b/packages/libp2p-pubsub/test/lifesycle.spec.ts
@@ -12,7 +12,7 @@ import type { Registrar } from 'libp2p-interfaces/registrar'
 import type { Message } from 'libp2p-interfaces/pubsub'
 
 class PubsubProtocol extends PubsubBaseProtocol {
-  async _publish (message: Message): Promise<Set<string> | undefined> {
+  async _publish (message: Message): Promise<Set<string>> {
     throw new Error('Method not implemented.')
   }
 }

--- a/packages/libp2p-pubsub/test/lifesycle.spec.ts
+++ b/packages/libp2p-pubsub/test/lifesycle.spec.ts
@@ -12,7 +12,7 @@ import type { Registrar } from 'libp2p-interfaces/registrar'
 import type { Message } from 'libp2p-interfaces/pubsub'
 
 class PubsubProtocol extends PubsubBaseProtocol {
-  async _publish (message: Message): Promise<void> {
+  async _publish (message: Message): Promise<Set<string> | undefined> {
     throw new Error('Method not implemented.')
   }
 }

--- a/packages/libp2p-pubsub/test/lifesycle.spec.ts
+++ b/packages/libp2p-pubsub/test/lifesycle.spec.ts
@@ -12,7 +12,7 @@ import type { Registrar } from 'libp2p-interfaces/registrar'
 import type { Message } from 'libp2p-interfaces/pubsub'
 
 class PubsubProtocol extends PubsubBaseProtocol {
-  async _publish (message: Message): Promise<Set<string>> {
+  async _publish (message: Message): Promise<number> {
     throw new Error('Method not implemented.')
   }
 }

--- a/packages/libp2p-pubsub/test/message.spec.ts
+++ b/packages/libp2p-pubsub/test/message.spec.ts
@@ -11,7 +11,7 @@ import type { PeerId } from 'libp2p-interfaces/peer-id'
 import type { Message } from 'libp2p-interfaces/pubsub'
 
 class PubsubProtocol extends PubsubBaseProtocol {
-  async _publish (message: Message): Promise<void> {
+  async _publish (message: Message): Promise<Set<string> | undefined> {
     throw new Error('Method not implemented')
   }
 

--- a/packages/libp2p-pubsub/test/message.spec.ts
+++ b/packages/libp2p-pubsub/test/message.spec.ts
@@ -11,7 +11,7 @@ import type { PeerId } from 'libp2p-interfaces/peer-id'
 import type { Message } from 'libp2p-interfaces/pubsub'
 
 class PubsubProtocol extends PubsubBaseProtocol {
-  async _publish (message: Message): Promise<Set<string> | undefined> {
+  async _publish (message: Message): Promise<Set<string>> {
     throw new Error('Method not implemented')
   }
 

--- a/packages/libp2p-pubsub/test/message.spec.ts
+++ b/packages/libp2p-pubsub/test/message.spec.ts
@@ -11,7 +11,7 @@ import type { PeerId } from 'libp2p-interfaces/peer-id'
 import type { Message } from 'libp2p-interfaces/pubsub'
 
 class PubsubProtocol extends PubsubBaseProtocol {
-  async _publish (message: Message): Promise<Set<string>> {
+  async _publish (message: Message): Promise<number> {
     throw new Error('Method not implemented')
   }
 

--- a/packages/libp2p-pubsub/test/utils/index.ts
+++ b/packages/libp2p-pubsub/test/utils/index.ts
@@ -13,7 +13,7 @@ export const createPeerId = async () => {
 }
 
 export class PubsubImplementation extends PubsubBaseProtocol {
-  async _publish (): Promise<Set<string> | undefined> {
+  async _publish (): Promise<Set<string>> {
     // ...
     return new Set()
   }

--- a/packages/libp2p-pubsub/test/utils/index.ts
+++ b/packages/libp2p-pubsub/test/utils/index.ts
@@ -13,8 +13,9 @@ export const createPeerId = async () => {
 }
 
 export class PubsubImplementation extends PubsubBaseProtocol {
-  async _publish () {
+  async _publish (): Promise<Set<string> | undefined> {
     // ...
+    return new Set()
   }
 
   _decodeRpc (bytes: Uint8Array) {

--- a/packages/libp2p-pubsub/test/utils/index.ts
+++ b/packages/libp2p-pubsub/test/utils/index.ts
@@ -13,9 +13,9 @@ export const createPeerId = async () => {
 }
 
 export class PubsubImplementation extends PubsubBaseProtocol {
-  async _publish (): Promise<Set<string>> {
+  async _publish (): Promise<number> {
     // ...
-    return new Set()
+    return 0
   }
 
   _decodeRpc (bytes: Uint8Array) {


### PR DESCRIPTION
**Motivation**
+ As a consumer of this library, Lodestar would like to know peers that a message sent to in `publish()` method
+ This is a breaking change to the pubsub interface