### PR TITLE
feat: async peer store

### DIFF
--- a/packages/compliance-tests/src/pubsub/connection-handlers.js
+++ b/packages/compliance-tests/src/pubsub/connection-handlers.js
@@ -242,7 +242,7 @@ module.exports = (common) => {
         await psB._libp2p.start()
         psB.start()
 
-        psA._libp2p.peerStore.addressBook.set(psB.peerId, psB._libp2p.multiaddrs)
+        await psA._libp2p.peerStore.addressBook.set(psB.peerId, psB._libp2p.multiaddrs)
         await psA._libp2p.dial(psB.peerId)
 
         // wait for remoteLibp2p to know about libp2p subscription

--- a/packages/compliance-tests/test/topology/mock-peer-store.js
+++ b/packages/compliance-tests/test/topology/mock-peer-store.js
@@ -11,8 +11,16 @@ class MockPeerStore extends EventEmitter {
     }
   }
 
-  get (peerId) {
+  async * getPeers () {
+    yield * this.peers.values()
+  }
+
+  async get (peerId) {
     return this.peers.get(peerId.toB58String())
+  }
+
+  async set (peerId, peer) {
+    return this.peers.set(peerId.toB58String(), peer)
   }
 }
 

--- a/packages/compliance-tests/test/topology/multicodec-topology.spec.js
+++ b/packages/compliance-tests/test/topology/multicodec-topology.spec.js
@@ -9,7 +9,7 @@ const MockPeerStore = require('./mock-peer-store')
 
 describe('multicodec topology compliance tests', () => {
   tests({
-    setup (properties, registrar) {
+    async setup (properties, registrar) {
       const multicodecs = ['/echo/1.0.0']
       const handlers = {
         onConnect: () => { },
@@ -34,7 +34,7 @@ describe('multicodec topology compliance tests', () => {
         }
       }
 
-      topology.registrar = registrar
+      await topology.setRegistrar(registrar)
 
       return topology
     },

--- a/packages/interfaces/src/topology/index.js
+++ b/packages/interfaces/src/topology/index.js
@@ -65,7 +65,7 @@ class Topology {
   /**
    * @param {any} registrar
    */
-  set registrar (registrar) { // eslint-disable-line
+  async setRegistrar (registrar) {
     this._registrar = registrar
   }
 


### PR DESCRIPTION
Refactors interfaces and classes used by `libp2p-interfaces` to use the async peer store from https://github.com/libp2p/js-libp2p/pull/1058

BREAKING CHANGE: peerstore methods are now all async