### PR TITLE
fix: remove abort controller polyfill

### DIFF
--- a/packages/compliance-tests/package.json
+++ b/packages/compliance-tests/package.json
@@ -34,7 +34,6 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-interfaces/tree/master/packages/compliance-tests#readme#readme",
   "dependencies": {
-    "abort-controller": "^3.0.0",
     "abortable-iterator": "^3.0.0",
     "aegir": "^35.0.1",
     "chai": "^4.3.4",

--- a/packages/compliance-tests/src/peer-id/index.js
+++ b/packages/compliance-tests/src/peer-id/index.js
@@ -394,7 +394,7 @@ module.exports = (common) => {
         })).eventually.be.rejectedWith(/inconsistent arguments/)
       })
 
-      it('invalid id', () => {
+      it('invalid id', async () => {
         await expect(factory.createFromJSON('hello world')).eventually.be.rejectedWith(/invalid id/)
       })
     })

--- a/packages/compliance-tests/src/stream-muxer/close-test.js
+++ b/packages/compliance-tests/src/stream-muxer/close-test.js
@@ -7,7 +7,6 @@ const pair = require('it-pair/duplex')
 const { pipe } = require('it-pipe')
 const { consume } = require('streaming-iterables')
 const { source: abortable } = require('abortable-iterator')
-const AbortController = require('abort-controller').default
 const { fromString: uint8ArrayFromString } = require('uint8arrays/from-string')
 
 function pause (ms) {

--- a/packages/compliance-tests/src/transport/dial-test.js
+++ b/packages/compliance-tests/src/transport/dial-test.js
@@ -7,7 +7,6 @@ const { isValidTick } = require('./utils')
 const goodbye = require('it-goodbye')
 const { collect } = require('streaming-iterables')
 const { pipe } = require('it-pipe')
-const AbortController = require('abort-controller').default
 const { AbortError } = require('libp2p-interfaces/src/transport/errors')
 const sinon = require('sinon')
 

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -57,7 +57,6 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-interfaces/tree/master/packages/interfaces#readme",
   "dependencies": {
-    "abort-controller": "^3.0.0",
     "abortable-iterator": "^3.0.0",
     "debug": "^4.3.1",
     "err-code": "^3.0.1",

--- a/packages/interfaces/src/pubsub/peer-streams.js
+++ b/packages/interfaces/src/pubsub/peer-streams.js
@@ -10,7 +10,6 @@ const lp = require('it-length-prefixed')
 const pushable = require('it-pushable')
 const { pipe } = require('it-pipe')
 const { source: abortable } = require('abortable-iterator')
-const AbortController = require('abort-controller').default
 
 /**
  * @typedef {import('../stream-muxer/types').MuxedStream} MuxedStream

--- a/packages/interfaces/src/transport/README.md
+++ b/packages/interfaces/src/transport/README.md
@@ -144,7 +144,6 @@ The dial may throw an `Error` instance if there was a problem connecting to the 
 Dials may be cancelled using an `AbortController`:
 
 ```Javascript
-const AbortController = require('abort-controller')
 const { AbortError } = require('libp2p-interfaces/src/transport/errors')
 const controller = new AbortController()
 try {


### PR DESCRIPTION
AbortController is global in all supported environments so there's
no need to use the polyfill any more.