### PR TITLE
fix: make discovery startable

### DIFF
--- a/packages/libp2p-interfaces/src/index.ts
+++ b/packages/libp2p-interfaces/src/index.ts
@@ -8,3 +8,8 @@ export interface Startable {
   stop: () => void | Promise<void>
   isStarted: () => boolean
 }
+
+export interface Logger {
+  (...opts: any[]): void
+  error: (...opts: any[]) => void
+}

--- a/packages/libp2p-interfaces/src/peer-discovery/index.ts
+++ b/packages/libp2p-interfaces/src/peer-discovery/index.ts
@@ -1,5 +1,6 @@
 import type { EventEmitter } from 'events'
-import type { PeerData } from '../peer-data'
+import type { PeerData } from '../peer-data/index.js'
+import type { Startable } from '../index.js'
 
 export interface PeerDiscoveryFactory {
   new (options?: any): PeerDiscovery
@@ -10,7 +11,8 @@ interface PeerDiscoveryEvents {
   'peer': PeerData
 }
 
-export interface PeerDiscovery extends EventEmitter {
+export interface PeerDiscovery extends EventEmitter, Startable {
+
   on: (<U extends keyof PeerDiscoveryEvents> (event: U, listener: (event: PeerDiscoveryEvents[U]) => void) => this) &
   ((event: string, listener: (...args: any[]) => void) => this)
 


### PR DESCRIPTION
Peer discovery methods are expected to be startable according to the compliance tests, so make the discovery interface extend startable.