### PR TITLE
fix: revert upgrader/crypto options

### DIFF
--- a/packages/interfaces/src/crypto/types.d.ts
+++ b/packages/interfaces/src/crypto/types.d.ts
@@ -1,6 +1,5 @@
 import { PeerId } from '../peer-id/types'
 import { MultiaddrConnection } from '../transport/types'
-import { AbortOptions } from '../types'
 
 /**
  * A libp2p crypto module must be compliant to this interface
@@ -11,11 +10,11 @@ export interface Crypto {
   /**
    * Encrypt outgoing data to the remote party.
    */
-  secureOutbound(localPeer: PeerId, connection: MultiaddrConnection, remotePeer: PeerId, options?: AbortOptions): Promise<SecureOutbound>;
+  secureOutbound(localPeer: PeerId, connection: MultiaddrConnection, remotePeer: PeerId): Promise<SecureOutbound>;
   /**
    * Decrypt incoming data.
    */
-  secureInbound(localPeer: PeerId, connection: MultiaddrConnection, remotePeer?: PeerId, options?: AbortOptions): Promise<SecureOutbound>;
+  secureInbound(localPeer: PeerId, connection: MultiaddrConnection, remotePeer?: PeerId): Promise<SecureOutbound>;
 }
 
 export type SecureOutbound = {

--- a/packages/interfaces/src/transport/types.d.ts
+++ b/packages/interfaces/src/transport/types.d.ts
@@ -48,12 +48,12 @@ export interface Upgrader {
   /**
    * Upgrades an outbound connection on `transport.dial`.
    */
-  upgradeOutbound(maConn: MultiaddrConnection, options?: AbortOptions): Promise<Connection>;
+  upgradeOutbound(maConn: MultiaddrConnection): Promise<Connection>;
 
   /**
    * Upgrades an inbound connection on transport listener.
    */
-  upgradeInbound(maConn: MultiaddrConnection, options?: AbortOptions): Promise<Connection>;
+  upgradeInbound(maConn: MultiaddrConnection): Promise<Connection>;
 }
 
 export type MultiaddrConnectionTimeline = {


### PR DESCRIPTION
This is the wrong fix - the maconn should be aborted at the source rather than each use of it.  We have a `TimeoutController` that is passed in to the connection that should abort it if the upgrade/crypto handshake isn't completed in time, but at the moment `abortable-iterator` doesn't reject when reads stall indefinitely - fix for that in https://github.com/alanshaw/abortable-iterator/pull/15