### PR TITLE
fix: PeerId.marshalPrivKey can return undefined

### DIFF
--- a/packages/interfaces/src/peer-id/types.d.ts
+++ b/packages/interfaces/src/peer-id/types.d.ts
@@ -14,18 +14,18 @@ export interface CreateOptions {
 
 export interface PeerId {
   readonly id: Uint8Array
-  privKey: PrivateKey;
-  pubKey: PublicKey;
+  privKey?: PrivateKey;
+  pubKey?: PublicKey;
 
   /**
    * Return the protobuf version of the public key, matching go ipfs formatting
    */
-  marshalPubKey: () => Uint8Array;
+  marshalPubKey: () => Uint8Array | undefined;
 
   /**
    * Return the protobuf version of the private key, matching go ipfs formatting
    */
-  marshalPrivKey (): Uint8Array;
+  marshalPrivKey (): Uint8Array | undefined;
 
   /**
    * Return the protobuf version of the peer-id


### PR DESCRIPTION
Because the `.privKey` property can be undefined, so can the return value from `.marshalPrivKey`

Reimplements #131 - see #138 for discussion.

BREAKING CHANGE: `.privKey` and `.pubKey` properties can be undefined, so can the return type from `.marshalXXKey`