### PR TITLE
fix: peer-id privKey and pubKey can be undefined

### DIFF
--- a/packages/compliance-tests/src/peer-id/index.js
+++ b/packages/compliance-tests/src/peer-id/index.js
@@ -378,7 +378,7 @@ module.exports = (common) => {
 
       it('missmatch private - public key', async () => {
         const digest = await k1.public.hash()
-        expect(factory.createFromJSON({
+        await expect(factory.createFromJSON({
           id: digest,
           pubKey: k1,
           privKey: k2.public
@@ -387,7 +387,7 @@ module.exports = (common) => {
 
       it('missmatch id - private - public key', async () => {
         const digest = await k1.public.hash()
-        expect(factory.createFromJSON({
+        await expect(factory.createFromJSON({
           id: digest,
           pubKey: k1,
           privKey: k3.public
@@ -395,7 +395,7 @@ module.exports = (common) => {
       })
 
       it('invalid id', () => {
-        expect(factory.createFromJSON('hello world')).eventually.be.rejectedWith(/invalid id/)
+        await expect(factory.createFromJSON('hello world')).eventually.be.rejectedWith(/invalid id/)
       })
     })
   })

--- a/packages/compliance-tests/src/peer-id/index.js
+++ b/packages/compliance-tests/src/peer-id/index.js
@@ -357,10 +357,6 @@ module.exports = (common) => {
       const peerId2 = factory.createFromB58String(peerId.toB58String())
 
       expect(peerId1).to.deep.equal(peerId2)
-
-      peerId1.toString()
-
-      expect(peerId1).to.deep.equal(peerId2)
     })
 
     describe('throws on inconsistent data', () => {
@@ -382,29 +378,24 @@ module.exports = (common) => {
 
       it('missmatch private - public key', async () => {
         const digest = await k1.public.hash()
-        expect(() => {
-          factory.createFromJSON({
-            id: digest,
-            pubKey: k1,
-            privKey: k2.public
-          }) // eslint-disable-line no-new
-        }).to.throw(/inconsistent arguments/)
+        expect(factory.createFromJSON({
+          id: digest,
+          pubKey: k1,
+          privKey: k2.public
+        })).eventually.be.rejectedWith(/inconsistent arguments/)
       })
 
       it('missmatch id - private - public key', async () => {
         const digest = await k1.public.hash()
-        expect(() => {
-          factory.createFromJSON({
-            id: digest,
-            pubKey: k1,
-            privKey: k3.public
-          }) // eslint-disable-line no-new
-        }).to.throw(/inconsistent arguments/)
+        expect(factory.createFromJSON({
+          id: digest,
+          pubKey: k1,
+          privKey: k3.public
+        })).eventually.be.rejectedWith(/inconsistent arguments/)
       })
 
       it('invalid id', () => {
-        // @ts-expect-error incorrect constructor arg type
-        expect(() => factory.createFromJSON('hello world')).to.throw(/invalid id/)
+        expect(factory.createFromJSON('hello world')).eventually.be.rejectedWith(/invalid id/)
       })
     })
   })

--- a/packages/interfaces/src/peer-id/types.d.ts
+++ b/packages/interfaces/src/peer-id/types.d.ts
@@ -1,13 +1,13 @@
 import type { CID } from 'multiformats/cid'
 import type { PublicKey, PrivateKey, KeyType } from '../keys/types'
 
-interface PeerIdJSON {
+export interface PeerIdJSON {
   readonly id: string;
   readonly pubKey?: string;
   readonly privKey?: string;
 }
 
-interface CreateOptions {
+export interface CreateOptions {
   bits?: number;
   keyType?: KeyType;
 }

--- a/packages/interfaces/src/peer-id/types.d.ts
+++ b/packages/interfaces/src/peer-id/types.d.ts
@@ -13,14 +13,14 @@ interface CreateOptions {
 }
 
 export interface PeerId {
-  readonly id: Uint8Array;
-  privKey:  PrivateKey;
-  pubKey: PublicKey;
+  readonly id: Uint8Array
+  privKey: PrivateKey | undefined;
+  pubKey: PublicKey | undefined;
 
   /**
    * Return the protobuf version of the public key, matching go ipfs formatting
    */
-  marshalPubKey ():Uint8Array;
+  marshalPubKey: () => Uint8Array | undefined;
 
   /**
    * Return the protobuf version of the private key, matching go ipfs formatting

--- a/packages/interfaces/src/peer-id/types.d.ts
+++ b/packages/interfaces/src/peer-id/types.d.ts
@@ -88,6 +88,11 @@ export interface PeerIdFactory {
   /**
    * Create a new PeerId.
    **/
+  new (id: Uint8Array, privKey?: PrivateKey, pubKey?: PublicKey): PeerId;
+
+  /**
+   * Create a new PeerId.
+   **/
   create (args: CreateOptions): Promise<PeerId>;
 
   /**


### PR DESCRIPTION
In the PR https://github.com/libp2p/js-libp2p-interfaces/pull/107  the `PeerId` interface was introduced. Later in the PR https://github.com/libp2p/js-libp2p-interfaces/pull/111/ that was refactored and some intentional changes introduced. 

The `privKey` and `pubKey` both can be undefined depending on the data, more details can be found in the PR https://github.com/libp2p/js-peer-id/pull/150.

The `PeerId` object can be created with the following scenarios: 

1. `new` in that case both keys are optional 
2. `PeerId.create` in that case if provided input is valid than both keys exists 
3. `PeerId.createFromBytes`, `PeerId.createFromB58String`, `PeerId.createFromHexString`, `PeerId.createFromCID`  in these cases public key _can_ be decoded but private key don't exists 
4. `PeerId.createFromPubKey` in that case public key exists but not private 
5. `PeerId.createFromPrivKey` in that case both keys exist
6. `PeerId.createFromJSON` in that case both keys exist 
7. `PeerId.createFromProtobuf` in that case both keys exist

Considering all the above cases, both `privKey` and `pubKey` were initially set was set to have `undefined`  values. Seems the change in refactoring PR #111 was made unintended. 

