### PR TITLE
feat: add logger package

### DIFF
--- a/packages/libp2p-interfaces/src/index.ts
+++ b/packages/libp2p-interfaces/src/index.ts
@@ -8,8 +8,3 @@ export interface Startable {
   stop: () => void | Promise<void>
   isStarted: () => boolean
 }
-
-export interface Logger {
-  (...opts: any[]): void
-  error: (...opts: any[]) => void
-}

--- a/packages/libp2p-logger/CHANGELOG.md
+++ b/packages/libp2p-logger/CHANGELOG.md
@@ -1,0 +1,6 @@
+## @libp2p/tracked-map-v1.0.0 (2022-02-05)
+
+
+### Features
+
+* add tracked-map ([#156](https://github.com/libp2p/js-libp2p-interfaces/issues/156)) ([c17730f](https://github.com/libp2p/js-libp2p-interfaces/commit/c17730f8bca172db85507740eaba81b3cf514d04))

--- a/packages/libp2p-logger/LICENSE
+++ b/packages/libp2p-logger/LICENSE
@@ -1,0 +1,4 @@
+This project is dual licensed under MIT and Apache-2.0.
+
+MIT: https://www.opensource.org/licenses/mit
+Apache-2.0: https://www.apache.org/licenses/license-2.0

--- a/packages/libp2p-logger/LICENSE-APACHE
+++ b/packages/libp2p-logger/LICENSE-APACHE
@@ -1,0 +1,5 @@
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/packages/libp2p-logger/LICENSE-MIT
+++ b/packages/libp2p-logger/LICENSE-MIT
@@ -1,0 +1,19 @@
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/libp2p-logger/README.md
+++ b/packages/libp2p-logger/README.md
@@ -1,0 +1,51 @@
+# libp2p-logger <!-- omit in toc -->
+
+> A logging component for use in js-libp2p components
+
+## Table of Contents <!-- omit in toc -->
+
+- [Description](#description)
+- [Installation](#installation)
+- [Example](#example)
+- [License](#license)
+  - [Contribution](#contribution)
+
+## Description
+
+A map that reports it's size to the libp2p [Metrics](https://github.com/libp2p/js-libp2p-interfaces/tree/master/packages/libp2p-interfaces/src/metrics#readme) system.
+
+If metrics are disabled a regular map is used.
+
+## Installation
+
+```console
+$ npm i @libp2p/logger
+```
+
+## Example
+
+```JavaScript
+import { logger } from '@libp2p/logger'
+
+const log = logger('libp2p:my:component:name')
+
+log('something happened: %s', 'it was ok')
+log.error('something bad happened: %o', err)
+```
+
+```console
+$ DEBUG=libp2p:* node index.js
+something happened: it was ok
+something bad happened: <stack trace>
+```
+
+## License
+
+Licensed under either of
+
+ * Apache 2.0, ([LICENSE-APACHE](LICENSE-APACHE) / http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT ([LICENSE-MIT](LICENSE-MIT) / http://opensource.org/licenses/MIT)
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/packages/libp2p-logger/package.json
+++ b/packages/libp2p-logger/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@libp2p/pubsub",
-  "version": "1.0.6",
-  "description": "libp2p pubsub base class",
+  "name": "@libp2p/logger",
+  "version": "0.0.0",
+  "description": "A logging component for use in js-libp2p components",
   "license": "Apache-2.0 OR MIT",
-  "homepage": "https://github.com/libp2p/js-libp2p-interfaces/tree/master/packages/libp2p-pubsub#readme",
+  "homepage": "https://github.com/libp2p/js-libp2p-interfaces/tree/master/packages/libp2p-logger#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/libp2p/js-libp2p-interfaces.git"
@@ -12,8 +12,7 @@
     "url": "https://github.com/libp2p/js-libp2p-interfaces/issues"
   },
   "keywords": [
-    "interface",
-    "libp2p"
+    "IPFS"
   ],
   "engines": {
     "node": ">=16.0.0",
@@ -21,22 +20,6 @@
   },
   "type": "module",
   "types": "./dist/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "*",
-        "dist/*",
-        "dist/src/*",
-        "dist/src/*/index"
-      ],
-      "src/*": [
-        "*",
-        "dist/*",
-        "dist/src/*",
-        "dist/src/*/index"
-      ]
-    }
-  },
   "files": [
     "src",
     "dist/src",
@@ -45,43 +28,14 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/src/index.js",
-      "types": "./dist/src/index.d.ts"
-    },
-    "./errors": {
-      "import": "./dist/src/errors.js",
-      "types": "./dist/src/errors.d.ts"
-    },
-    "./message/rpc": {
-      "import": "./dist/src/message/rpc.js",
-      "types": "./dist/src/message/rpc.d.ts"
-    },
-    "./message/topic-descriptor": {
-      "import": "./dist/src/message/topic-descriptor.js",
-      "types": "./dist/src/message/topic-descriptor.d.ts"
-    },
-    "./peer-streams": {
-      "import": "./dist/src/peer-streams.js",
-      "types": "./dist/src/peer-streams.d.ts"
-    },
-    "./signature-policy": {
-      "import": "./dist/src/signature-policy.js",
-      "types": "./dist/src/signature-policy.d.ts"
-    },
-    "./utils": {
-      "import": "./dist/src/utils.js",
-      "types": "./dist/src/utils.d.ts"
+      "import": "./dist/src/index.js"
     }
   },
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
       "sourceType": "module"
-    },
-    "ignorePatterns": [
-      "src/message/*.d.ts",
-      "src/message/*.js"
-    ]
+    }
   },
   "release": {
     "branches": [
@@ -168,7 +122,6 @@
     "lint": "aegir lint",
     "dep-check": "aegir dep-check dist/src/**/*.js",
     "build": "tsc",
-    "postbuild": "npm run build:copy-proto-files",
     "pretest": "npm run build",
     "test": "aegir test -f ./dist/test/**/*.js",
     "test:chrome": "npm run test -- -t browser",
@@ -176,35 +129,14 @@
     "test:firefox": "npm run test -- -t browser -- --browser firefox",
     "test:firefox-webworker": "npm run test -- -t webworker -- --browser firefox",
     "test:node": "npm run test -- -t node --cov",
-    "test:electron-main": "npm run test -- -t electron-main",
-    "build:proto": "npm run build:proto:rpc && npm run build:proto:topic-descriptor",
-    "build:proto:rpc": "pbjs -t static-module -w es6 -r libp2p-pubsub-rpc --force-number --no-verify --no-delimited --no-create --no-beautify --no-defaults --lint eslint-disable -o src/message/rpc.js ./src/message/rpc.proto",
-    "build:proto:topic-descriptor": "pbjs -t static-module -w es6 -r libp2p-pubsub-topic-descriptor --force-number --no-verify --no-delimited --no-create --no-beautify --no-defaults --lint eslint-disable -o src/message/topic-descriptor.js ./src/message/topic-descriptor.proto",
-    "build:proto-types": "npm run build:proto-types:rpc && npm run build:proto-types:topic-descriptor",
-    "build:proto-types:rpc": "pbts -o src/message/rpc.d.ts src/message/rpc.js",
-    "build:proto-types:topic-descriptor": "pbts -o src/message/topic-descriptor.d.ts src/message/topic-descriptor.js",
-    "build:copy-proto-files": "cp src/message/*.js dist/src/message && cp src/message/*.d.ts dist/src/message"
+    "test:electron-main": "npm run test -- -t electron-main"
   },
   "dependencies": {
-    "@libp2p/crypto": "^0.22.2",
     "@libp2p/interfaces": "^1.0.0",
-    "@libp2p/logger": "^0.0.0",
-    "@libp2p/peer-id": "^1.0.0",
-    "@libp2p/peer-id-factory": "^1.0.0",
-    "@libp2p/topology": "^1.0.0",
-    "@multiformats/multiaddr": "^10.1.1",
-    "err-code": "^3.0.1",
-    "iso-random-stream": "^2.0.0",
-    "it-length-prefixed": "^6.0.1",
-    "it-pipe": "^2.0.2",
-    "multiformats": "^9.4.10",
-    "p-queue": "^7.1.0",
-    "uint8arrays": "^3.0.0"
+    "debug": "^4.3.3"
   },
   "devDependencies": {
-    "@types/bl": "^5.0.2",
-    "aegir": "^36.1.3",
-    "protobufjs": "^6.10.2",
-    "util": "^0.12.4"
+    "@types/debug": "^4.1.7",
+    "aegir": "^36.1.3"
   }
 }

--- a/packages/libp2p-logger/src/index.ts
+++ b/packages/libp2p-logger/src/index.ts
@@ -1,0 +1,13 @@
+import debug from 'debug'
+
+export interface Logger {
+  (formatter: any, ...args: any[]): void
+  error: (formatter: any, ...args: any[]) => void
+  enabled: boolean
+}
+
+export function logger (name: string): Logger {
+  return Object.assign(debug(name), {
+    error: debug(`${name}:error`)
+  })
+}

--- a/packages/libp2p-logger/test/index.spec.ts
+++ b/packages/libp2p-logger/test/index.spec.ts
@@ -1,0 +1,12 @@
+import { expect } from 'aegir/utils/chai.js'
+import { logger } from '../src/index.js'
+
+describe('logger', () => {
+  it('creates a logger', () => {
+    const log = logger('hello')
+
+    expect(log).to.be.a('function')
+    expect(log).to.have.property('error').that.is.a('function')
+    expect(log).to.have.property('enabled')
+  })
+})

--- a/packages/libp2p-logger/tsconfig.json
+++ b/packages/libp2p-logger/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "aegir/src/config/tsconfig.aegir.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "emitDeclarationOnly": false,
+    "module": "ES2020"
+  },
+  "include": [
+    "src",
+    "test"
+  ]
+}

--- a/packages/libp2p-pubsub/src/peer-streams.ts
+++ b/packages/libp2p-pubsub/src/peer-streams.ts
@@ -1,4 +1,4 @@
-import debug from 'debug'
+import { logger } from '@libp2p/logger'
 import { EventEmitter } from 'events'
 import * as lp from 'it-length-prefixed'
 import { pushable } from 'it-pushable'
@@ -8,9 +8,7 @@ import type { PeerId } from '@libp2p/interfaces/peer-id'
 import type { MuxedStream } from '@libp2p/interfaces/stream-muxer'
 import type { Pushable } from 'it-pushable'
 
-const log = Object.assign(debug('libp2p-pubsub:peer-streams'), {
-  error: debug('libp2p-pubsub:peer-streams:err')
-})
+const log = logger('libp2p-pubsub:peer-streams')
 
 export interface Options {
   id: PeerId


### PR DESCRIPTION
Adds @libp2p/logger for use in libp2p components.

Currently wraps debug but lets us swap it out in future - for example
if it doesn't go to ESM in a reasonable timeframe.