### PR TITLE
fix: remove args from listener events

### DIFF
--- a/packages/libp2p-interface-compliance-tests/src/transport/listen-test.ts
+++ b/packages/libp2p-interface-compliance-tests/src/transport/listen-test.ts
@@ -147,7 +147,7 @@ export default (common: TestSetup<TransportTestFixtures, SetupArgs>) => {
 
       it('close', (done) => {
         const listener = transport.createListener()
-        listener.addEventListener('close', done)
+        listener.addEventListener('close', () => done())
 
         void (async () => {
           await listener.listen(addrs[0])

--- a/packages/libp2p-interfaces/src/transport/index.ts
+++ b/packages/libp2p-interfaces/src/transport/index.ts
@@ -35,9 +35,9 @@ export interface Transport <DialOptions extends AbortOptions = AbortOptions, Cre
 
 export interface ListenerEvents {
   'connection': CustomEvent<Connection>
-  'listening': CustomEvent<Connection>
+  'listening': CustomEvent
   'error': CustomEvent<Error>
-  'close': CustomEvent<Connection>
+  'close': CustomEvent
 }
 
 export interface Listener extends EventEmitter<ListenerEvents> {


### PR DESCRIPTION
Cannot return a Connection on listen because we don't have one until a peer connects to the listener.