### PR TITLE
fix: make connection upgrade and encryption abortable

### DIFF
--- a/packages/libp2p-interfaces/src/crypto/index.ts
+++ b/packages/libp2p-interfaces/src/crypto/index.ts
@@ -1,5 +1,6 @@
 import type { PeerId } from '../peer-id'
 import type { MultiaddrConnection } from '../transport'
+import type { AbortOptions } from '../index'
 
 /**
  * A libp2p crypto module must be compliant to this interface
@@ -10,11 +11,11 @@ export interface Crypto {
   /**
    * Encrypt outgoing data to the remote party.
    */
-  secureOutbound: (localPeer: PeerId, connection: MultiaddrConnection, remotePeer: PeerId) => Promise<SecureOutbound>
+  secureOutbound: (localPeer: PeerId, connection: MultiaddrConnection, remotePeer: PeerId, options?: AbortOptions) => Promise<SecureOutbound>
   /**
    * Decrypt incoming data.
    */
-  secureInbound: (localPeer: PeerId, connection: MultiaddrConnection, remotePeer?: PeerId) => Promise<SecureOutbound>
+  secureInbound: (localPeer: PeerId, connection: MultiaddrConnection, remotePeer?: PeerId, options?: AbortOptions) => Promise<SecureOutbound>
 }
 
 export interface SecureOutbound {

--- a/packages/libp2p-interfaces/src/transport/index.ts
+++ b/packages/libp2p-interfaces/src/transport/index.ts
@@ -1,10 +1,7 @@
 import type events from 'events'
 import type { Multiaddr } from 'multiaddr'
 import type { Connection } from '../connection'
-
-export interface AbortOptions {
-  signal?: AbortSignal
-}
+import type { AbortOptions } from '../index'
 
 export interface TransportFactory<DialOptions extends { signal?: AbortSignal }, ListenerOptions> {
   new(upgrader: Upgrader): Transport<DialOptions, ListenerOptions>
@@ -51,12 +48,12 @@ export interface Upgrader {
   /**
    * Upgrades an outbound connection on `transport.dial`.
    */
-  upgradeOutbound: (maConn: MultiaddrConnection) => Promise<Connection>
+  upgradeOutbound: (maConn: MultiaddrConnection, options?: AbortOptions) => Promise<Connection>
 
   /**
    * Upgrades an inbound connection on transport listener.
    */
-  upgradeInbound: (maConn: MultiaddrConnection) => Promise<Connection>
+  upgradeInbound: (maConn: MultiaddrConnection, options?: AbortOptions) => Promise<Connection>
 }
 
 export interface MultiaddrConnectionTimeline {


### PR DESCRIPTION
Allow passing AbortSignals in to connection upgrading and encryption so the operations can be aborted if a timeout is reached.

ts version of https://github.com/libp2p/js-libp2p-interfaces/pull/120