### PR TITLE
fix: make connection upgrade and encryption abortable

### DIFF
--- a/packages/interfaces/src/crypto/types.d.ts
+++ b/packages/interfaces/src/crypto/types.d.ts
@@ -1,5 +1,6 @@
 import { PeerId } from '../peer-id/types'
 import { MultiaddrConnection } from '../transport/types'
+import { AbortOptions } from '../types'
 
 /**
  * A libp2p crypto module must be compliant to this interface
@@ -10,11 +11,11 @@ export interface Crypto {
   /**
    * Encrypt outgoing data to the remote party.
    */
-  secureOutbound(localPeer: PeerId, connection: MultiaddrConnection, remotePeer: PeerId): Promise<SecureOutbound>;
+  secureOutbound(localPeer: PeerId, connection: MultiaddrConnection, remotePeer: PeerId, options?: AbortOptions): Promise<SecureOutbound>;
   /**
    * Decrypt incoming data.
    */
-  secureInbound(localPeer: PeerId, connection: MultiaddrConnection, remotePeer?: PeerId): Promise<SecureOutbound>;
+  secureInbound(localPeer: PeerId, connection: MultiaddrConnection, remotePeer?: PeerId, options?: AbortOptions): Promise<SecureOutbound>;
 }
 
 export type SecureOutbound = {

--- a/packages/interfaces/src/transport/types.d.ts
+++ b/packages/interfaces/src/transport/types.d.ts
@@ -3,15 +3,16 @@ import events from 'events'
 import { Multiaddr } from 'multiaddr'
 import Connection from '../connection/connection'
 import { Sink } from '../stream-muxer/types'
+import { AbortOptions } from '../types'
 
-export interface TransportFactory<DialOptions extends { signal?: AbortSignal }, ListenerOptions> {
+export interface TransportFactory<DialOptions extends AbortOptions, ListenerOptions> {
   new(upgrader: Upgrader): Transport<DialOptions, ListenerOptions>;
 }
 
 /**
  * A libp2p transport is understood as something that offers a dial and listen interface to establish connections.
  */
-export interface Transport <DialOptions extends { signal?: AbortSignal }, ListenerOptions> {
+export interface Transport <DialOptions extends AbortOptions, ListenerOptions> {
   /**
    * Dial a given multiaddr.
    */
@@ -47,12 +48,12 @@ export interface Upgrader {
   /**
    * Upgrades an outbound connection on `transport.dial`.
    */
-  upgradeOutbound(maConn: MultiaddrConnection): Promise<Connection>;
+  upgradeOutbound(maConn: MultiaddrConnection, options?: AbortOptions): Promise<Connection>;
 
   /**
    * Upgrades an inbound connection on transport listener.
    */
-  upgradeInbound(maConn: MultiaddrConnection): Promise<Connection>;
+  upgradeInbound(maConn: MultiaddrConnection, options?: AbortOptions): Promise<Connection>;
 }
 
 export type MultiaddrConnectionTimeline = {

--- a/packages/interfaces/src/types.d.ts
+++ b/packages/interfaces/src/types.d.ts
@@ -3,3 +3,7 @@ export type ValidateFn = (a: Uint8Array, b: Uint8Array) => Promise<void>
 
 export type DhtSelectors = { [key: string]: SelectFn }
 export type DhtValidators = { [key: string]: { func: ValidateFn } }
+
+export interface AbortOptions {
+  signal?: AbortSignal
+}


### PR DESCRIPTION
Allow passing AbortSignals in to connection upgrading and encryption
so the operations can be aborted if a timeout is reached.