### PR TITLE
fix: remove extra fields

### DIFF
--- a/packages/libp2p-interface-compliance-tests/src/connection/connection.ts
+++ b/packages/libp2p-interface-compliance-tests/src/connection/connection.ts
@@ -19,9 +19,7 @@ export default (test: TestSetup<Connection>) => {
 
       it('should have properties set', () => {
         expect(connection.id).to.exist()
-        expect(connection.localPeer).to.exist()
         expect(connection.remotePeer).to.exist()
-        expect(connection.localAddr).to.exist()
         expect(connection.remoteAddr).to.exist()
         expect(connection.stat.status).to.equal('OPEN')
         expect(connection.stat.timeline.open).to.exist()

--- a/packages/libp2p-interface-compliance-tests/src/crypto/utils/index.ts
+++ b/packages/libp2p-interface-compliance-tests/src/crypto/utils/index.ts
@@ -10,7 +10,6 @@ export function createMaConnPair (): [MultiaddrConnection, MultiaddrConnection] 
     const output: MultiaddrConnection = {
       ...duplex,
       close: async () => {},
-      conn: {},
       remoteAddr: new Multiaddr('/ip4/127.0.0.1/tcp/4001'),
       timeline: {
         open: Date.now()

--- a/packages/libp2p-interface-compliance-tests/src/transport/dial-test.ts
+++ b/packages/libp2p-interface-compliance-tests/src/transport/dial-test.ts
@@ -49,7 +49,7 @@ export default (common: TestSetup<TransportTestFixtures, SetupArgs>) => {
       expect(upgradeSpy.callCount).to.equal(1)
       await expect(upgradeSpy.getCall(0).returnValue).to.eventually.equal(conn)
       expect(result.length).to.equal(1)
-      expect(result[0].toString()).to.equal('hey')
+      expect(result[0]).to.equalBytes(uint8ArrayFromString('hey'))
       await conn.close()
     })
 

--- a/packages/libp2p-interface-compliance-tests/src/transport/utils/index.ts
+++ b/packages/libp2p-interface-compliance-tests/src/transport/utils/index.ts
@@ -46,16 +46,8 @@ export function mockUpgrader () {
 }
 
 async function createConnection (maConn: MultiaddrConnection, direction: 'inbound' | 'outbound'): Promise<Connection> {
-  const localAddr = maConn.localAddr
   const remoteAddr = maConn.remoteAddr
-
-  if (localAddr == null) {
-    throw new Error('No localAddr found on MultiaddrConnection')
-  }
-
-  const localPeerIdStr = localAddr.getPeerId()
   const remotePeerIdStr = remoteAddr.getPeerId()
-  const localPeer = localPeerIdStr != null ? PeerId.fromString(localPeerIdStr) : await PeerIdFactory.createEd25519PeerId()
   const remotePeer = remotePeerIdStr != null ? PeerId.fromString(remotePeerIdStr) : await PeerIdFactory.createEd25519PeerId()
 
   const streams: MuxedStream[] = []
@@ -65,9 +57,7 @@ async function createConnection (maConn: MultiaddrConnection, direction: 'inboun
 
   return {
     id: 'mock-connection',
-    localAddr,
     remoteAddr,
-    localPeer,
     remotePeer,
     stat: {
       status: 'OPEN',

--- a/packages/libp2p-interface-compliance-tests/src/transport/utils/index.ts
+++ b/packages/libp2p-interface-compliance-tests/src/transport/utils/index.ts
@@ -25,7 +25,7 @@ export function isValidTick (date?: number, ms: number = 5000) {
 
 export function mockUpgrader () {
   const ensureProps = (multiaddrConnection: MultiaddrConnection) => {
-    ['sink', 'source', 'remoteAddr', 'conn', 'timeline', 'close'].forEach(prop => {
+    ['sink', 'source', 'remoteAddr', 'timeline', 'close'].forEach(prop => {
       expect(multiaddrConnection).to.have.property(prop)
     })
     expect(isValidTick(multiaddrConnection.timeline.open)).to.equal(true)

--- a/packages/libp2p-interfaces/src/connection/index.ts
+++ b/packages/libp2p-interfaces/src/connection/index.ts
@@ -30,9 +30,7 @@ export interface Stream {
 export interface Connection {
   id: string
   stat: ConnectionStat
-  localAddr: Multiaddr
   remoteAddr: Multiaddr
-  localPeer: PeerId
   remotePeer: PeerId
   registry: Map<string, StreamData>
   tags: string[]

--- a/packages/libp2p-interfaces/src/connection/index.ts
+++ b/packages/libp2p-interfaces/src/connection/index.ts
@@ -27,6 +27,12 @@ export interface Stream {
   stream: MuxedStream
 }
 
+/**
+ * A Connection is a high-level representation of a connection
+ * to a remote peer that may have been secured by encryption and
+ * multiplexed, depending on the configuration of the nodes
+ * between which the connection is made.
+ */
 export interface Connection {
   id: string
   stat: ConnectionStat

--- a/packages/libp2p-interfaces/src/peer-id/index.ts
+++ b/packages/libp2p-interfaces/src/peer-id/index.ts
@@ -1,6 +1,6 @@
 import type { CID } from 'multiformats/cid'
-import type { MultihashDigest } from 'multiformats/types/hashes/interface'
-import type { MultibaseEncoder } from 'multiformats/types/bases/interface'
+import type { MultihashDigest } from 'multiformats/hashes/interface'
+import type { MultibaseEncoder } from 'multiformats/bases/interface'
 
 export interface PeerId {
   readonly type: 'RSA' | 'Ed25519' | 'secp256k1'

--- a/packages/libp2p-interfaces/src/transport/index.ts
+++ b/packages/libp2p-interfaces/src/transport/index.ts
@@ -1,4 +1,4 @@
-import type events from 'events'
+import type { EventEmitter } from 'events'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Connection } from '../connection/index.js'
 import type { AbortOptions } from '../index.js'
@@ -34,7 +34,7 @@ export interface Transport <DialOptions extends AbortOptions = AbortOptions, Cre
   filter: MultiaddrFilter
 }
 
-export interface Listener extends events.EventEmitter {
+export interface Listener extends EventEmitter {
   /**
    * Start a listener
    */
@@ -69,10 +69,8 @@ export interface MultiaddrConnectionTimeline {
   close?: number
 }
 
-export interface MultiaddrConnection extends Duplex<Uint8Array, Uint8Array, Promise<void>> {
+export interface MultiaddrConnection extends Duplex<Uint8Array> {
   close: (err?: Error) => Promise<void>
-  conn: unknown
   remoteAddr: Multiaddr
-  localAddr?: Multiaddr
   timeline: MultiaddrConnectionTimeline
 }

--- a/packages/libp2p-interfaces/src/transport/index.ts
+++ b/packages/libp2p-interfaces/src/transport/index.ts
@@ -69,6 +69,11 @@ export interface MultiaddrConnectionTimeline {
   close?: number
 }
 
+/**
+ * A MultiaddrConnection is returned by transports after dialing
+ * a peer. It is a low-level primitive and is the raw connection
+ * without encryption or stream multiplexing.
+ */
 export interface MultiaddrConnection extends Duplex<Uint8Array> {
   close: (err?: Error) => Promise<void>
   remoteAddr: Multiaddr

--- a/packages/libp2p-peer-id/src/index.ts
+++ b/packages/libp2p-peer-id/src/index.ts
@@ -4,8 +4,8 @@ import { base58btc } from 'multiformats/bases/base58'
 import * as Digest from 'multiformats/hashes/digest'
 import { identity } from 'multiformats/hashes/identity'
 import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
-import type { MultibaseDecoder, MultibaseEncoder } from 'multiformats/types/bases/interface'
-import type { MultihashDigest } from 'multiformats/types/hashes/interface'
+import type { MultibaseDecoder, MultibaseEncoder } from 'multiformats/bases/interface'
+import type { MultihashDigest } from 'multiformats/hashes/interface'
 import { sha256 } from 'multiformats/hashes/sha2'
 
 const baseDecoder = Object


### PR DESCRIPTION
Trying to cut the number of fields objects have down - some of these should be obvious from the context - our own peer id, etc.