### PR TITLE
fix: partial revert of 131 for v2.x.x

### DIFF
--- a/packages/interfaces/src/peer-id/types.d.ts
+++ b/packages/interfaces/src/peer-id/types.d.ts
@@ -14,13 +14,13 @@ export interface CreateOptions {
 
 export interface PeerId {
   readonly id: Uint8Array
-  privKey: PrivateKey | undefined;
-  pubKey: PublicKey | undefined;
+  privKey: PrivateKey;
+  pubKey: PublicKey;
 
   /**
    * Return the protobuf version of the public key, matching go ipfs formatting
    */
-  marshalPubKey: () => Uint8Array | undefined;
+  marshalPubKey: () => Uint8Array;
 
   /**
    * Return the protobuf version of the private key, matching go ipfs formatting


### PR DESCRIPTION
A PeerId's privKey and/or pubKey can be undefined but we've got types
that say they cannot.

These fields are accessed when a node is interacting with it's own
PeerId so these fields are set, but really they can be undefined.

Marking these fields as undefined was a breaking change so this PR
partially reverts #131 - the proper fix is in the 4.x.x release line
which should be used in preference to 2.x.x.