### PR TITLE
fix: partial revert of 131 for v4.x.x

### DIFF
--- a/packages/compliance-tests/src/peer-id/index.js
+++ b/packages/compliance-tests/src/peer-id/index.js
@@ -394,7 +394,7 @@ module.exports = (common) => {
         })).eventually.be.rejectedWith(/inconsistent arguments/)
       })
 
-      it('invalid id', () => {
+      it('invalid id', async () => {
         await expect(factory.createFromJSON('hello world')).eventually.be.rejectedWith(/invalid id/)
       })
     })

--- a/packages/interfaces/src/peer-id/types.d.ts
+++ b/packages/interfaces/src/peer-id/types.d.ts
@@ -14,13 +14,13 @@ export interface CreateOptions {
 
 export interface PeerId {
   readonly id: Uint8Array
-  privKey: PrivateKey | undefined;
-  pubKey: PublicKey | undefined;
+  privKey: PrivateKey;
+  pubKey: PublicKey;
 
   /**
    * Return the protobuf version of the public key, matching go ipfs formatting
    */
-  marshalPubKey: () => Uint8Array | undefined;
+  marshalPubKey: () => Uint8Array;
 
   /**
    * Return the protobuf version of the private key, matching go ipfs formatting


### PR DESCRIPTION
See #138 for discussion - will re-release #131 as v5.x.x to enable managing the transition since it will require a breaking release of the peer-id module.