### PR TITLE
fix: pubsub typescript type export

### DIFF
--- a/packages/libp2p-pubsub/package.json
+++ b/packages/libp2p-pubsub/package.json
@@ -11,6 +11,7 @@
   "typesVersions": {
     "*": {
       "*": [
+        "dist/src",
         "dist/src/*",
         "dist/src/*/index"
       ]


### PR DESCRIPTION
Resolve https://github.com/libp2p/js-libp2p-interfaces/issues/114

~I'm not entirely sure what about the `typesVersions` field breaks the types, but... removing it resolves the problem.
We shouldn't need the `typesVersions` field anyways unless we have different types for different versions of typescript.~

Added an additional field to `typeVersions`. Based on how it's done in [`uint8arrays`](https://github.com/achingbrain/uint8arrays/blob/master/package.json#L43)

This probably should be applied to all of the packages, but I tested this locally against gossipsub.
LMK if you'd like me to apply this consistently.