### PR TITLE
chore: update package versions

### DIFF
--- a/packages/libp2p-connection/package.json
+++ b/packages/libp2p-connection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libp2p/connection",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "JS Libp2p connections",
   "type": "module",
   "files": [

--- a/packages/libp2p-interface-compliance-tests/package.json
+++ b/packages/libp2p-interface-compliance-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libp2p/interface-compliance-tests",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Compliance tests for JS libp2p interfaces",
   "type": "module",
   "files": [

--- a/packages/libp2p-interfaces/package.json
+++ b/packages/libp2p-interfaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libp2p/interfaces",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Interfaces for JS Libp2p",
   "type": "module",
   "files": [

--- a/packages/libp2p-interfaces/src/transport/index.ts
+++ b/packages/libp2p-interfaces/src/transport/index.ts
@@ -9,6 +9,8 @@ export interface TransportFactory<DialOptions extends { signal?: AbortSignal }, 
 
 export interface ConnectionHandler { (connection: Connection): void }
 
+export interface MultiaddrFilter { (multiaddrs: Multiaddr[]): Multiaddr[] }
+
 /**
  * A libp2p transport is understood as something that offers a dial and listen interface to establish connections.
  */
@@ -24,7 +26,7 @@ export interface Transport <DialOptions extends AbortOptions = AbortOptions, Lis
   /**
    * Takes a list of `Multiaddr`s and returns only valid addresses for the transport
    */
-  filter: (multiaddrs: Multiaddr[]) => Multiaddr[]
+  filter: MultiaddrFilter
 }
 
 export interface Listener extends events.EventEmitter {

--- a/packages/libp2p-peer-id-factory/package.json
+++ b/packages/libp2p-peer-id-factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libp2p/peer-id-factory",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "IPFS Peer Id implementation in Node.js",
   "type": "module",
   "types": "./dist/src/index.d.ts",

--- a/packages/libp2p-peer-id/package.json
+++ b/packages/libp2p-peer-id/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libp2p/peer-id",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "IPFS Peer Id implementation in Node.js",
   "type": "module",
   "types": "./dist/src/index.d.ts",

--- a/packages/libp2p-pubsub/package.json
+++ b/packages/libp2p-pubsub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libp2p/pubsub",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "libp2p pubsub base class",
   "type": "module",
   "files": [

--- a/packages/libp2p-topology/package.json
+++ b/packages/libp2p-topology/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libp2p/topology",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "libp2p network topology",
   "type": "module",
   "files": [


### PR DESCRIPTION
semantic-release-monorepo doesn't do this either and without this you get duplicate versions when running `npm i` in this repo.

See: https://github.com/pmowrer/semantic-release-monorepo/issues/92