### PR TITLE
fix: remove node event emitters

### DIFF
--- a/packages/libp2p-connection/package.json
+++ b/packages/libp2p-connection/package.json
@@ -142,7 +142,7 @@
   },
   "scripts": {
     "lint": "aegir lint",
-    "dep-check": "aegir dep-check dist/src/**/*.js",
+    "dep-check": "aegir dep-check dist/src/**/*.js dist/test/**/*.js",
     "build": "tsc",
     "pretest": "npm run build",
     "test": "aegir test -f ./dist/test/**/*.js",
@@ -161,6 +161,7 @@
   "devDependencies": {
     "@libp2p/interface-compliance-tests": "^1.0.0",
     "@libp2p/peer-id-factory": "^1.0.0",
-    "aegir": "^36.1.3"
+    "aegir": "^36.1.3",
+    "it-pair": "^2.0.2"
   }
 }

--- a/packages/libp2p-connection/package.json
+++ b/packages/libp2p-connection/package.json
@@ -145,7 +145,7 @@
     "dep-check": "aegir dep-check dist/src/**/*.js dist/test/**/*.js",
     "build": "tsc",
     "pretest": "npm run build",
-    "test": "aegir test -f ./dist/test/**/*.js",
+    "test": "aegir test -f ./dist/test/*.js -f ./dist/test/**/*.js",
     "test:chrome": "npm run test -- -t browser",
     "test:chrome-webworker": "npm run test -- -t webworker",
     "test:firefox": "npm run test -- -t browser -- --browser firefox",

--- a/packages/libp2p-interface-compliance-tests/package.json
+++ b/packages/libp2p-interface-compliance-tests/package.json
@@ -214,7 +214,7 @@
   },
   "scripts": {
     "lint": "aegir lint",
-    "dep-check": "aegir dep-check dist/src/**/*.js",
+    "dep-check": "aegir dep-check dist/src/**/*.js dist/test/**/*.js",
     "build": "tsc",
     "pretest": "npm run build",
     "test": "aegir test -f ./dist/test/**/*.js",

--- a/packages/libp2p-interface-compliance-tests/package.json
+++ b/packages/libp2p-interface-compliance-tests/package.json
@@ -96,17 +96,13 @@
       "import": "./dist/src/utils/mock-connection-gater.js",
       "types": "./dist/src/utils/mock-connection-gater.d.ts"
     },
-    "./utils/mock-multiaddr-connection": {
-      "import": "./dist/src/utils/mock-multiaddr-connection.js",
-      "types": "./dist/src/utils/mock-multiaddr-connection.d.ts"
-    },
-    "./utils/mock-registrar": {
-      "import": "./dist/src/utils/mock-registrar.js",
-      "types": "./dist/src/utils/mock-registrar.d.ts"
-    },
     "./utils/mock-connection-manager": {
       "import": "./dist/src/utils/mock-connection-manager.js",
       "types": "./dist/src/utils/mock-connection-manager.d.ts"
+    },
+    "./utils/mock-multiaddr-connection": {
+      "import": "./dist/src/utils/mock-multiaddr-connection.js",
+      "types": "./dist/src/utils/mock-multiaddr-connection.d.ts"
     },
     "./utils/mock-muxer": {
       "import": "./dist/src/utils/mock-muxer.js",
@@ -115,6 +111,10 @@
     "./utils/mock-peer-store": {
       "import": "./dist/src/utils/mock-peer-store.js",
       "types": "./dist/src/utils/mock-peer-store.d.ts"
+    },
+    "./utils/mock-registrar": {
+      "import": "./dist/src/utils/mock-registrar.js",
+      "types": "./dist/src/utils/mock-registrar.d.ts"
     },
     "./utils/mock-upgrader": {
       "import": "./dist/src/utils/mock-upgrader.js",

--- a/packages/libp2p-interface-compliance-tests/package.json
+++ b/packages/libp2p-interface-compliance-tests/package.json
@@ -217,7 +217,7 @@
     "dep-check": "aegir dep-check dist/src/**/*.js dist/test/**/*.js",
     "build": "tsc",
     "pretest": "npm run build",
-    "test": "aegir test -f ./dist/test/**/*.js",
+    "test": "aegir test -f ./dist/test/*.js -f ./dist/test/**/*.js",
     "test:chrome": "npm run test -- -t browser",
     "test:chrome-webworker": "npm run test -- -t webworker",
     "test:firefox": "npm run test -- -t browser -- --browser firefox",

--- a/packages/libp2p-interface-compliance-tests/package.json
+++ b/packages/libp2p-interface-compliance-tests/package.json
@@ -100,6 +100,14 @@
       "import": "./dist/src/utils/mock-multiaddr-connection.js",
       "types": "./dist/src/utils/mock-multiaddr-connection.d.ts"
     },
+    "./utils/mock-registrar": {
+      "import": "./dist/src/utils/mock-registrar.js",
+      "types": "./dist/src/utils/mock-registrar.d.ts"
+    },
+    "./utils/mock-connection-manager": {
+      "import": "./dist/src/utils/mock-connection-manager.js",
+      "types": "./dist/src/utils/mock-connection-manager.d.ts"
+    },
     "./utils/mock-muxer": {
       "import": "./dist/src/utils/mock-muxer.js",
       "types": "./dist/src/utils/mock-muxer.d.ts"

--- a/packages/libp2p-interface-compliance-tests/src/peer-discovery/index.ts
+++ b/packages/libp2p-interface-compliance-tests/src/peer-discovery/index.ts
@@ -16,9 +16,6 @@ export default (common: TestSetup<PeerDiscovery & Startable>) => {
 
     afterEach('ensure discovery was stopped', async () => {
       await discovery.stop()
-
-      discovery.removeAllListeners()
-
       await common.teardown()
     })
 
@@ -44,7 +41,8 @@ export default (common: TestSetup<PeerDiscovery & Startable>) => {
       const defer = pDefer()
       await discovery.start()
 
-      discovery.on('peer', ({ id, multiaddrs }) => {
+      discovery.addEventListener('peer', (evt) => {
+        const { id, multiaddrs } = evt.detail
         expect(id).to.exist()
         expect(id).to.have.property('type').that.is.oneOf(['RSA', 'Ed25519', 'secp256k1'])
         expect(multiaddrs).to.exist()
@@ -58,7 +56,7 @@ export default (common: TestSetup<PeerDiscovery & Startable>) => {
     })
 
     it('should not receive a peer event before start', async () => {
-      discovery.on('peer', () => {
+      discovery.addEventListener('peer', () => {
         throw new Error('should not receive a peer event before start')
       })
 
@@ -70,14 +68,14 @@ export default (common: TestSetup<PeerDiscovery & Startable>) => {
 
       await discovery.start()
 
-      discovery.on('peer', () => {
+      discovery.addEventListener('peer', () => {
         deferStart.resolve()
       })
 
       await deferStart.promise
       await discovery.stop()
 
-      discovery.on('peer', () => {
+      discovery.addEventListener('peer', () => {
         throw new Error('should not receive a peer event after stop')
       })
 

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/emit-self.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/emit-self.ts
@@ -3,15 +3,15 @@ import sinon from 'sinon'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import type { TestSetup } from '../index.js'
 import type { PubSub, PubsubOptions } from '@libp2p/interfaces/pubsub'
-import type { Startable } from '@libp2p/interfaces'
+import type { EventMap } from './index.js'
 
 const topic = 'foo'
 const data = uint8ArrayFromString('bar')
 const shouldNotHappen = () => expect.fail()
 
-export default (common: TestSetup<PubSub & Startable, Partial<PubsubOptions>>) => {
+export default (common: TestSetup<PubSub<EventMap>, Partial<PubsubOptions>>) => {
   describe('emit self', () => {
-    let pubsub: PubSub & Startable
+    let pubsub: PubSub<EventMap>
 
     describe('enabled', () => {
       before(async () => {
@@ -30,7 +30,9 @@ export default (common: TestSetup<PubSub & Startable, Partial<PubsubOptions>>) =
       })
 
       it('should emit to self on publish', async () => {
-        const promise = new Promise((resolve) => pubsub.once(topic, resolve))
+        const promise = new Promise((resolve) => pubsub.addEventListener(topic, resolve, {
+          once: true
+        }))
 
         void pubsub.publish(topic, data)
 
@@ -55,7 +57,9 @@ export default (common: TestSetup<PubSub & Startable, Partial<PubsubOptions>>) =
       })
 
       it('should not emit to self on publish', async () => {
-        pubsub.once(topic, () => shouldNotHappen)
+        pubsub.addEventListener(topic, () => shouldNotHappen, {
+          once: true
+        })
 
         void pubsub.publish(topic, data)
 

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/index.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/index.ts
@@ -5,10 +5,17 @@ import connectionHandlersTest from './connection-handlers.js'
 import twoNodesTest from './two-nodes.js'
 import multipleNodesTest from './multiple-nodes.js'
 import type { TestSetup } from '../index.js'
-import type { PubSub } from '@libp2p/interfaces/pubsub'
-import type { Startable } from '@libp2p/interfaces'
+import type { PubSub, Message, PubsubEvents } from '@libp2p/interfaces/pubsub'
 
-export default (common: TestSetup<PubSub & Startable>) => {
+export interface EventMap extends PubsubEvents {
+  'topic': CustomEvent<Message>
+  'foo': CustomEvent<Message>
+  'test-topic': CustomEvent<Message>
+  'reconnect-channel': CustomEvent<Message>
+  'Z': CustomEvent<Message>
+}
+
+export default (common: TestSetup<PubSub<EventMap>>) => {
   describe('interface-pubsub compliance tests', () => {
     apiTest(common)
     emitSelfTest(common)

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/messages.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/messages.ts
@@ -6,14 +6,14 @@ import * as utils from '@libp2p/pubsub/utils'
 import { PeerStreams } from '@libp2p/pubsub/peer-streams'
 import type { TestSetup } from '../index.js'
 import type { PubSub } from '@libp2p/interfaces/pubsub'
-import type { Startable } from '@libp2p/interfaces'
+import type { EventMap } from './index.js'
 
 const topic = 'foo'
 const data = uint8ArrayFromString('bar')
 
-export default (common: TestSetup<PubSub & Startable>) => {
+export default (common: TestSetup<PubSub<EventMap>>) => {
   describe('messages', () => {
-    let pubsub: PubSub & Startable
+    let pubsub: PubSub<EventMap>
 
     // Create pubsub router
     beforeEach(async () => {

--- a/packages/libp2p-interface-compliance-tests/src/utils/mock-connection-manager.ts
+++ b/packages/libp2p-interface-compliance-tests/src/utils/mock-connection-manager.ts
@@ -1,0 +1,30 @@
+import { EventEmitter } from '@libp2p/interfaces'
+import type { Connection } from '@libp2p/interfaces/src/connection'
+import type { PeerId } from '@libp2p/interfaces/src/peer-id'
+import type { ConnectionManager, ConnectionManagerEvents } from '@libp2p/interfaces/src/registrar'
+
+class MockConnectionManager extends EventEmitter<ConnectionManagerEvents> implements ConnectionManager {
+  getConnection (peerId: PeerId): Connection | undefined {
+    throw new Error('Method not implemented.')
+  }
+
+  listenerCount (type: string): number {
+    throw new Error('Method not implemented.')
+  }
+
+  addEventListener<U extends 'peer:connect'>(type: U, callback: ((evt: ConnectionManagerEvents[U]) => void) | { handleEvent: (evt: ConnectionManagerEvents[U]) => void } | null, options?: boolean | AddEventListenerOptions): void {
+    throw new Error('Method not implemented.')
+  }
+
+  removeEventListener<U extends 'peer:connect'>(type: U, callback: (((evt: ConnectionManagerEvents[U]) => void) | { handleEvent: (evt: ConnectionManagerEvents[U]) => void } | null) | undefined, options?: boolean | EventListenerOptions): void {
+    throw new Error('Method not implemented.')
+  }
+
+  dispatchEvent (event: Event): boolean {
+    throw new Error('Method not implemented.')
+  }
+}
+
+export function mockConnectionManager () {
+  return new MockConnectionManager()
+}

--- a/packages/libp2p-interface-compliance-tests/src/utils/mock-registrar.ts
+++ b/packages/libp2p-interface-compliance-tests/src/utils/mock-registrar.ts
@@ -1,0 +1,49 @@
+import type { IncomingStreamEvent, Registrar } from '@libp2p/interfaces/registrar'
+import type { PeerId } from '@libp2p/interfaces/peer-id'
+import type { Connection } from '@libp2p/interfaces/connection'
+
+class MockRegistrar implements Registrar {
+  private readonly registrarRecord: Map<string, Record<string, any>> = new Map()
+
+  handle (multicodecs: string | string[], handler: (event: IncomingStreamEvent) => void) {
+    if (!Array.isArray(multicodecs)) {
+      multicodecs = [multicodecs]
+    }
+
+    const rec = this.registrarRecord.get(multicodecs[0]) ?? {}
+
+    this.registrarRecord.set(multicodecs[0], {
+      ...rec,
+      handler
+    })
+  }
+
+  unhandle (multicodec: string) {
+    this.registrarRecord.delete(multicodec)
+  }
+
+  register (topology: any) {
+    const { multicodecs } = topology
+    const rec = this.registrarRecord.get(multicodecs[0]) ?? {}
+
+    this.registrarRecord.set(multicodecs[0], {
+      ...rec,
+      onConnect: topology._onConnect,
+      onDisconnect: topology._onDisconnect
+    })
+
+    return multicodecs[0]
+  }
+
+  unregister (id: string) {
+    this.registrarRecord.delete(id)
+  }
+
+  getConnection (peerId: PeerId): Connection | undefined {
+    throw new Error('Not implemented')
+  }
+}
+
+export function mockRegistrar () {
+  return new MockRegistrar()
+}

--- a/packages/libp2p-interface-compliance-tests/test/peer-discovery/mock-discovery.ts
+++ b/packages/libp2p-interface-compliance-tests/test/peer-discovery/mock-discovery.ts
@@ -1,6 +1,7 @@
-import { EventEmitter } from 'events'
 import { Multiaddr } from '@multiformats/multiaddr'
 import * as PeerIdFactory from '@libp2p/peer-id-factory'
+import { EventEmitter, CustomEvent } from '@libp2p/interfaces'
+import type { PeerDiscovery, PeerDiscoveryEvents } from '@libp2p/interfaces/peer-discovery'
 
 interface MockDiscoveryOptions {
   discoveryDelay?: number
@@ -9,7 +10,7 @@ interface MockDiscoveryOptions {
 /**
  * Emits 'peer' events on discovery.
  */
-export class MockDiscovery extends EventEmitter {
+export class MockDiscovery extends EventEmitter<PeerDiscoveryEvents> implements PeerDiscovery {
   public readonly options: MockDiscoveryOptions
   private _isRunning: boolean
   private _timer: any
@@ -41,10 +42,13 @@ export class MockDiscovery extends EventEmitter {
     PeerIdFactory.createEd25519PeerId()
       .then(peerId => {
         this._timer = setTimeout(() => {
-          this.emit('peer', {
-            id: peerId,
-            multiaddrs: [new Multiaddr('/ip4/127.0.0.1/tcp/8000')]
-          })
+          this.dispatchEvent(new CustomEvent('peer', {
+            detail: {
+              id: peerId,
+              multiaddrs: [new Multiaddr('/ip4/127.0.0.1/tcp/8000')],
+              protocols: []
+            }
+          }))
         }, this.options.discoveryDelay ?? 1000)
       })
       .catch(() => {})

--- a/packages/libp2p-interfaces/package.json
+++ b/packages/libp2p-interfaces/package.json
@@ -214,7 +214,7 @@
   },
   "scripts": {
     "lint": "aegir lint",
-    "dep-check": "aegir dep-check dist/src/**/*.js",
+    "dep-check": "aegir dep-check dist/src/**/*.js dist/test/**/*.js",
     "build": "tsc"
   },
   "dependencies": {

--- a/packages/libp2p-interfaces/src/index.ts
+++ b/packages/libp2p-interfaces/src/index.ts
@@ -21,3 +21,66 @@ export interface Dialer {
 export interface Addressable {
   multiaddrs: Multiaddr[]
 }
+
+interface EventCallback<EventType> { (evt: EventType): void }
+type EventHandler<EventType> = EventCallback<EventType> | ({ handleEvent: EventCallback<EventType> }) | null
+
+/**
+ * Adds types to the EventTarget class. Hopefully this won't be necessary forever.
+ *
+ * https://github.com/microsoft/TypeScript/issues/28357
+ * https://github.com/microsoft/TypeScript/issues/43477
+ * https://github.com/microsoft/TypeScript/issues/299
+ * etc
+ */
+export class EventEmitter<EventMap> extends EventTarget {
+  #listeners: Map<any, number> = new Map()
+
+  listenerCount (type: string) {
+    return this.#listeners.get(type) ?? 0
+  }
+
+  // @ts-expect-error EventTarget is not typed
+  addEventListener<U extends keyof EventMap> (type: U, callback: EventHandler<EventMap[U]>, options?: AddEventListenerOptions | boolean) {
+    // @ts-expect-error EventTarget is not typed
+    super.addEventListener(type, callback)
+
+    const count = this.#listeners.get(type) ?? 0
+
+    this.#listeners.set(type, count + 1)
+  }
+
+  // @ts-expect-error EventTarget is not typed
+  removeEventListener<U extends keyof EventMap> (type: U, callback: EventHandler<EventMap[U]> | undefined, options?: EventListenerOptions | boolean) {
+    // @ts-expect-error EventTarget is not typed
+    super.removeEventListener(type, callback)
+
+    const count = this.#listeners.get(type) ?? 0
+
+    if (count === 1) {
+      this.#listeners.delete(type)
+    } else {
+      this.#listeners.set(type, count - 1)
+    }
+  }
+}
+
+/**
+ * CustomEvent is a standard event but it's not supported by node.
+ *
+ * Remove this when https://github.com/nodejs/node/issues/40678 is closed.
+ *
+ * Ref: https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent
+ */
+class CustomEventPolyfill<T = any> extends Event {
+  /** Returns any custom data event was created with. Typically used for synthetic events. */
+  public detail: T
+
+  constructor (message: string, data?: EventInit & { detail: T }) {
+    super(message, data)
+    // @ts-expect-error could be undefined
+    this.detail = data?.detail
+  }
+}
+
+export const CustomEvent = globalThis.CustomEvent ?? CustomEventPolyfill

--- a/packages/libp2p-interfaces/src/peer-discovery/index.ts
+++ b/packages/libp2p-interfaces/src/peer-discovery/index.ts
@@ -1,26 +1,15 @@
-import type { EventEmitter } from 'events'
 import type { PeerData } from '../peer-data/index.js'
-import type { Startable } from '../index.js'
+import type { EventEmitter, Startable } from '../index.js'
 
 export interface PeerDiscoveryFactory {
   new (options?: any): PeerDiscovery
   tag: string
 }
 
-interface PeerDiscoveryEvents {
-  'peer': PeerData
+export interface PeerDiscoveryEvents {
+  'peer': CustomEvent<PeerData>
 }
 
-export interface PeerDiscovery extends EventEmitter, Startable {
+export interface PeerDiscovery extends EventEmitter<PeerDiscoveryEvents>, Startable {
 
-  on: (<U extends keyof PeerDiscoveryEvents> (event: U, listener: (event: PeerDiscoveryEvents[U]) => void) => this) &
-  ((event: string, listener: (...args: any[]) => void) => this)
-
-  once: (<U extends keyof PeerDiscoveryEvents> (event: U, listener: (event: PeerDiscoveryEvents[U]) => void) => this) &
-  ((event: string, listener: (...args: any[]) => void) => this)
-
-  emit: (<U extends keyof PeerDiscoveryEvents> (name: U, event: PeerDiscoveryEvents[U]) => boolean) &
-  ((name: string, ...args: any[]) => boolean)
 }
-
-export default PeerDiscovery

--- a/packages/libp2p-interfaces/src/peer-store/index.ts
+++ b/packages/libp2p-interfaces/src/peer-store/index.ts
@@ -1,6 +1,6 @@
 import type { PeerId } from '../peer-id/index.js'
 import type { Multiaddr } from '@multiformats/multiaddr'
-import type { EventEmitter } from 'events'
+import type { EventEmitter } from '../index.js'
 import type { Envelope } from '../record/index.js'
 
 export interface Address {
@@ -182,22 +182,26 @@ export interface ProtoBook extends Book<string[]> {
   remove: (peerId: PeerId, protocols: string[]) => Promise<void>
 }
 
-export interface PeerProtocolsChangeEvent {
+export interface PeerData {
+  peerId: PeerId
+}
+
+export interface PeerProtocolsChangeData {
   peerId: PeerId
   protocols: string[]
 }
 
-export interface PeerMultiaddrsChangeEvent {
+export interface PeerMultiaddrsChangeData {
   peerId: PeerId
   multiaddrs: Multiaddr[]
 }
 
-export interface PeerPublicKeyChangeEvent {
+export interface PeerPublicKeyChangeData {
   peerId: PeerId
   pubKey?: Uint8Array
 }
 
-export interface PeerMetadataChangeEvent {
+export interface PeerMetadataChangeData {
   peerId: PeerId
   metadata: Map<string, Uint8Array>
 }
@@ -205,14 +209,14 @@ export interface PeerMetadataChangeEvent {
 export type EventName = 'peer' | 'change:protocols' | 'change:multiaddrs' | 'change:pubkey' | 'change:metadata'
 
 export interface PeerStoreEvents {
-  'peer': (event: PeerId) => void
-  'change:protocols': (event: PeerProtocolsChangeEvent) => void
-  'change:multiaddrs': (event: PeerMultiaddrsChangeEvent) => void
-  'change:pubkey': (event: PeerPublicKeyChangeEvent) => void
-  'change:metadata': (event: PeerMetadataChangeEvent) => void
+  'peer': CustomEvent<PeerData>
+  'change:protocols': CustomEvent<PeerProtocolsChangeData>
+  'change:multiaddrs': CustomEvent<PeerMultiaddrsChangeData>
+  'change:pubkey': CustomEvent<PeerPublicKeyChangeData>
+  'change:metadata': CustomEvent<PeerMetadataChangeData>
 }
 
-export interface PeerStore extends EventEmitter {
+export interface PeerStore extends EventEmitter<PeerStoreEvents> {
   addressBook: AddressBook
   keyBook: KeyBook
   metadataBook: MetadataBook
@@ -222,13 +226,4 @@ export interface PeerStore extends EventEmitter {
   delete: (peerId: PeerId) => Promise<void>
   has: (peerId: PeerId) => Promise<boolean>
   get: (peerId: PeerId) => Promise<Peer>
-  on: <U extends keyof PeerStoreEvents>(
-    event: U, listener: PeerStoreEvents[U]
-  ) => this
-  once: <U extends keyof PeerStoreEvents>(
-    event: U, listener: PeerStoreEvents[U]
-  ) => this
-  emit: <U extends keyof PeerStoreEvents>(
-    event: U, ...args: Parameters<PeerStoreEvents[U]>
-  ) => boolean
 }

--- a/packages/libp2p-interfaces/src/pubsub/index.ts
+++ b/packages/libp2p-interfaces/src/pubsub/index.ts
@@ -1,7 +1,7 @@
 import type { PeerId } from '../peer-id'
 import type { Pushable } from 'it-pushable'
 import type { Registrar } from '../registrar'
-import type { EventEmitter } from 'events'
+import type { EventEmitter, Startable } from '../index.js'
 
 /**
  * On the producing side:
@@ -73,16 +73,16 @@ interface Subscription {
   subscribe: boolean
 }
 
-interface SubscriptionChangeEvent {
+interface SubscriptionChangeData {
   peerId: PeerId
   subscriptions: Subscription[]
 }
 
-interface PubSubEvents {
-  'pubsub:subscription-change': SubscriptionChangeEvent
+export interface PubsubEvents {
+  'pubsub:subscription-change': CustomEvent<SubscriptionChangeData>
 }
 
-export interface PubSub extends EventEmitter {
+export interface PubSub<EventMap extends PubsubEvents> extends EventEmitter<EventMap>, Startable {
   peerId: PeerId
   started: boolean
   peers: Map<string, PeerStreams>
@@ -97,13 +97,10 @@ export interface PubSub extends EventEmitter {
   unsubscribe: (topic: string) => void
   publish: (topic: string, data: Uint8Array) => Promise<void>
   validate: (message: Message) => Promise<void>
+}
 
-  on: (<U extends keyof PubSubEvents> (event: U, listener: (event: PubSubEvents[U]) => void) => this) &
-  ((event: string, listener: (event: Message) => void) => this)
-
-  once: (<U extends keyof PubSubEvents> (event: U, listener: (event: PubSubEvents[U]) => void) => this) &
-  ((event: string, listener: (event: Message) => void) => this)
-
-  emit: (<U extends keyof PubSubEvents> (name: U, event: PubSubEvents[U]) => boolean) &
-  ((name: string, event: Message) => boolean)
+export interface PeerStreamEvents {
+  'stream:inbound': CustomEvent<never>
+  'stream:outbound': CustomEvent<never>
+  'close': CustomEvent<never>
 }

--- a/packages/libp2p-interfaces/src/registrar/index.ts
+++ b/packages/libp2p-interfaces/src/registrar/index.ts
@@ -1,6 +1,6 @@
-import type { Connection, Stream } from '../connection'
-import type { PeerId } from '../peer-id'
-import type { PeerStore } from '../peer-store'
+import type { EventEmitter } from '../index.js'
+import type { Connection, Stream } from '../connection/index.js'
+import type { PeerId } from '../peer-id/index.js'
 
 export interface IncomingStreamEvent {
   protocol: string
@@ -8,16 +8,17 @@ export interface IncomingStreamEvent {
   connection: Connection
 }
 
+export interface ConnectionManagerEvents {
+  'peer:connect': CustomEvent<Connection>
+}
+
+export interface ConnectionManager extends EventEmitter<ConnectionManagerEvents> {
+  getConnection: (peerId: PeerId) => Connection | undefined
+}
+
 export interface Registrar {
   handle: (multicodec: string | string[], handler: (event: IncomingStreamEvent) => void) => void
   unhandle: (multicodec: string) => void
-
   register: (topology: any) => string
   unregister: (id: string) => void
-  getConnection: (peerId: PeerId) => Connection | undefined
-  peerStore: PeerStore
-
-  connectionManager: {
-    on: (event: 'peer:connect', handler: (connection: Connection) => void) => void
-  }
 }

--- a/packages/libp2p-interfaces/src/topology/index.ts
+++ b/packages/libp2p-interfaces/src/topology/index.ts
@@ -1,5 +1,7 @@
-import type { PeerId } from '../peer-id'
-import type { Connection } from '../connection'
+import type { PeerId } from '../peer-id/index.js'
+import type { Connection } from '../connection/index.js'
+import type { ConnectionManager } from '../registrar/index.js'
+import type { PeerStore } from '../peer-store/index.js'
 
 export interface onConnectHandler { (peerId: PeerId, conn: Connection): void }
 export interface onDisconnectHandler { (peerId: PeerId, conn?: Connection): void }
@@ -32,6 +34,8 @@ export interface Topology {
 
 export interface MulticodecTopologyOptions extends TopologyOptions {
   multicodecs: string[]
+  peerStore: PeerStore
+  connectionManager: ConnectionManager
 }
 
 export interface MulticodecTopology extends Topology {

--- a/packages/libp2p-interfaces/src/transport/index.ts
+++ b/packages/libp2p-interfaces/src/transport/index.ts
@@ -1,7 +1,6 @@
-import type { EventEmitter } from 'events'
+import type { EventEmitter, AbortOptions } from '../index.js'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Connection } from '../connection/index.js'
-import type { AbortOptions } from '../index.js'
 import type { Duplex } from 'it-stream-types'
 
 export interface TransportFactory<DialOptions extends { signal?: AbortSignal }, ListenerOptions> {
@@ -34,7 +33,14 @@ export interface Transport <DialOptions extends AbortOptions = AbortOptions, Cre
   filter: MultiaddrFilter
 }
 
-export interface Listener extends EventEmitter {
+export interface ListenerEvents {
+  'connection': CustomEvent<Connection>
+  'listening': CustomEvent<Connection>
+  'error': CustomEvent<Error>
+  'close': CustomEvent<Connection>
+}
+
+export interface Listener extends EventEmitter<ListenerEvents> {
   /**
    * Start a listener
    */

--- a/packages/libp2p-logger/package.json
+++ b/packages/libp2p-logger/package.json
@@ -120,7 +120,7 @@
   },
   "scripts": {
     "lint": "aegir lint",
-    "dep-check": "aegir dep-check dist/src/**/*.js",
+    "dep-check": "aegir dep-check dist/src/**/*.js dist/test/**/*.js",
     "build": "tsc",
     "pretest": "npm run build",
     "test": "aegir test -f ./dist/test/**/*.js",

--- a/packages/libp2p-logger/package.json
+++ b/packages/libp2p-logger/package.json
@@ -123,7 +123,7 @@
     "dep-check": "aegir dep-check dist/src/**/*.js dist/test/**/*.js",
     "build": "tsc",
     "pretest": "npm run build",
-    "test": "aegir test -f ./dist/test/**/*.js",
+    "test": "aegir test -f ./dist/test/*.js -f ./dist/test/**/*.js",
     "test:chrome": "npm run test -- -t browser",
     "test:chrome-webworker": "npm run test -- -t webworker",
     "test:firefox": "npm run test -- -t browser -- --browser firefox",

--- a/packages/libp2p-peer-id-factory/package.json
+++ b/packages/libp2p-peer-id-factory/package.json
@@ -124,7 +124,7 @@
   },
   "scripts": {
     "lint": "aegir lint",
-    "dep-check": "aegir dep-check dist/src/**/*.js",
+    "dep-check": "aegir dep-check dist/src/**/*.js dist/test/**/*.js",
     "build": "tsc",
     "pretest": "npm run build",
     "test": "aegir test -f ./dist/test/**/*.js",

--- a/packages/libp2p-peer-id-factory/package.json
+++ b/packages/libp2p-peer-id-factory/package.json
@@ -127,7 +127,7 @@
     "dep-check": "aegir dep-check dist/src/**/*.js dist/test/**/*.js",
     "build": "tsc",
     "pretest": "npm run build",
-    "test": "aegir test -f ./dist/test/**/*.js",
+    "test": "aegir test -f ./dist/test/*.js -f ./dist/test/**/*.js",
     "test:chrome": "npm run test -- -t browser",
     "test:chrome-webworker": "npm run test -- -t webworker",
     "test:firefox": "npm run test -- -t browser -- --browser firefox",

--- a/packages/libp2p-peer-id/package.json
+++ b/packages/libp2p-peer-id/package.json
@@ -120,7 +120,7 @@
   },
   "scripts": {
     "lint": "aegir lint",
-    "dep-check": "aegir dep-check dist/src/**/*.js",
+    "dep-check": "aegir dep-check dist/src/**/*.js dist/test/**/*.js",
     "build": "tsc",
     "pretest": "npm run build",
     "test": "aegir test -f ./dist/test/**/*.js",

--- a/packages/libp2p-peer-id/package.json
+++ b/packages/libp2p-peer-id/package.json
@@ -123,7 +123,7 @@
     "dep-check": "aegir dep-check dist/src/**/*.js dist/test/**/*.js",
     "build": "tsc",
     "pretest": "npm run build",
-    "test": "aegir test -f ./dist/test/**/*.js",
+    "test": "aegir test -f ./dist/test/*.js -f ./dist/test/**/*.js",
     "test:chrome": "npm run test -- -t browser",
     "test:chrome-webworker": "npm run test -- -t webworker",
     "test:firefox": "npm run test -- -t browser -- --browser firefox",

--- a/packages/libp2p-peer-record/package.json
+++ b/packages/libp2p-peer-record/package.json
@@ -136,7 +136,7 @@
     "generate:peer-record-types": "pbts -o src/peer-record/peer-record.d.ts src/peer-record/peer-record.js",
     "build:copy-proto-files": "cp src/envelope/envelope.js dist/src/envelope && cp src/envelope/*.d.ts dist/src/envelope && cp src/peer-record/peer-record.js dist/src/peer-record && cp src/peer-record/*.d.ts dist/src/peer-record",
     "pretest": "npm run build",
-    "test": "aegir test -f ./dist/test",
+    "test": "aegir test -f ./dist/test/*.js -f ./dist/test/**/*.js",
     "test:chrome": "npm run test -- -t browser",
     "test:chrome-webworker": "npm run test -- -t webworker",
     "test:firefox": "npm run test -- -t browser -- --browser firefox",

--- a/packages/libp2p-peer-record/package.json
+++ b/packages/libp2p-peer-record/package.json
@@ -126,7 +126,7 @@
   },
   "scripts": {
     "lint": "aegir lint",
-    "dep-check": "aegir dep-check dist/src/**/*.js",
+    "dep-check": "aegir dep-check dist/src/**/*.js dist/test/**/*.js",
     "build": "tsc",
     "postbuild": "npm run build:copy-proto-files",
     "generate": "npm run generate:envelope && npm run generate:envelope-types && npm run generate:peer-record && npm run generate:peer-record-types",

--- a/packages/libp2p-peer-store/package.json
+++ b/packages/libp2p-peer-store/package.json
@@ -124,7 +124,7 @@
   },
   "scripts": {
     "lint": "aegir lint",
-    "dep-check": "aegir dep-check dist/src/**/*.js",
+    "dep-check": "aegir dep-check dist/src/**/*.js dist/test/**/*.js",
     "build": "tsc",
     "postbuild": "npm run build:copy-proto-files",
     "generate": "npm run generate:proto && npm run generate:proto-types && tsc",
@@ -156,8 +156,16 @@
     "protobufjs": "^6.10.2"
   },
   "devDependencies": {
+    "@libp2p/interface-compliance-tests": "^1.1.0",
+    "@libp2p/peer-id": "^1.1.0",
+    "@libp2p/peer-id-factory": "^1.0.3",
+    "@libp2p/utils": "^1.0.5",
     "aegir": "^36.1.3",
     "datastore-core": "^7.0.1",
-    "sinon": "^13.0.1"
+    "err-code": "^3.0.1",
+    "p-defer": "^4.0.0",
+    "p-wait-for": "^4.1.0",
+    "sinon": "^13.0.1",
+    "uint8arrays": "^3.0.0"
   }
 }

--- a/packages/libp2p-peer-store/package.json
+++ b/packages/libp2p-peer-store/package.json
@@ -132,7 +132,7 @@
     "generate:proto-types": "pbts -o src/pb/peer.d.ts src/pb/peer.js",
     "build:copy-proto-files": "mkdirp dist/src/pb && cp src/pb/*.js dist/src/pb && cp src/pb/*.d.ts dist/src/pb",
     "pretest": "npm run build",
-    "test": "aegir test -f ./dist/test",
+    "test": "aegir test -f ./dist/test/*.js -f ./dist/test/**/*.js",
     "test:chrome": "npm run test -- -t browser",
     "test:chrome-webworker": "npm run test -- -t webworker",
     "test:firefox": "npm run test -- -t browser -- --browser firefox",

--- a/packages/libp2p-peer-store/src/address-book.ts
+++ b/packages/libp2p-peer-store/src/address-book.ts
@@ -10,6 +10,7 @@ import map from 'it-map'
 import each from 'it-foreach'
 import { base58btc } from 'multiformats/bases/base58'
 import { PeerId } from '@libp2p/peer-id'
+import { CustomEvent } from '@libp2p/interfaces'
 import type { PeerStore } from '@libp2p/interfaces/peer-store'
 import type { Store } from './store.js'
 import type { AddressFilter, AddressSorter } from './index.js'
@@ -23,12 +24,12 @@ async function allowAll () {
 }
 
 export class PeerStoreAddressBook {
-  private readonly emit: PeerStore['emit']
+  private readonly dispatchEvent: PeerStore['dispatchEvent']
   private readonly store: Store
   private readonly addressFilter: AddressFilter
 
-  constructor (emit: PeerStore['emit'], store: Store, addressFilter?: AddressFilter) {
-    this.emit = emit
+  constructor (dispatchEvent: PeerStore['dispatchEvent'], store: Store, addressFilter?: AddressFilter) {
+    this.dispatchEvent = dispatchEvent
     this.store = store
     this.addressFilter = addressFilter ?? allowAll
   }
@@ -96,7 +97,9 @@ export class PeerStoreAddressBook {
       release()
     }
 
-    this.emit(EVENT_NAME, { peerId, multiaddrs: updatedPeer.addresses.map(({ multiaddr }) => multiaddr) })
+    this.dispatchEvent(new CustomEvent(EVENT_NAME, {
+      detail: { peerId, multiaddrs: updatedPeer.addresses.map(({ multiaddr }) => multiaddr) }
+    }))
 
     return true
   }
@@ -205,11 +208,17 @@ export class PeerStoreAddressBook {
       release()
     }
 
-    this.emit(EVENT_NAME, { peerId, multiaddrs: updatedPeer.addresses.map(addr => addr.multiaddr) })
+    this.dispatchEvent(new CustomEvent(EVENT_NAME, {
+      detail: { peerId, multiaddrs: updatedPeer.addresses.map(addr => addr.multiaddr) }
+    }))
 
     // Notify the existence of a new peer
     if (!hasPeer) {
-      this.emit('peer', peerId)
+      this.dispatchEvent(new CustomEvent('peer', {
+        detail: {
+          peerId
+        }
+      }))
     }
   }
 
@@ -260,11 +269,15 @@ export class PeerStoreAddressBook {
       release()
     }
 
-    this.emit(EVENT_NAME, { peerId, multiaddrs: updatedPeer.addresses.map(addr => addr.multiaddr) })
+    this.dispatchEvent(new CustomEvent(EVENT_NAME, {
+      detail: { peerId, multiaddrs: updatedPeer.addresses.map(addr => addr.multiaddr) }
+    }))
 
     // Notify the existence of a new peer
     if (hasPeer === true) {
-      this.emit('peer', peerId)
+      this.dispatchEvent(new CustomEvent('peer', {
+        detail: { peerId }
+      }))
     }
   }
 
@@ -289,7 +302,9 @@ export class PeerStoreAddressBook {
     }
 
     if (has) {
-      this.emit(EVENT_NAME, { peerId, multiaddrs: [] })
+      this.dispatchEvent(new CustomEvent(EVENT_NAME, {
+        detail: { peerId, multiaddrs: [] }
+      }))
     }
   }
 

--- a/packages/libp2p-peer-store/src/index.ts
+++ b/packages/libp2p-peer-store/src/index.ts
@@ -1,11 +1,11 @@
 import { logger } from '@libp2p/logger'
-import { EventEmitter } from 'events'
+import { EventEmitter } from '@libp2p/interfaces'
 import { PeerStoreAddressBook } from './address-book.js'
 import { PeerStoreKeyBook } from './key-book.js'
 import { PeerStoreMetadataBook } from './metadata-book.js'
 import { PeerStoreProtoBook } from './proto-book.js'
 import { PersistentStore, Store } from './store.js'
-import type { PeerStore, Address, AddressBook, KeyBook, MetadataBook, ProtoBook } from '@libp2p/interfaces/peer-store'
+import type { PeerStore, Address, AddressBook, KeyBook, MetadataBook, ProtoBook, PeerStoreEvents } from '@libp2p/interfaces/peer-store'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Datastore } from 'interface-datastore'
@@ -30,7 +30,7 @@ export interface PeerStoreOptions {
 /**
  * An implementation of PeerStore that stores data in a Datastore
  */
-export class DefaultPeerStore extends EventEmitter implements PeerStore {
+export class DefaultPeerStore extends EventEmitter<PeerStoreEvents> implements PeerStore {
   public addressBook: AddressBook
   public keyBook: KeyBook
   public metadataBook: MetadataBook
@@ -47,10 +47,10 @@ export class DefaultPeerStore extends EventEmitter implements PeerStore {
     this.peerId = peerId
     this.store = new PersistentStore(datastore)
 
-    this.addressBook = new PeerStoreAddressBook(this.emit.bind(this), this.store, addressFilter)
-    this.keyBook = new PeerStoreKeyBook(this.emit.bind(this), this.store)
-    this.metadataBook = new PeerStoreMetadataBook(this.emit.bind(this), this.store)
-    this.protoBook = new PeerStoreProtoBook(this.emit.bind(this), this.store)
+    this.addressBook = new PeerStoreAddressBook(this.dispatchEvent.bind(this), this.store, addressFilter)
+    this.keyBook = new PeerStoreKeyBook(this.dispatchEvent.bind(this), this.store)
+    this.metadataBook = new PeerStoreMetadataBook(this.dispatchEvent.bind(this), this.store)
+    this.protoBook = new PeerStoreProtoBook(this.dispatchEvent.bind(this), this.store)
   }
 
   async * getPeers () {

--- a/packages/libp2p-peer-store/src/key-book.ts
+++ b/packages/libp2p-peer-store/src/key-book.ts
@@ -3,6 +3,7 @@ import errcode from 'err-code'
 import { codes } from './errors.js'
 import { PeerId } from '@libp2p/peer-id'
 import { equals as uint8arrayEquals } from 'uint8arrays/equals'
+import { CustomEvent } from '@libp2p/interfaces'
 import type { Store } from './store.js'
 import type { PeerStore, KeyBook } from '@libp2p/interfaces/src/peer-store'
 
@@ -17,14 +18,14 @@ const log = logger('libp2p:peer-store:key-book')
 const EVENT_NAME = 'change:pubkey'
 
 export class PeerStoreKeyBook implements KeyBook {
-  private readonly emit: PeerStore['emit']
+  private readonly dispatchEvent: PeerStore['dispatchEvent']
   private readonly store: Store
 
   /**
    * The KeyBook is responsible for keeping the known public keys of a peer
    */
-  constructor (emit: PeerStore['emit'], store: Store) {
-    this.emit = emit
+  constructor (dispatchEvent: PeerStore['dispatchEvent'], store: Store) {
+    this.dispatchEvent = dispatchEvent
     this.store = store
   }
 
@@ -68,7 +69,9 @@ export class PeerStoreKeyBook implements KeyBook {
     }
 
     if (updatedKey) {
-      this.emit(EVENT_NAME, { peerId, pubKey: publicKey })
+      this.dispatchEvent(new CustomEvent(EVENT_NAME, {
+        detail: { peerId, pubKey: publicKey }
+      }))
     }
   }
 
@@ -112,6 +115,8 @@ export class PeerStoreKeyBook implements KeyBook {
       release()
     }
 
-    this.emit(EVENT_NAME, { peerId, pubKey: undefined })
+    this.dispatchEvent(new CustomEvent(EVENT_NAME, {
+      detail: { peerId, pubKey: undefined }
+    }))
   }
 }

--- a/packages/libp2p-peer-store/src/metadata-book.ts
+++ b/packages/libp2p-peer-store/src/metadata-book.ts
@@ -3,6 +3,7 @@ import errcode from 'err-code'
 import { codes } from './errors.js'
 import { PeerId } from '@libp2p/peer-id'
 import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
+import { CustomEvent } from '@libp2p/interfaces'
 import type { Store } from './store.js'
 import type { PeerStore, MetadataBook } from '@libp2p/interfaces/src/peer-store'
 
@@ -11,15 +12,15 @@ const log = logger('libp2p:peer-store:metadata-book')
 const EVENT_NAME = 'change:metadata'
 
 export class PeerStoreMetadataBook implements MetadataBook {
-  private readonly emit: PeerStore['emit']
+  private readonly dispatchEvent: PeerStore['dispatchEvent']
   private readonly store: Store
 
   /**
    * The MetadataBook is responsible for keeping metadata
    * about known peers
    */
-  constructor (emit: PeerStore['emit'], store: Store) {
-    this.emit = emit
+  constructor (dispatchEvent: PeerStore['dispatchEvent'], store: Store) {
+    this.dispatchEvent = dispatchEvent
     this.store = store
   }
 
@@ -94,7 +95,9 @@ export class PeerStoreMetadataBook implements MetadataBook {
       release()
     }
 
-    this.emit(EVENT_NAME, { peerId, metadata })
+    this.dispatchEvent(new CustomEvent(EVENT_NAME, {
+      detail: { peerId, metadata }
+    }))
   }
 
   /**
@@ -136,7 +139,9 @@ export class PeerStoreMetadataBook implements MetadataBook {
       release()
     }
 
-    this.emit(EVENT_NAME, { peerId, metadata: updatedPeer.metadata })
+    this.dispatchEvent(new CustomEvent(EVENT_NAME, {
+      detail: { peerId, metadata: updatedPeer.metadata }
+    }))
   }
 
   async delete (peerId: PeerId) {
@@ -162,7 +167,9 @@ export class PeerStoreMetadataBook implements MetadataBook {
     }
 
     if (has) {
-      this.emit(EVENT_NAME, { peerId, metadata: new Map() })
+      this.dispatchEvent(new CustomEvent(EVENT_NAME, {
+        detail: { peerId, metadata: new Map() }
+      }))
     }
   }
 
@@ -194,7 +201,9 @@ export class PeerStoreMetadataBook implements MetadataBook {
     }
 
     if (metadata != null) {
-      this.emit(EVENT_NAME, { peerId, metadata })
+      this.dispatchEvent(new CustomEvent(EVENT_NAME, {
+        detail: { peerId, metadata }
+      }))
     }
   }
 }

--- a/packages/libp2p-peer-store/src/proto-book.ts
+++ b/packages/libp2p-peer-store/src/proto-book.ts
@@ -2,24 +2,25 @@ import { logger } from '@libp2p/logger'
 import errcode from 'err-code'
 import { codes } from './errors.js'
 import { PeerId } from '@libp2p/peer-id'
+import { base58btc } from 'multiformats/bases/base58'
+import { CustomEvent } from '@libp2p/interfaces'
 import type { Store } from './store.js'
 import type { PeerStore, ProtoBook } from '@libp2p/interfaces/src/peer-store'
-import { base58btc } from 'multiformats/bases/base58'
 
 const log = logger('libp2p:peer-store:proto-book')
 
 const EVENT_NAME = 'change:protocols'
 
 export class PeerStoreProtoBook implements ProtoBook {
-  private readonly emit: PeerStore['emit']
+  private readonly dispatchEvent: PeerStore['dispatchEvent']
   private readonly store: Store
 
   /**
    * The ProtoBook is responsible for keeping the known supported
    * protocols of a peer
    */
-  constructor (emit: PeerStore['emit'], store: Store) {
-    this.emit = emit
+  constructor (dispatchEvent: PeerStore['dispatchEvent'], store: Store) {
+    this.dispatchEvent = dispatchEvent
     this.store = store
   }
 
@@ -83,7 +84,9 @@ export class PeerStoreProtoBook implements ProtoBook {
       release()
     }
 
-    this.emit(EVENT_NAME, { peerId, protocols: updatedPeer.protocols })
+    this.dispatchEvent(new CustomEvent(EVENT_NAME, {
+      detail: { peerId, protocols: updatedPeer.protocols }
+    }))
   }
 
   async add (peerId: PeerId, protocols: string[]) {
@@ -126,7 +129,9 @@ export class PeerStoreProtoBook implements ProtoBook {
       release()
     }
 
-    this.emit(EVENT_NAME, { peerId, protocols: updatedPeer.protocols })
+    this.dispatchEvent(new CustomEvent(EVENT_NAME, {
+      detail: { peerId, protocols: updatedPeer.protocols }
+    }))
   }
 
   async remove (peerId: PeerId, protocols: string[]) {
@@ -171,7 +176,9 @@ export class PeerStoreProtoBook implements ProtoBook {
       release()
     }
 
-    this.emit(EVENT_NAME, { peerId, protocols: updatedPeer.protocols })
+    this.dispatchEvent(new CustomEvent(EVENT_NAME, {
+      detail: { peerId, protocols: updatedPeer.protocols }
+    }))
   }
 
   async delete (peerId: PeerId) {
@@ -198,7 +205,9 @@ export class PeerStoreProtoBook implements ProtoBook {
     }
 
     if (has === true) {
-      this.emit(EVENT_NAME, { peerId, protocols: [] })
+      this.dispatchEvent(new CustomEvent(EVENT_NAME, {
+        detail: { peerId, protocols: [] }
+      }))
     }
   }
 }

--- a/packages/libp2p-peer-store/test/address-book.spec.ts
+++ b/packages/libp2p-peer-store/test/address-book.spec.ts
@@ -47,10 +47,6 @@ describe('addressBook', () => {
       ab = peerStore.addressBook
     })
 
-    afterEach(() => {
-      peerStore.removeAllListeners()
-    })
-
     it('throws invalid parameters error if invalid PeerId is provided', async () => {
       try {
         // @ts-expect-error invalid input
@@ -88,10 +84,13 @@ describe('addressBook', () => {
       const defer = pDefer()
       const supportedMultiaddrs = [addr1, addr2]
 
-      peerStore.once('change:multiaddrs', ({ peerId, multiaddrs }) => {
+      peerStore.addEventListener('change:multiaddrs', (evt) => {
+        const { peerId, multiaddrs } = evt.detail
         expect(peerId).to.exist()
         expect(multiaddrs).to.eql(supportedMultiaddrs)
         defer.resolve()
+      }, {
+        once: true
       })
 
       await ab.set(peerId, supportedMultiaddrs)
@@ -109,7 +108,7 @@ describe('addressBook', () => {
       const supportedMultiaddrsB = [addr2]
 
       let changeCounter = 0
-      peerStore.on('change:multiaddrs', () => {
+      peerStore.addEventListener('change:multiaddrs', () => {
         changeCounter++
         if (changeCounter > 1) {
           defer.resolve()
@@ -134,7 +133,7 @@ describe('addressBook', () => {
       const supportedMultiaddrs = [addr1, addr2]
 
       let changeCounter = 0
-      peerStore.on('change:multiaddrs', () => {
+      peerStore.addEventListener('change:multiaddrs', () => {
         changeCounter++
         if (changeCounter > 1) {
           defer.reject()
@@ -167,10 +166,6 @@ describe('addressBook', () => {
         addressFilter: connectionGater.filterMultiaddrForPeer
       })
       ab = peerStore.addressBook
-    })
-
-    afterEach(() => {
-      peerStore.removeAllListeners()
     })
 
     it('throws invalid parameters error if invalid PeerId is provided', async () => {
@@ -209,7 +204,7 @@ describe('addressBook', () => {
     it('does not emit event if no addresses are added', async () => {
       const defer = pDefer()
 
-      peerStore.on('peer', () => {
+      peerStore.addEventListener('peer', () => {
         defer.reject()
       })
 
@@ -231,7 +226,8 @@ describe('addressBook', () => {
       const finalMultiaddrs = supportedMultiaddrsA.concat(supportedMultiaddrsB)
 
       let changeTrigger = 2
-      peerStore.on('change:multiaddrs', ({ multiaddrs }) => {
+      peerStore.addEventListener('change:multiaddrs', (evt) => {
+        const { multiaddrs } = evt.detail
         changeTrigger--
         if (changeTrigger === 0 && arrayEquals(multiaddrs, finalMultiaddrs)) {
           defer.resolve()
@@ -261,7 +257,7 @@ describe('addressBook', () => {
       const finalMultiaddrs = supportedMultiaddrsA.concat(supportedMultiaddrsB)
 
       let changeCounter = 0
-      peerStore.on('change:multiaddrs', () => {
+      peerStore.addEventListener('change:multiaddrs', () => {
         changeCounter++
         if (changeCounter > 1) {
           defer.resolve()
@@ -287,7 +283,7 @@ describe('addressBook', () => {
       const supportedMultiaddrsB = [addr2]
 
       let changeCounter = 0
-      peerStore.on('change:multiaddrs', () => {
+      peerStore.addEventListener('change:multiaddrs', () => {
         changeCounter++
         if (changeCounter > 1) {
           defer.reject()
@@ -439,7 +435,7 @@ describe('addressBook', () => {
     it('does not emit an event if no records exist for the peer', async () => {
       const defer = pDefer()
 
-      peerStore.on('change:multiaddrs', () => {
+      peerStore.addEventListener('change:multiaddrs', () => {
         defer.reject()
       })
 
@@ -460,7 +456,8 @@ describe('addressBook', () => {
       await ab.set(peerId, supportedMultiaddrs)
 
       // Listen after set
-      peerStore.on('change:multiaddrs', ({ multiaddrs }) => {
+      peerStore.addEventListener('change:multiaddrs', (evt) => {
+        const { multiaddrs } = evt.detail
         expect(multiaddrs.length).to.eql(0)
         defer.resolve()
       })
@@ -516,10 +513,13 @@ describe('addressBook', () => {
         })
         const envelope = await RecordEnvelope.seal(peerRecord, peerId)
 
-        peerStore.once('change:multiaddrs', ({ peerId, multiaddrs }) => {
+        peerStore.addEventListener('change:multiaddrs', (evt) => {
+          const { peerId, multiaddrs } = evt.detail
           expect(peerId).to.exist()
           expect(multiaddrs).to.eql(multiaddrs)
           defer.resolve()
+        }, {
+          once: true
         })
 
         // consume peer record
@@ -553,10 +553,13 @@ describe('addressBook', () => {
         })
         const envelope = await RecordEnvelope.seal(peerRecord, peerId)
 
-        peerStore.once('change:multiaddrs', ({ peerId, multiaddrs }) => {
+        peerStore.addEventListener('change:multiaddrs', (evt) => {
+          const { peerId, multiaddrs } = evt.detail
           expect(peerId).to.exist()
           expect(multiaddrs).to.eql(multiaddrs)
           defer.resolve()
+        }, {
+          once: true
         })
 
         // consume peer record
@@ -597,10 +600,13 @@ describe('addressBook', () => {
         })
         const envelope = await RecordEnvelope.seal(peerRecord, peerId)
 
-        peerStore.once('change:multiaddrs', ({ peerId, multiaddrs }) => {
+        peerStore.addEventListener('change:multiaddrs', (evt) => {
+          const { peerId, multiaddrs } = evt.detail
           expect(peerId).to.exist()
           expect(multiaddrs).to.eql(multiaddrs)
           defer.resolve()
+        }, {
+          once: true
         })
 
         // consume peer record
@@ -644,10 +650,13 @@ describe('addressBook', () => {
         })
         const envelope = await RecordEnvelope.seal(peerRecord, peerId)
 
-        peerStore.once('change:multiaddrs', ({ peerId, multiaddrs }) => {
+        peerStore.addEventListener('change:multiaddrs', (evt) => {
+          const { peerId, multiaddrs } = evt.detail
           expect(peerId).to.exist()
           expect(multiaddrs).to.eql(multiaddrs)
           defer.resolve()
+        }, {
+          once: true
         })
 
         // consume peer record

--- a/packages/libp2p-peer-store/test/key-book.spec.ts
+++ b/packages/libp2p-peer-store/test/key-book.spec.ts
@@ -85,7 +85,8 @@ describe('keyBook', () => {
   it('should emit an event when setting a key', async () => {
     const defer = pDefer()
 
-    peerStore.on('change:pubkey', ({ peerId: id, pubKey }) => {
+    peerStore.addEventListener('change:pubkey', (evt) => {
+      const { peerId: id, pubKey } = evt.detail
       if (peerId.publicKey == null) {
         throw new Error('Public key was missing')
       }
@@ -124,7 +125,8 @@ describe('keyBook', () => {
 
     await kb.set(peerId, peerId.publicKey)
 
-    peerStore.on('change:pubkey', ({ peerId: id, pubKey }) => {
+    peerStore.addEventListener('change:pubkey', (evt) => {
+      const { peerId: id, pubKey } = evt.detail
       expect(id.toString(base58btc)).to.equal(peerId.toString(base58btc))
       expect(pubKey).to.be.undefined()
       defer.resolve()

--- a/packages/libp2p-peer-store/test/metadata-book.spec.ts
+++ b/packages/libp2p-peer-store/test/metadata-book.spec.ts
@@ -30,10 +30,6 @@ describe('metadataBook', () => {
       mb = peerStore.metadataBook
     })
 
-    afterEach(() => {
-      peerStore.removeAllListeners()
-    })
-
     it('throws invalid parameters error if invalid PeerId is provided', async () => {
       try {
         // @ts-expect-error invalid input
@@ -83,10 +79,13 @@ describe('metadataBook', () => {
       const metadataKey = 'location'
       const metadataValue = uint8ArrayFromString('mars')
 
-      peerStore.once('change:metadata', ({ peerId, metadata }) => {
+      peerStore.addEventListener('change:metadata', (evt) => {
+        const { peerId, metadata } = evt.detail
         expect(peerId).to.exist()
         expect(metadata.get(metadataKey)).to.equalBytes(metadataValue)
         defer.resolve()
+      }, {
+        once: true
       })
 
       await mb.setValue(peerId, metadataKey, metadataValue)
@@ -108,7 +107,7 @@ describe('metadataBook', () => {
       const metadataValue2 = uint8ArrayFromString('saturn')
 
       let changeCounter = 0
-      peerStore.on('change:metadata', () => {
+      peerStore.addEventListener('change:metadata', () => {
         changeCounter++
         if (changeCounter > 1) {
           defer.resolve()
@@ -137,7 +136,7 @@ describe('metadataBook', () => {
       const metadataValue = uint8ArrayFromString('mars')
 
       let changeCounter = 0
-      peerStore.on('change:metadata', () => {
+      peerStore.addEventListener('change:metadata', () => {
         changeCounter++
         if (changeCounter > 1) {
           defer.reject()
@@ -281,7 +280,7 @@ describe('metadataBook', () => {
     it('should not emit event if no records exist for the peer', async () => {
       const defer = pDefer()
 
-      peerStore.on('change:metadata', () => {
+      peerStore.addEventListener('change:metadata', () => {
         defer.reject()
       })
 
@@ -303,7 +302,7 @@ describe('metadataBook', () => {
       await mb.setValue(peerId, metadataKey, metadataValue)
 
       // Listen after set
-      peerStore.on('change:metadata', () => {
+      peerStore.addEventListener('change:metadata', () => {
         defer.resolve()
       })
 
@@ -340,7 +339,7 @@ describe('metadataBook', () => {
       const defer = pDefer()
       const metadataKey = 'location'
 
-      peerStore.on('change:metadata', () => {
+      peerStore.addEventListener('change:metadata', () => {
         defer.reject()
       })
 
@@ -362,7 +361,7 @@ describe('metadataBook', () => {
       await mb.setValue(peerId, metadataKey, metadataValue)
 
       // Listen after set
-      peerStore.on('change:metadata', () => {
+      peerStore.addEventListener('change:metadata', () => {
         defer.resolve()
       })
 

--- a/packages/libp2p-peer-store/test/proto-book.spec.ts
+++ b/packages/libp2p-peer-store/test/proto-book.spec.ts
@@ -38,10 +38,6 @@ describe('protoBook', () => {
       pb = peerStore.protoBook
     })
 
-    afterEach(() => {
-      peerStore.removeAllListeners()
-    })
-
     it('throws invalid parameters error if invalid PeerId is provided', async () => {
       // @ts-expect-error invalid input
       await expect(pb.set('invalid peerId')).to.eventually.be.rejected().with.property('code', codes.ERR_INVALID_PARAMETERS)
@@ -56,10 +52,13 @@ describe('protoBook', () => {
       const defer = pDefer()
       const supportedProtocols = ['protocol1', 'protocol2']
 
-      peerStore.once('change:protocols', ({ peerId, protocols }) => {
+      peerStore.addEventListener('change:protocols', (evt) => {
+        const { peerId, protocols } = evt.detail
         expect(peerId).to.exist()
         expect(protocols).to.have.deep.members(supportedProtocols)
         defer.resolve()
+      }, {
+        once: true
       })
 
       await pb.set(peerId, supportedProtocols)
@@ -76,7 +75,7 @@ describe('protoBook', () => {
       const supportedProtocolsB = ['protocol2']
 
       let changeCounter = 0
-      peerStore.on('change:protocols', () => {
+      peerStore.addEventListener('change:protocols', () => {
         changeCounter++
         if (changeCounter > 1) {
           defer.resolve()
@@ -100,7 +99,7 @@ describe('protoBook', () => {
       const supportedProtocols = ['protocol1', 'protocol2']
 
       let changeCounter = 0
-      peerStore.on('change:protocols', () => {
+      peerStore.addEventListener('change:protocols', () => {
         changeCounter++
         if (changeCounter > 1) {
           defer.reject()
@@ -134,10 +133,6 @@ describe('protoBook', () => {
       pb = peerStore.protoBook
     })
 
-    afterEach(() => {
-      peerStore.removeAllListeners()
-    })
-
     it('throws invalid parameters error if invalid PeerId is provided', async () => {
       // @ts-expect-error invalid input
       await expect(pb.add('invalid peerId')).to.eventually.be.rejected().with.property('code', codes.ERR_INVALID_PARAMETERS)
@@ -156,7 +151,8 @@ describe('protoBook', () => {
       const finalProtocols = supportedProtocolsA.concat(supportedProtocolsB)
 
       let changeTrigger = 2
-      peerStore.on('change:protocols', ({ protocols }) => {
+      peerStore.addEventListener('change:protocols', (evt) => {
+        const { protocols } = evt.detail
         changeTrigger--
         if (changeTrigger === 0 && arraysAreEqual(protocols, finalProtocols)) {
           defer.resolve()
@@ -184,7 +180,7 @@ describe('protoBook', () => {
       const finalProtocols = supportedProtocolsA.concat(supportedProtocolsB)
 
       let changeCounter = 0
-      peerStore.on('change:protocols', () => {
+      peerStore.addEventListener('change:protocols', () => {
         changeCounter++
         if (changeCounter > 1) {
           defer.resolve()
@@ -209,7 +205,7 @@ describe('protoBook', () => {
       const supportedProtocolsB = ['protocol2']
 
       let changeCounter = 0
-      peerStore.on('change:protocols', () => {
+      peerStore.addEventListener('change:protocols', () => {
         changeCounter++
         if (changeCounter > 1) {
           defer.reject()
@@ -243,10 +239,6 @@ describe('protoBook', () => {
       pb = peerStore.protoBook
     })
 
-    afterEach(() => {
-      peerStore.removeAllListeners()
-    })
-
     it('throws invalid parameters error if invalid PeerId is provided', async () => {
       // @ts-expect-error invalid input
       await expect(pb.remove('invalid peerId')).to.eventually.be.rejected().with.property('code', codes.ERR_INVALID_PARAMETERS)
@@ -264,7 +256,7 @@ describe('protoBook', () => {
       const removedProtocols = ['protocol1']
       const finalProtocols = supportedProtocols.filter(p => !removedProtocols.includes(p))
 
-      peerStore.on('change:protocols', spy)
+      peerStore.addEventListener('change:protocols', spy)
 
       // Replace
       await pb.set(peerId, supportedProtocols)
@@ -280,8 +272,8 @@ describe('protoBook', () => {
 
       const [firstCallArgs] = spy.firstCall.args
       const [secondCallArgs] = spy.secondCall.args
-      expect(arraysAreEqual(firstCallArgs.protocols, supportedProtocols))
-      expect(arraysAreEqual(secondCallArgs.protocols, finalProtocols))
+      expect(arraysAreEqual(firstCallArgs.detail.protocols, supportedProtocols))
+      expect(arraysAreEqual(secondCallArgs.detail.protocols, finalProtocols))
     })
 
     it('emits on remove if the content changes', async () => {
@@ -291,7 +283,7 @@ describe('protoBook', () => {
       const removedProtocols = ['protocol2']
       const finalProtocols = supportedProtocols.filter(p => !removedProtocols.includes(p))
 
-      peerStore.on('change:protocols', spy)
+      peerStore.addEventListener('change:protocols', spy)
 
       // set
       await pb.set(peerId, supportedProtocols)
@@ -310,7 +302,7 @@ describe('protoBook', () => {
       const supportedProtocols = ['protocol1', 'protocol2']
       const removedProtocols = ['protocol3']
 
-      peerStore.on('change:protocols', spy)
+      peerStore.addEventListener('change:protocols', spy)
 
       // set
       await pb.set(peerId, supportedProtocols)
@@ -376,7 +368,7 @@ describe('protoBook', () => {
     it('should not emit event if no records exist for the peer', async () => {
       const defer = pDefer()
 
-      peerStore.on('change:protocols', () => {
+      peerStore.addEventListener('change:protocols', () => {
         defer.reject()
       })
 
@@ -397,7 +389,8 @@ describe('protoBook', () => {
       await pb.set(peerId, supportedProtocols)
 
       // Listen after set
-      peerStore.on('change:protocols', ({ protocols }) => {
+      peerStore.addEventListener('change:protocols', (evt) => {
+        const { protocols } = evt.detail
         expect(protocols.length).to.eql(0)
         defer.resolve()
       })

--- a/packages/libp2p-pubsub/package.json
+++ b/packages/libp2p-pubsub/package.json
@@ -170,7 +170,7 @@
     "build": "tsc",
     "postbuild": "npm run build:copy-proto-files",
     "pretest": "npm run build",
-    "test": "aegir test -f ./dist/test/**/*.js",
+    "test": "aegir test -f ./dist/test/*.js -f ./dist/test/**/*.js",
     "test:chrome": "npm run test -- -t browser",
     "test:chrome-webworker": "npm run test -- -t webworker",
     "test:firefox": "npm run test -- -t browser -- --browser firefox",

--- a/packages/libp2p-pubsub/package.json
+++ b/packages/libp2p-pubsub/package.json
@@ -166,7 +166,7 @@
   },
   "scripts": {
     "lint": "aegir lint",
-    "dep-check": "aegir dep-check dist/src/**/*.js",
+    "dep-check": "aegir dep-check dist/src/**/*.js dist/test/**/*.js",
     "build": "tsc",
     "postbuild": "npm run build:copy-proto-files",
     "pretest": "npm run build",
@@ -203,7 +203,10 @@
   },
   "devDependencies": {
     "@types/bl": "^5.0.2",
+    "abortable-iterator": "^4.0.2",
     "aegir": "^36.1.3",
+    "it-pair": "^2.0.2",
+    "it-pushable": "^2.0.1",
     "protobufjs": "^6.10.2",
     "util": "^0.12.4"
   }

--- a/packages/libp2p-pubsub/src/index.ts
+++ b/packages/libp2p-pubsub/src/index.ts
@@ -240,7 +240,9 @@ export abstract class PubsubBaseProtocol<EventMap> extends EventEmitter<EventMap
   protected _removePeer (peerId: PeerId) {
     const id = peerId.toString()
     const peerStreams = this.peers.get(id)
-    if (peerStreams == null) return
+    if (peerStreams == null) {
+      return
+    }
 
     // close peer streams
     peerStreams.close()

--- a/packages/libp2p-pubsub/src/index.ts
+++ b/packages/libp2p-pubsub/src/index.ts
@@ -1,5 +1,5 @@
 import { logger } from '@libp2p/logger'
-import { EventEmitter } from 'events'
+import { EventEmitter, CustomEvent } from '@libp2p/interfaces'
 import errcode from 'err-code'
 import { pipe } from 'it-pipe'
 import Queue from 'p-queue'
@@ -8,15 +8,15 @@ import { codes } from './errors.js'
 import { RPC, IRPC } from './message/rpc.js'
 import { PeerStreams } from './peer-streams.js'
 import * as utils from './utils.js'
-import type { PeerId } from '@libp2p/interfaces/peer-id'
-import type { Registrar, IncomingStreamEvent } from '@libp2p/interfaces/registrar'
-import type { Connection } from '@libp2p/interfaces/connection'
-import type BufferList from 'bl'
 import {
   signMessage,
   verifySignature
 } from './message/sign.js'
-import type { PubSub, Message, StrictNoSign, StrictSign, PubsubOptions } from '@libp2p/interfaces/pubsub'
+import type { PeerId } from '@libp2p/interfaces/peer-id'
+import type { Registrar, IncomingStreamEvent } from '@libp2p/interfaces/registrar'
+import type { Connection } from '@libp2p/interfaces/connection'
+import type BufferList from 'bl'
+import type { PubSub, Message, StrictNoSign, StrictSign, PubsubOptions, PubsubEvents } from '@libp2p/interfaces/pubsub'
 import type { Startable } from '@libp2p/interfaces'
 import type { Logger } from '@libp2p/logger'
 
@@ -26,7 +26,7 @@ export interface TopicValidator { (topic: string, message: Message): Promise<voi
  * PubsubBaseProtocol handles the peers and connections logic for pubsub routers
  * and specifies the API that pubsub routers should have.
  */
-export abstract class PubsubBaseProtocol extends EventEmitter implements PubSub, Startable {
+export abstract class PubsubBaseProtocol<EventMap> extends EventEmitter<EventMap & PubsubEvents> implements PubSub<EventMap & PubsubEvents>, Startable {
   public peerId: PeerId
   public started: boolean
   /**
@@ -122,6 +122,8 @@ export abstract class PubsubBaseProtocol extends EventEmitter implements PubSub,
     // register protocol with topology
     // Topology callbacks called on connection manager changes
     const topology = new MulticodecTopology({
+      peerStore: this._libp2p.peerStore,
+      connectionManager: this._libp2p.connectionManager,
       multicodecs: this.multicodecs,
       handlers: {
         onConnect: this._onPeerConnected,
@@ -225,7 +227,9 @@ export abstract class PubsubBaseProtocol extends EventEmitter implements PubSub,
     })
 
     this.peers.set(id, peerStreams)
-    peerStreams.once('close', () => this._removePeer(peerId))
+    peerStreams.addEventListener('close', () => this._removePeer(peerId), {
+      once: true
+    })
 
     return peerStreams
   }
@@ -239,7 +243,6 @@ export abstract class PubsubBaseProtocol extends EventEmitter implements PubSub,
     if (peerStreams == null) return
 
     // close peer streams
-    peerStreams.removeAllListeners()
     peerStreams.close()
 
     // delete peer streams
@@ -295,7 +298,9 @@ export abstract class PubsubBaseProtocol extends EventEmitter implements PubSub,
       subs.forEach((subOpt) => {
         this._processRpcSubOpt(idB58Str, subOpt)
       })
-      this.emit('pubsub:subscription-change', { peerId: peerStreams.id, subscriptions: subs })
+      this.dispatchEvent(new CustomEvent('pubsub:subscription-change', {
+        detail: { peerId: peerStreams.id, subscriptions: subs }
+      }))
     }
 
     if (!this._acceptFrom(idB58Str)) {
@@ -379,7 +384,9 @@ export abstract class PubsubBaseProtocol extends EventEmitter implements PubSub,
   _emitMessage (message: Message) {
     message.topicIDs.forEach((topic) => {
       if (this.subscriptions.has(topic)) {
-        this.emit(topic, message)
+        this.dispatchEvent(new CustomEvent(topic, {
+          detail: message
+        }))
       }
     })
   }

--- a/packages/libp2p-pubsub/src/peer-streams.ts
+++ b/packages/libp2p-pubsub/src/peer-streams.ts
@@ -1,5 +1,5 @@
 import { logger } from '@libp2p/logger'
-import { EventEmitter } from 'events'
+import { EventEmitter, CustomEvent } from '@libp2p/interfaces'
 import * as lp from 'it-length-prefixed'
 import { pushable } from 'it-pushable'
 import { pipe } from 'it-pipe'
@@ -7,6 +7,7 @@ import { abortableSource } from 'abortable-iterator'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import type { Stream } from '@libp2p/interfaces/connection'
 import type { Pushable } from 'it-pushable'
+import type { PeerStreamEvents } from '@libp2p/interfaces/pubsub'
 
 const log = logger('libp2p-pubsub:peer-streams')
 
@@ -18,7 +19,7 @@ export interface Options {
 /**
  * Thin wrapper around a peer's inbound / outbound pubsub streams
  */
-export class PeerStreams extends EventEmitter {
+export class PeerStreams extends EventEmitter<PeerStreamEvents> {
   public readonly id: PeerId
   public readonly protocol: string
   /**
@@ -96,7 +97,7 @@ export class PeerStreams extends EventEmitter {
       { returnOnAbort: true }
     )
 
-    this.emit('stream:inbound')
+    this.dispatchEvent(new CustomEvent('stream:inbound'))
     return this.inboundStream
   }
 
@@ -122,7 +123,7 @@ export class PeerStreams extends EventEmitter {
         this._rawOutboundStream = undefined
         this.outboundStream = undefined
         if (shouldEmit != null) {
-          this.emit('close')
+          this.dispatchEvent(new CustomEvent('close'))
         }
       }
     })
@@ -137,7 +138,7 @@ export class PeerStreams extends EventEmitter {
 
     // Only emit if the connection is new
     if (_prevStream == null) {
-      this.emit('stream:outbound')
+      this.dispatchEvent(new CustomEvent('stream:outbound'))
     }
   }
 
@@ -158,6 +159,6 @@ export class PeerStreams extends EventEmitter {
     this.outboundStream = undefined
     this._rawInboundStream = undefined
     this.inboundStream = undefined
-    this.emit('close')
+    this.dispatchEvent(new CustomEvent('close'))
   }
 }

--- a/packages/libp2p-pubsub/src/peer-streams.ts
+++ b/packages/libp2p-pubsub/src/peer-streams.ts
@@ -42,6 +42,7 @@ export class PeerStreams extends EventEmitter<PeerStreamEvents> {
    * An AbortController for controlled shutdown of the inbound stream
    */
   private readonly _inboundAbortController: AbortController
+  private closed: boolean
 
   constructor (opts: Options) {
     super()
@@ -50,6 +51,7 @@ export class PeerStreams extends EventEmitter<PeerStreamEvents> {
     this.protocol = opts.protocol
 
     this._inboundAbortController = new AbortController()
+    this.closed = false
   }
 
   /**
@@ -146,6 +148,12 @@ export class PeerStreams extends EventEmitter<PeerStreamEvents> {
    * Closes the open connection to peer
    */
   close () {
+    if (this.closed) {
+      return
+    }
+
+    this.closed = true
+
     // End the outbound stream
     if (this.outboundStream != null) {
       this.outboundStream.end()

--- a/packages/libp2p-pubsub/test/emit-self.spec.ts
+++ b/packages/libp2p-pubsub/test/emit-self.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from 'aegir/utils/chai.js'
 import {
   createPeerId,
-  mockRegistrar,
-  PubsubImplementation
+  PubsubImplementation,
+  mockRegistrar
 } from './utils/index.js'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import delay from 'delay'
@@ -12,14 +12,18 @@ const topic = 'foo'
 const data = uint8ArrayFromString('bar')
 const shouldNotHappen = () => expect.fail()
 
+interface PubsubEvents {
+  'foo': CustomEvent<any>
+}
+
 describe('emitSelf', () => {
-  let pubsub: PubsubImplementation
+  let pubsub: PubsubImplementation<PubsubEvents>
 
   describe('enabled', () => {
     before(async () => {
       const peerId = await createPeerId()
 
-      pubsub = new PubsubImplementation({
+      pubsub = new PubsubImplementation<PubsubEvents>({
         multicodecs: [protocol],
         libp2p: {
           peerId,
@@ -39,7 +43,9 @@ describe('emitSelf', () => {
     })
 
     it('should emit to self on publish', async () => {
-      const promise = new Promise((resolve) => pubsub.once(topic, resolve))
+      const promise = new Promise((resolve) => pubsub.addEventListener(topic, resolve, {
+        once: true
+      }))
 
       await pubsub.publish(topic, data)
 
@@ -71,7 +77,9 @@ describe('emitSelf', () => {
     })
 
     it('should not emit to self on publish', async () => {
-      pubsub.once(topic, () => shouldNotHappen)
+      pubsub.addEventListener(topic, () => shouldNotHappen, {
+        once: true
+      })
 
       await pubsub.publish(topic, data)
 

--- a/packages/libp2p-pubsub/test/emit-self.spec.ts
+++ b/packages/libp2p-pubsub/test/emit-self.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from 'aegir/utils/chai.js'
 import {
   createPeerId,
-  PubsubImplementation,
-  mockRegistrar
+  mockRegistrar,
+  PubsubImplementation
 } from './utils/index.js'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import delay from 'delay'
@@ -12,18 +12,14 @@ const topic = 'foo'
 const data = uint8ArrayFromString('bar')
 const shouldNotHappen = () => expect.fail()
 
-interface PubsubEvents {
-  'foo': CustomEvent<any>
-}
-
 describe('emitSelf', () => {
-  let pubsub: PubsubImplementation<PubsubEvents>
+  let pubsub: PubsubImplementation
 
   describe('enabled', () => {
     before(async () => {
       const peerId = await createPeerId()
 
-      pubsub = new PubsubImplementation<PubsubEvents>({
+      pubsub = new PubsubImplementation({
         multicodecs: [protocol],
         libp2p: {
           peerId,
@@ -43,9 +39,7 @@ describe('emitSelf', () => {
     })
 
     it('should emit to self on publish', async () => {
-      const promise = new Promise((resolve) => pubsub.addEventListener(topic, resolve, {
-        once: true
-      }))
+      const promise = new Promise((resolve) => pubsub.addEventListener(topic, resolve))
 
       await pubsub.publish(topic, data)
 

--- a/packages/libp2p-pubsub/test/instance.spec.ts
+++ b/packages/libp2p-pubsub/test/instance.spec.ts
@@ -7,7 +7,7 @@ import {
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import type { Message } from '@libp2p/interfaces/pubsub'
 
-class PubsubProtocol extends PubsubBaseProtocol {
+class PubsubProtocol extends PubsubBaseProtocol<{}> {
   async _publish (message: Message): Promise<void> {
     throw new Error('Method not implemented.')
   }

--- a/packages/libp2p-pubsub/test/lifecycle.spec.ts
+++ b/packages/libp2p-pubsub/test/lifecycle.spec.ts
@@ -3,9 +3,9 @@ import sinon from 'sinon'
 import { PubsubBaseProtocol } from '../src/index.js'
 import {
   createPeerId,
+  createMockRegistrar,
   PubsubImplementation,
-  ConnectionPair,
-  mockRegistrar
+  ConnectionPair
 } from './utils/index.js'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import type { Registrar } from '@libp2p/interfaces/registrar'
@@ -74,7 +74,7 @@ describe('pubsub base lifecycle', () => {
 
   describe('should be able to register two nodes', () => {
     const protocol = '/pubsub/1.0.0'
-    let pubsubA: PubsubImplementation<{}>, pubsubB: PubsubImplementation<{}>
+    let pubsubA: PubsubImplementation, pubsubB: PubsubImplementation
     let peerIdA: PeerId, peerIdB: PeerId
     const registrarRecordA = new Map()
     const registrarRecordB = new Map()
@@ -88,14 +88,14 @@ describe('pubsub base lifecycle', () => {
         multicodecs: [protocol],
         libp2p: {
           peerId: peerIdA,
-          registrar: mockRegistrar
+          registrar: createMockRegistrar(registrarRecordA)
         }
       })
       pubsubB = new PubsubImplementation({
         multicodecs: [protocol],
         libp2p: {
           peerId: peerIdB,
-          registrar: mockRegistrar
+          registrar: createMockRegistrar(registrarRecordB)
         }
       })
     })
@@ -112,7 +112,7 @@ describe('pubsub base lifecycle', () => {
     afterEach(async () => {
       sinon.restore()
 
-      return await Promise.all([
+      await Promise.all([
         pubsubA.stop(),
         pubsubB.stop()
       ])

--- a/packages/libp2p-pubsub/test/lifecycle.spec.ts
+++ b/packages/libp2p-pubsub/test/lifecycle.spec.ts
@@ -3,15 +3,15 @@ import sinon from 'sinon'
 import { PubsubBaseProtocol } from '../src/index.js'
 import {
   createPeerId,
-  createMockRegistrar,
   PubsubImplementation,
-  ConnectionPair
+  ConnectionPair,
+  mockRegistrar
 } from './utils/index.js'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import type { Registrar } from '@libp2p/interfaces/registrar'
 import type { Message } from '@libp2p/interfaces/pubsub'
 
-class PubsubProtocol extends PubsubBaseProtocol {
+class PubsubProtocol extends PubsubBaseProtocol<{}> {
   async _publish (message: Message): Promise<void> {
     throw new Error('Method not implemented.')
   }
@@ -74,7 +74,7 @@ describe('pubsub base lifecycle', () => {
 
   describe('should be able to register two nodes', () => {
     const protocol = '/pubsub/1.0.0'
-    let pubsubA: PubsubImplementation, pubsubB: PubsubImplementation
+    let pubsubA: PubsubImplementation<{}>, pubsubB: PubsubImplementation<{}>
     let peerIdA: PeerId, peerIdB: PeerId
     const registrarRecordA = new Map()
     const registrarRecordB = new Map()
@@ -88,14 +88,14 @@ describe('pubsub base lifecycle', () => {
         multicodecs: [protocol],
         libp2p: {
           peerId: peerIdA,
-          registrar: createMockRegistrar(registrarRecordA)
+          registrar: mockRegistrar
         }
       })
       pubsubB = new PubsubImplementation({
         multicodecs: [protocol],
         libp2p: {
           peerId: peerIdB,
-          registrar: createMockRegistrar(registrarRecordB)
+          registrar: mockRegistrar
         }
       })
     })

--- a/packages/libp2p-pubsub/test/message.spec.ts
+++ b/packages/libp2p-pubsub/test/message.spec.ts
@@ -10,7 +10,7 @@ import {
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import type { Message } from '@libp2p/interfaces/pubsub'
 
-class PubsubProtocol extends PubsubBaseProtocol {
+class PubsubProtocol extends PubsubBaseProtocol<{}> {
   async _publish (message: Message): Promise<void> {
     throw new Error('Method not implemented')
   }

--- a/packages/libp2p-pubsub/test/pubsub.spec.ts
+++ b/packages/libp2p-pubsub/test/pubsub.spec.ts
@@ -6,6 +6,7 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { PeerStreams } from '../src/peer-streams.js'
 import {
   createPeerId,
+  createMockRegistrar,
   ConnectionPair,
   mockRegistrar,
   PubsubImplementation
@@ -18,7 +19,7 @@ const message = uint8ArrayFromString('hello')
 
 describe('pubsub base implementation', () => {
   describe('publish', () => {
-    let pubsub: PubsubImplementation<{}>
+    let pubsub: PubsubImplementation
 
     beforeEach(async () => {
       const peerId = await createPeerId()
@@ -59,7 +60,7 @@ describe('pubsub base implementation', () => {
 
   describe('subscribe', () => {
     describe('basics', () => {
-      let pubsub: PubsubImplementation<{}>
+      let pubsub: PubsubImplementation
 
       beforeEach(async () => {
         const peerId = await createPeerId()
@@ -84,7 +85,7 @@ describe('pubsub base implementation', () => {
     })
 
     describe('two nodes', () => {
-      let pubsubA: PubsubImplementation<{}>, pubsubB: PubsubImplementation<{}>
+      let pubsubA: PubsubImplementation, pubsubB: PubsubImplementation
       let peerIdA: PeerId, peerIdB: PeerId
       const registrarRecordA = new Map()
       const registrarRecordB = new Map()
@@ -97,14 +98,14 @@ describe('pubsub base implementation', () => {
           multicodecs: [protocol],
           libp2p: {
             peerId: peerIdA,
-            registrar: mockRegistrar
+            registrar: createMockRegistrar(registrarRecordA)
           }
         })
         pubsubB = new PubsubImplementation({
           multicodecs: [protocol],
           libp2p: {
             peerId: peerIdB,
-            registrar: mockRegistrar
+            registrar: createMockRegistrar(registrarRecordB)
           }
         })
       })
@@ -160,7 +161,7 @@ describe('pubsub base implementation', () => {
 
   describe('unsubscribe', () => {
     describe('basics', () => {
-      let pubsub: PubsubImplementation<{}>
+      let pubsub: PubsubImplementation
 
       beforeEach(async () => {
         const peerId = await createPeerId()
@@ -189,7 +190,7 @@ describe('pubsub base implementation', () => {
     })
 
     describe('two nodes', () => {
-      let pubsubA: PubsubImplementation<{}>, pubsubB: PubsubImplementation<{}>
+      let pubsubA: PubsubImplementation, pubsubB: PubsubImplementation
       let peerIdA: PeerId, peerIdB: PeerId
       const registrarRecordA = new Map()
       const registrarRecordB = new Map()
@@ -202,14 +203,14 @@ describe('pubsub base implementation', () => {
           multicodecs: [protocol],
           libp2p: {
             peerId: peerIdA,
-            registrar: mockRegistrar
+            registrar: createMockRegistrar(registrarRecordA)
           }
         })
         pubsubB = new PubsubImplementation({
           multicodecs: [protocol],
           libp2p: {
             peerId: peerIdB,
-            registrar: mockRegistrar
+            registrar: createMockRegistrar(registrarRecordB)
           }
         })
       })
@@ -293,7 +294,7 @@ describe('pubsub base implementation', () => {
 
   describe('getTopics', () => {
     let peerId: PeerId
-    let pubsub: PubsubImplementation<{}>
+    let pubsub: PubsubImplementation
 
     beforeEach(async () => {
       peerId = await createPeerId()
@@ -323,7 +324,7 @@ describe('pubsub base implementation', () => {
 
   describe('getSubscribers', () => {
     let peerId: PeerId
-    let pubsub: PubsubImplementation<{}>
+    let pubsub: PubsubImplementation
 
     beforeEach(async () => {
       peerId = await createPeerId()

--- a/packages/libp2p-pubsub/test/pubsub.spec.ts
+++ b/packages/libp2p-pubsub/test/pubsub.spec.ts
@@ -6,7 +6,6 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { PeerStreams } from '../src/peer-streams.js'
 import {
   createPeerId,
-  createMockRegistrar,
   ConnectionPair,
   mockRegistrar,
   PubsubImplementation
@@ -19,7 +18,7 @@ const message = uint8ArrayFromString('hello')
 
 describe('pubsub base implementation', () => {
   describe('publish', () => {
-    let pubsub: PubsubImplementation
+    let pubsub: PubsubImplementation<{}>
 
     beforeEach(async () => {
       const peerId = await createPeerId()
@@ -60,7 +59,7 @@ describe('pubsub base implementation', () => {
 
   describe('subscribe', () => {
     describe('basics', () => {
-      let pubsub: PubsubImplementation
+      let pubsub: PubsubImplementation<{}>
 
       beforeEach(async () => {
         const peerId = await createPeerId()
@@ -85,7 +84,7 @@ describe('pubsub base implementation', () => {
     })
 
     describe('two nodes', () => {
-      let pubsubA: PubsubImplementation, pubsubB: PubsubImplementation
+      let pubsubA: PubsubImplementation<{}>, pubsubB: PubsubImplementation<{}>
       let peerIdA: PeerId, peerIdB: PeerId
       const registrarRecordA = new Map()
       const registrarRecordB = new Map()
@@ -98,14 +97,14 @@ describe('pubsub base implementation', () => {
           multicodecs: [protocol],
           libp2p: {
             peerId: peerIdA,
-            registrar: createMockRegistrar(registrarRecordA)
+            registrar: mockRegistrar
           }
         })
         pubsubB = new PubsubImplementation({
           multicodecs: [protocol],
           libp2p: {
             peerId: peerIdB,
-            registrar: createMockRegistrar(registrarRecordB)
+            registrar: mockRegistrar
           }
         })
       })
@@ -161,7 +160,7 @@ describe('pubsub base implementation', () => {
 
   describe('unsubscribe', () => {
     describe('basics', () => {
-      let pubsub: PubsubImplementation
+      let pubsub: PubsubImplementation<{}>
 
       beforeEach(async () => {
         const peerId = await createPeerId()
@@ -190,7 +189,7 @@ describe('pubsub base implementation', () => {
     })
 
     describe('two nodes', () => {
-      let pubsubA: PubsubImplementation, pubsubB: PubsubImplementation
+      let pubsubA: PubsubImplementation<{}>, pubsubB: PubsubImplementation<{}>
       let peerIdA: PeerId, peerIdB: PeerId
       const registrarRecordA = new Map()
       const registrarRecordB = new Map()
@@ -203,14 +202,14 @@ describe('pubsub base implementation', () => {
           multicodecs: [protocol],
           libp2p: {
             peerId: peerIdA,
-            registrar: createMockRegistrar(registrarRecordA)
+            registrar: mockRegistrar
           }
         })
         pubsubB = new PubsubImplementation({
           multicodecs: [protocol],
           libp2p: {
             peerId: peerIdB,
-            registrar: createMockRegistrar(registrarRecordB)
+            registrar: mockRegistrar
           }
         })
       })
@@ -294,7 +293,7 @@ describe('pubsub base implementation', () => {
 
   describe('getTopics', () => {
     let peerId: PeerId
-    let pubsub: PubsubImplementation
+    let pubsub: PubsubImplementation<{}>
 
     beforeEach(async () => {
       peerId = await createPeerId()
@@ -324,7 +323,7 @@ describe('pubsub base implementation', () => {
 
   describe('getSubscribers', () => {
     let peerId: PeerId
-    let pubsub: PubsubImplementation
+    let pubsub: PubsubImplementation<{}>
 
     beforeEach(async () => {
       peerId = await createPeerId()

--- a/packages/libp2p-pubsub/test/topic-validators.spec.ts
+++ b/packages/libp2p-pubsub/test/topic-validators.spec.ts
@@ -15,7 +15,7 @@ import {
 const protocol = '/pubsub/1.0.0'
 
 describe('topic validators', () => {
-  let pubsub: PubsubImplementation
+  let pubsub: PubsubImplementation<{}>
 
   beforeEach(async () => {
     const peerId = await createPeerId()

--- a/packages/libp2p-pubsub/test/topic-validators.spec.ts
+++ b/packages/libp2p-pubsub/test/topic-validators.spec.ts
@@ -15,7 +15,7 @@ import {
 const protocol = '/pubsub/1.0.0'
 
 describe('topic validators', () => {
-  let pubsub: PubsubImplementation<{}>
+  let pubsub: PubsubImplementation
 
   beforeEach(async () => {
     const peerId = await createPeerId()

--- a/packages/libp2p-pubsub/test/utils/index.ts
+++ b/packages/libp2p-pubsub/test/utils/index.ts
@@ -2,8 +2,6 @@ import { duplexPair } from 'it-pair/duplex'
 import * as PeerIdFactory from '@libp2p/peer-id-factory'
 import { PubsubBaseProtocol } from '../../src/index.js'
 import { RPC, IRPC } from '../../src/message/rpc.js'
-import type { Registrar } from '@libp2p/interfaces/registrar'
-import type { PeerId } from '@libp2p/interfaces/peer-id'
 import type { Ed25519PeerId } from '@libp2p/peer-id'
 
 export const createPeerId = async (): Promise<Ed25519PeerId> => {
@@ -12,7 +10,7 @@ export const createPeerId = async (): Promise<Ed25519PeerId> => {
   return peerId
 }
 
-export class PubsubImplementation extends PubsubBaseProtocol {
+export class PubsubImplementation<Events> extends PubsubBaseProtocol<Events> {
   async _publish () {
     // ...
   }
@@ -30,66 +28,6 @@ export const mockRegistrar = {
   handle: () => {},
   register: () => {},
   unregister: () => {}
-}
-
-export const createMockRegistrar = (registrarRecord: Map<string, Record<string, any>>) => {
-  const registrar: Registrar = {
-    handle: (multicodecs: string[] | string, handler) => {
-      if (!Array.isArray(multicodecs)) {
-        multicodecs = [multicodecs]
-      }
-
-      const rec = registrarRecord.get(multicodecs[0]) ?? {}
-
-      registrarRecord.set(multicodecs[0], {
-        ...rec,
-        handler
-      })
-    },
-    register: (topology) => {
-      const { multicodecs } = topology
-      const rec = registrarRecord.get(multicodecs[0]) ?? {}
-
-      registrarRecord.set(multicodecs[0], {
-        ...rec,
-        onConnect: topology._onConnect,
-        onDisconnect: topology._onDisconnect
-      })
-
-      return multicodecs[0]
-    },
-    unregister: (id: string) => {
-      registrarRecord.delete(id)
-    },
-
-    getConnection (peerId: PeerId) {
-      throw new Error('Not implemented')
-    },
-
-    peerStore: {
-      on: () => {
-        throw new Error('Not implemented')
-      },
-      // @ts-expect-error use protobook type
-      protoBook: {
-        get: () => {
-          throw new Error('Not implemented')
-        }
-      },
-      peers: new Map(),
-      get: (peerId) => {
-        throw new Error('Not implemented')
-      }
-    },
-
-    connectionManager: {
-      on: () => {
-        throw new Error('Not implemented')
-      }
-    }
-  }
-
-  return registrar
 }
 
 export const ConnectionPair = () => {

--- a/packages/libp2p-pubsub/test/utils/index.ts
+++ b/packages/libp2p-pubsub/test/utils/index.ts
@@ -2,6 +2,7 @@ import { duplexPair } from 'it-pair/duplex'
 import * as PeerIdFactory from '@libp2p/peer-id-factory'
 import { PubsubBaseProtocol } from '../../src/index.js'
 import { RPC, IRPC } from '../../src/message/rpc.js'
+import type { Registrar } from '@libp2p/interfaces/registrar'
 import type { Ed25519PeerId } from '@libp2p/peer-id'
 
 export const createPeerId = async (): Promise<Ed25519PeerId> => {
@@ -10,7 +11,11 @@ export const createPeerId = async (): Promise<Ed25519PeerId> => {
   return peerId
 }
 
-export class PubsubImplementation<Events> extends PubsubBaseProtocol<Events> {
+interface EventMap {
+  'foo': CustomEvent
+}
+
+export class PubsubImplementation extends PubsubBaseProtocol<EventMap> {
   async _publish () {
     // ...
   }
@@ -28,6 +33,43 @@ export const mockRegistrar = {
   handle: () => {},
   register: () => {},
   unregister: () => {}
+}
+
+export const createMockRegistrar = (registrarRecord: Map<string, Record<string, any>>) => {
+  const registrar: Registrar = {
+    handle: (multicodecs: string[] | string, handler) => {
+      if (!Array.isArray(multicodecs)) {
+        multicodecs = [multicodecs]
+      }
+
+      const rec = registrarRecord.get(multicodecs[0]) ?? {}
+
+      registrarRecord.set(multicodecs[0], {
+        ...rec,
+        handler
+      })
+    },
+    unhandle (multicodec: string) {
+
+    },
+    register: (topology) => {
+      const { multicodecs } = topology
+      const rec = registrarRecord.get(multicodecs[0]) ?? {}
+
+      registrarRecord.set(multicodecs[0], {
+        ...rec,
+        onConnect: topology._onConnect,
+        onDisconnect: topology._onDisconnect
+      })
+
+      return multicodecs[0]
+    },
+    unregister: (id: string) => {
+      registrarRecord.delete(id)
+    }
+  }
+
+  return registrar
 }
 
 export const ConnectionPair = () => {

--- a/packages/libp2p-pubsub/tsconfig.json
+++ b/packages/libp2p-pubsub/tsconfig.json
@@ -19,6 +19,12 @@
     },
     {
       "path": "../libp2p-topology"
+    },
+    {
+      "path": "../libp2p-peer-id"
+    },
+    {
+      "path": "../libp2p-peer-id-factory"
     }
   ]
 }

--- a/packages/libp2p-topology/package.json
+++ b/packages/libp2p-topology/package.json
@@ -142,7 +142,7 @@
   },
   "scripts": {
     "lint": "aegir lint",
-    "dep-check": "aegir dep-check dist/src/**/*.js",
+    "dep-check": "aegir dep-check dist/src/**/*.js dist/test/**/*.js",
     "build": "tsc"
   },
   "dependencies": {

--- a/packages/libp2p-tracked-map/package.json
+++ b/packages/libp2p-tracked-map/package.json
@@ -120,7 +120,7 @@
   },
   "scripts": {
     "lint": "aegir lint",
-    "dep-check": "aegir dep-check dist/src/**/*.js",
+    "dep-check": "aegir dep-check dist/src/**/*.js dist/test/**/*.js",
     "build": "tsc",
     "pretest": "npm run build",
     "test": "aegir test -f ./dist/test/**/*.js",

--- a/packages/libp2p-tracked-map/package.json
+++ b/packages/libp2p-tracked-map/package.json
@@ -123,7 +123,7 @@
     "dep-check": "aegir dep-check dist/src/**/*.js dist/test/**/*.js",
     "build": "tsc",
     "pretest": "npm run build",
-    "test": "aegir test -f ./dist/test/**/*.js",
+    "test": "aegir test -f ./dist/test/*.js -f ./dist/test/**/*.js",
     "test:chrome": "npm run test -- -t browser",
     "test:chrome-webworker": "npm run test -- -t webworker",
     "test:firefox": "npm run test -- -t browser -- --browser firefox",


### PR DESCRIPTION
Replaces the node `EventEmitter` with the pure-js `EventTarget` class.

All events are now instances of [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event).

For typing [CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent) can be used which gives us a typed `.detail` field.

Tediously `EventTarget` itself [doesn't support typed events](https://github.com/microsoft/TypeScript/issues/28357) (yet?) and node.js [doesn't support](https://github.com/nodejs/node/issues/40678) `CustomEvent` globally so bit of trickery was required but hopefully this can be removed in future:

```js
import { EventEmitter, CustomEvent } from '@libp2p/interfaces'

interface EventMap {
  'foo': CustomEvent<number>
}

class MyEmitter extends EventEmitter<EventMap> {
  // ... other code here
} 

const emitter = new MyEmitter()

emitter.addEventListener('foo', (evt) => {
  const n = evt.detail // n is a 'number'
})
```