### PR TITLE
fix: BufferList imports and MuxedStream sinks

### DIFF
--- a/packages/interfaces/src/stream-muxer/types.d.ts
+++ b/packages/interfaces/src/stream-muxer/types.d.ts
@@ -1,4 +1,4 @@
-import BufferList from 'bl'
+import BufferList from 'bl/BufferList'
 
 export interface MuxerFactory {
   new (options: MuxerOptions): Muxer;
@@ -48,4 +48,4 @@ export interface MuxedStream extends AsyncIterable<Uint8Array | BufferList> {
   id: string;
 }
 
-export type Sink = (source: Uint8Array) => Promise<void>;
+export type Sink = (source: AsyncIterable<Uint8Array | BufferList>) => Promise<void>;

--- a/packages/interfaces/src/transport/types.d.ts
+++ b/packages/interfaces/src/transport/types.d.ts
@@ -1,4 +1,4 @@
-import BufferList from 'bl'
+import BufferList from 'bl/BufferList'
 import events from 'events'
 import { Multiaddr } from 'multiaddr'
 import Connection from '../connection/connection'


### PR DESCRIPTION
`BufferList` is exported from `'bl/BufferList'` not `'bl'` and the `source` arg for `Sink` should be an `AsyncIterable<Uint8Array>` not a `Uint8Array`.

It should also be symmetrical with `Source` - e.g., both are `AsyncIterable<Uint8Array | BufferList>`.