### PR TITLE
chore: revert "fix: make connection upgrade and encryption abortable"

### DIFF
--- a/packages/libp2p-interfaces/src/crypto/index.ts
+++ b/packages/libp2p-interfaces/src/crypto/index.ts
@@ -1,6 +1,5 @@
 import type { PeerId } from '../peer-id'
 import type { MultiaddrConnection } from '../transport'
-import type { AbortOptions } from '../index'
 
 /**
  * A libp2p crypto module must be compliant to this interface
@@ -11,11 +10,11 @@ export interface Crypto {
   /**
    * Encrypt outgoing data to the remote party.
    */
-  secureOutbound: (localPeer: PeerId, connection: MultiaddrConnection, remotePeer: PeerId, options?: AbortOptions) => Promise<SecureOutbound>
+  secureOutbound: (localPeer: PeerId, connection: MultiaddrConnection, remotePeer: PeerId) => Promise<SecureOutbound>
   /**
    * Decrypt incoming data.
    */
-  secureInbound: (localPeer: PeerId, connection: MultiaddrConnection, remotePeer?: PeerId, options?: AbortOptions) => Promise<SecureOutbound>
+  secureInbound: (localPeer: PeerId, connection: MultiaddrConnection, remotePeer?: PeerId) => Promise<SecureOutbound>
 }
 
 export interface SecureOutbound {

--- a/packages/libp2p-interfaces/src/transport/index.ts
+++ b/packages/libp2p-interfaces/src/transport/index.ts
@@ -1,7 +1,10 @@
 import type events from 'events'
 import type { Multiaddr } from 'multiaddr'
 import type { Connection } from '../connection'
-import type { AbortOptions } from '../index'
+
+export interface AbortOptions {
+  signal?: AbortSignal
+}
 
 export interface TransportFactory<DialOptions extends { signal?: AbortSignal }, ListenerOptions> {
   new(upgrader: Upgrader): Transport<DialOptions, ListenerOptions>
@@ -48,12 +51,12 @@ export interface Upgrader {
   /**
    * Upgrades an outbound connection on `transport.dial`.
    */
-  upgradeOutbound: (maConn: MultiaddrConnection, options?: AbortOptions) => Promise<Connection>
+  upgradeOutbound: (maConn: MultiaddrConnection) => Promise<Connection>
 
   /**
    * Upgrades an inbound connection on transport listener.
    */
-  upgradeInbound: (maConn: MultiaddrConnection, options?: AbortOptions) => Promise<Connection>
+  upgradeInbound: (maConn: MultiaddrConnection) => Promise<Connection>
 }
 
 export interface MultiaddrConnectionTimeline {


### PR DESCRIPTION
Reverts libp2p/js-libp2p-interfaces#121 - see explanation in https://github.com/libp2p/js-libp2p-interfaces/pull/124