### PR TITLE
fix: hide implementations behind factory methods

### DIFF
--- a/packages/libp2p-interface-compliance-tests/src/mocks/connection.ts
+++ b/packages/libp2p-interface-compliance-tests/src/mocks/connection.ts
@@ -1,4 +1,4 @@
-import { PeerId } from '@libp2p/peer-id'
+import { peerIdFromString } from '@libp2p/peer-id'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { pipe } from 'it-pipe'
 import { duplexPair } from 'it-pair/duplex'
@@ -11,7 +11,7 @@ import { mockMuxer } from './muxer.js'
 export async function mockConnection (maConn: MultiaddrConnection, direction: 'inbound' | 'outbound' = 'inbound', muxer: Muxer = mockMuxer()): Promise<Connection> {
   const remoteAddr = maConn.remoteAddr
   const remotePeerIdStr = remoteAddr.getPeerId()
-  const remotePeer = remotePeerIdStr != null ? PeerId.fromString(remotePeerIdStr) : await createEd25519PeerId()
+  const remotePeer = remotePeerIdStr != null ? peerIdFromString(remotePeerIdStr) : await createEd25519PeerId()
   const registry = new Map()
   const streams: Stream[] = []
   let streamId = 0

--- a/packages/libp2p-interface-compliance-tests/src/transport/utils/index.ts
+++ b/packages/libp2p-interface-compliance-tests/src/transport/utils/index.ts
@@ -1,6 +1,6 @@
 import { expect } from 'aegir/utils/chai.js'
 import { pair } from 'it-pair'
-import { PeerId } from '@libp2p/peer-id'
+import { peerIdFromString } from '@libp2p/peer-id'
 import * as PeerIdFactory from '@libp2p/peer-id-factory'
 import { pushable } from 'it-pushable'
 import drain from 'it-drain'
@@ -114,7 +114,7 @@ export function mockUpgrader (options: MockUpgraderOptions = {}) {
 async function createConnection (maConn: MultiaddrConnection, direction: 'inbound' | 'outbound', muxer: Muxer): Promise<Connection> {
   const remoteAddr = maConn.remoteAddr
   const remotePeerIdStr = remoteAddr.getPeerId()
-  const remotePeer = remotePeerIdStr != null ? PeerId.fromString(remotePeerIdStr) : await PeerIdFactory.createEd25519PeerId()
+  const remotePeer = remotePeerIdStr != null ? peerIdFromString(remotePeerIdStr) : await PeerIdFactory.createEd25519PeerId()
 
   const streams: Stream[] = []
   let streamId = 0

--- a/packages/libp2p-interface-compliance-tests/test/crypto/mock-crypto.ts
+++ b/packages/libp2p-interface-compliance-tests/test/crypto/mock-crypto.ts
@@ -1,4 +1,4 @@
-import { PeerId } from '@libp2p/peer-id'
+import { peerIdFromBytes } from '@libp2p/peer-id'
 import { handshake } from 'it-handshake'
 import { duplexPair } from 'it-pair/duplex'
 import { pipe } from 'it-pipe'
@@ -28,7 +28,7 @@ const crypto: Crypto = {
       throw new Error('Could not read remote ID')
     }
 
-    const remotePeer = PeerId.fromBytes(remoteId.slice())
+    const remotePeer = peerIdFromBytes(remoteId.slice())
     shake.rest()
 
     if (expectedPeer != null && !expectedPeer.equals(remotePeer)) {
@@ -99,7 +99,7 @@ const crypto: Crypto = {
         },
         conn: true
       },
-      remotePeer: PeerId.fromBytes(remoteId.slice()),
+      remotePeer: peerIdFromBytes(remoteId.slice()),
       remoteEarlyData: new Uint8Array(0)
     }
   }

--- a/packages/libp2p-interfaces/src/peer-id/index.ts
+++ b/packages/libp2p-interfaces/src/peer-id/index.ts
@@ -2,7 +2,7 @@ import type { CID } from 'multiformats/cid'
 import type { MultihashDigest } from 'multiformats/hashes/interface'
 import type { MultibaseEncoder } from 'multiformats/bases/interface'
 
-export interface PeerId {
+interface BasePeerId {
   readonly type: 'RSA' | 'Ed25519' | 'secp256k1'
   readonly multihash: MultihashDigest
   readonly privateKey?: Uint8Array
@@ -14,17 +14,25 @@ export interface PeerId {
   equals: (other: any) => boolean
 }
 
-export interface RSAPeerId extends PeerId {
+export interface RSAPeerId extends BasePeerId {
   readonly type: 'RSA'
   readonly publicKey?: Uint8Array
 }
 
-export interface Ed25519PeerId extends PeerId {
+export interface Ed25519PeerId extends BasePeerId {
   readonly type: 'Ed25519'
   readonly publicKey: Uint8Array
 }
 
-export interface Secp256k1PeerId extends PeerId {
+export interface Secp256k1PeerId extends BasePeerId {
   readonly type: 'secp256k1'
   readonly publicKey: Uint8Array
+}
+
+export type PeerId = RSAPeerId | Ed25519PeerId | Secp256k1PeerId
+
+export const symbol = Symbol.for('@libp2p/peer-id')
+
+export function isPeerId (other: any): other is PeerId {
+  return symbol in other
 }

--- a/packages/libp2p-peer-id-factory/src/index.ts
+++ b/packages/libp2p-peer-id-factory/src/index.ts
@@ -1,9 +1,9 @@
 import { keys } from '@libp2p/crypto'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import { PeerId } from '@libp2p/peer-id'
+import { peerIdFromKeys, peerIdFromBytes } from '@libp2p/peer-id'
 import { PeerIdProto } from './proto.js'
 import type { PublicKey, PrivateKey } from '@libp2p/interfaces/keys'
-import type { RSAPeerId, Ed25519PeerId, Secp256k1PeerId } from '@libp2p/peer-id'
+import type { RSAPeerId, Ed25519PeerId, Secp256k1PeerId } from '@libp2p/interfaces/peer-id'
 
 export const createEd25519PeerId = async (): Promise<Ed25519PeerId> => {
   const key = await keys.generateKeyPair('Ed25519')
@@ -39,11 +39,11 @@ export const createRSAPeerId = async (opts?: { bits: number }): Promise<RSAPeerI
 }
 
 export async function createFromPubKey (publicKey: PublicKey) {
-  return await PeerId.fromKeys(keys.marshalPublicKey(publicKey))
+  return await peerIdFromKeys(keys.marshalPublicKey(publicKey))
 }
 
 export async function createFromPrivKey (privateKey: PrivateKey) {
-  return await PeerId.fromKeys(keys.marshalPublicKey(privateKey.public), keys.marshalPrivateKey(privateKey))
+  return await peerIdFromKeys(keys.marshalPublicKey(privateKey.public), keys.marshalPrivateKey(privateKey))
 }
 
 export function exportToProtobuf (peerId: RSAPeerId | Ed25519PeerId | Secp256k1PeerId, excludePrivateKey?: boolean) {
@@ -87,5 +87,5 @@ async function createFromParts (multihash: Uint8Array, privKey?: Uint8Array, pub
     return await createFromPubKey(key)
   }
 
-  return PeerId.fromBytes(multihash)
+  return peerIdFromBytes(multihash)
 }

--- a/packages/libp2p-peer-id-factory/test/index.spec.ts
+++ b/packages/libp2p-peer-id-factory/test/index.spec.ts
@@ -11,7 +11,7 @@ import { base58btc } from 'multiformats/bases/base58'
 import { identity } from 'multiformats/hashes/identity'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
-import { PeerId } from '@libp2p/peer-id'
+import { peerIdFromString, peerIdFromBytes, peerIdFromCID, createPeerId } from '@libp2p/peer-id'
 import * as PeerIdFactory from '../src/index.js'
 import util from 'util'
 import testId from './fixtures/sample-id.js'
@@ -29,7 +29,8 @@ const testIdCIDString = testIdCID.toString()
 
 describe('PeerId', () => {
   it('create an id without \'new\'', () => {
-    expect(PeerId).to.throw(Error)
+    // @ts-expect-error missing args
+    expect(() => createPeerId()).to.throw(Error)
   })
 
   it('create a new id', async () => {
@@ -45,49 +46,49 @@ describe('PeerId', () => {
 
   it('can get the public key from a Secp256k1 key', async () => {
     const original = await PeerIdFactory.createSecp256k1PeerId()
-    const newId = PeerId.fromString(original.toString(base58btc))
+    const newId = peerIdFromString(original.toString(base58btc))
     expect(original.publicKey).to.equalBytes(newId.publicKey)
   })
 
   it('recreate from a Uint8Array', () => {
-    const id = PeerId.fromBytes(testIdBytes)
+    const id = peerIdFromBytes(testIdBytes)
     expect(testId.id).to.equal(uint8ArrayToString(id.multihash.bytes, 'base16'))
     expect(testIdBytes).to.equalBytes(id.multihash.bytes)
   })
 
   it('recreate from a B58 String', () => {
-    const id = PeerId.fromString(testIdB58String)
+    const id = peerIdFromString(testIdB58String)
     expect(testIdB58String).to.equal(id.toString())
     expect(testIdBytes).to.equalBytes(id.multihash.bytes)
   })
 
   it('recreate from CID object', () => {
-    const id = PeerId.fromCID(testIdCID)
+    const id = peerIdFromCID(testIdCID)
     expect(testIdCIDString).to.equal(id.toCID().toString())
     expect(testIdBytes).to.equalBytes(id.multihash.bytes)
   })
 
   it('recreate from Base58 String (CIDv0)', () => {
-    const id = PeerId.fromCID(CID.parse(testIdB58String))
+    const id = peerIdFromCID(CID.parse(testIdB58String))
     expect(testIdCIDString).to.equal(id.toCID().toString())
     expect(testIdBytes).to.equalBytes(id.multihash.bytes)
   })
 
   it('recreate from Base36 String', () => {
-    const id = PeerId.fromString(testIdB36String)
+    const id = peerIdFromString(testIdB36String)
     expect(testIdCIDString).to.equal(id.toCID().toString())
     expect(testIdBytes).to.equalBytes(id.multihash.bytes)
   })
 
   it('recreate from CIDv1 Base32 (libp2p-key multicodec)', () => {
     const cid = CID.createV1(LIBP2P_KEY_CODE, testIdDigest)
-    const id = PeerId.fromCID(cid)
+    const id = peerIdFromCID(cid)
     expect(cid.toString()).to.equal(id.toCID().toString())
     expect(testIdBytes).to.equalBytes(id.multihash.bytes)
   })
 
   it('recreate from CID Uint8Array', () => {
-    const id = PeerId.fromBytes(testIdCID.bytes)
+    const id = peerIdFromBytes(testIdCID.bytes)
     expect(testIdCIDString).to.equal(id.toCID().toString())
     expect(testIdBytes).to.equalBytes(id.multihash.bytes)
   })
@@ -96,7 +97,7 @@ describe('PeerId', () => {
     // only libp2p and dag-pb are supported
     const invalidCID = CID.createV1(RAW_CODE, testIdDigest)
     expect(() => {
-      PeerId.fromCID(invalidCID)
+      peerIdFromCID(invalidCID)
     }).to.throw(/invalid/i)
   })
 
@@ -105,7 +106,7 @@ describe('PeerId', () => {
     // https://github.com/multiformats/js-multihash/blob/b85999d5768bf06f1b0f16b926ef2cb6d9c14265/src/constants.js#L345
     const invalidMultihash = uint8ArrayToString(Uint8Array.from([0x50, 0x1, 0x0]), 'base58btc')
     expect(() => {
-      PeerId.fromString(invalidMultihash)
+      peerIdFromString(invalidMultihash)
     }).to.throw(/Non-base32hexpadupper character/i)
   })
 
@@ -113,7 +114,7 @@ describe('PeerId', () => {
     const invalidCID = {}
     expect(() => {
       // @ts-expect-error invalid cid is invalid type
-      PeerId.fromCID(invalidCID)
+      peerIdFromCID(invalidCID)
     }).to.throw(/invalid/i)
   })
 
@@ -153,7 +154,7 @@ describe('PeerId', () => {
 
   it('recreate from embedded ed25519 key', async () => {
     const key = '12D3KooWRm8J3iL796zPFi2EtGGtUJn58AG67gcqzMFHZnnsTzqD'
-    const id = await PeerId.fromString(key)
+    const id = await peerIdFromString(key)
     expect(id.toString()).to.equal(key)
 
     if (id.publicKey == null) {
@@ -166,7 +167,7 @@ describe('PeerId', () => {
 
   it('recreate from embedded secp256k1 key', async () => {
     const key = '16Uiu2HAm5qw8UyXP2RLxQUx5KvtSN8DsTKz8quRGqGNC3SYiaB8E'
-    const id = await PeerId.fromString(key)
+    const id = await peerIdFromString(key)
     expect(id.toString()).to.equal(key)
 
     if (id.publicKey == null) {
@@ -179,7 +180,7 @@ describe('PeerId', () => {
 
   it('recreate from string key', async () => {
     const key = 'QmRsooYQasV5f5r834NSpdUtmejdQcpxXkK6qsozZWEihC'
-    const id = await PeerId.fromString(key)
+    const id = await peerIdFromString(key)
     expect(id.toString()).to.equal(key)
   })
 
@@ -258,7 +259,7 @@ describe('PeerId', () => {
     it('only id', async () => {
       const key = await keys.generateKeyPair('RSA', 1024)
       const digest = await key.public.hash()
-      const id = PeerId.fromBytes(digest)
+      const id = peerIdFromBytes(digest)
       expect(id.privateKey).to.not.exist()
       expect(id.publicKey).to.not.exist()
       const other = await PeerIdFactory.createFromJSON({
@@ -277,8 +278,8 @@ describe('PeerId', () => {
 
   it('keys are equal after one is stringified', async () => {
     const peerId = await PeerIdFactory.createEd25519PeerId()
-    const peerId1 = PeerId.fromString(peerId.toString(base58btc))
-    const peerId2 = PeerId.fromString(peerId.toString(base58btc))
+    const peerId1 = peerIdFromString(peerId.toString(base58btc))
+    const peerId2 = peerIdFromString(peerId.toString(base58btc))
 
     expect(peerId1).to.deep.equal(peerId2)
 

--- a/packages/libp2p-peer-id/test/index.spec.js
+++ b/packages/libp2p-peer-id/test/index.spec.js
@@ -1,80 +1,81 @@
 /* eslint-env mocha */
 import { expect } from 'aegir/utils/chai.js'
-import { PeerId } from '../src/index.js'
+import { createPeerId, peerIdFromBytes, peerIdFromString } from '../src/index.js'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { base58btc } from 'multiformats/bases/base58'
 
 describe('PeerId', () => {
   it('create an id without \'new\'', () => {
-    expect(PeerId).to.throw(Error)
+    // @ts-expect-error missing args
+    expect(() => createPeerId()).to.throw(Error)
   })
 
   it('create a new id from multihash', async () => {
     const buf = uint8ArrayFromString('12D3KooWbtp1AcgweFSArD7dbKWYpAr8MZR1tofwNwLFLjeNGLWa', 'base58btc')
-    const id = PeerId.fromBytes(buf)
+    const id = peerIdFromBytes(buf)
     expect(id.equals(buf)).to.be.true()
   })
 
   it('defaults to base58btc when stringifying', async () => {
     const buf = uint8ArrayFromString('12D3KooWbtp1AcgweFSArD7dbKWYpAr8MZR1tofwNwLFLjeNGLWa', 'base58btc')
-    const id = PeerId.fromBytes(buf)
+    const id = peerIdFromBytes(buf)
     expect(id.toString()).to.equal('12D3KooWbtp1AcgweFSArD7dbKWYpAr8MZR1tofwNwLFLjeNGLWa')
   })
 
   it('accepts a multibase encoder when stringifying', async () => {
     const buf = uint8ArrayFromString('12D3KooWbtp1AcgweFSArD7dbKWYpAr8MZR1tofwNwLFLjeNGLWa', 'base58btc')
-    const id = PeerId.fromBytes(buf)
+    const id = peerIdFromBytes(buf)
     expect(id.toString(base58btc)).to.equal('12D3KooWbtp1AcgweFSArD7dbKWYpAr8MZR1tofwNwLFLjeNGLWa')
   })
 
   it('turns into a CID', async () => {
     const buf = uint8ArrayFromString('12D3KooWbtp1AcgweFSArD7dbKWYpAr8MZR1tofwNwLFLjeNGLWa', 'base58btc')
-    const id = PeerId.fromBytes(buf)
+    const id = peerIdFromBytes(buf)
     expect(id.toCID().toString()).to.equal('bafzaajaiaejcda3tmul6p2537j5upxpjgz3jabbzxqrjqvhhfnthtnezvwibizjh')
   })
 
   it('equals a Uint8Array', async () => {
     const buf = uint8ArrayFromString('12D3KooWbtp1AcgweFSArD7dbKWYpAr8MZR1tofwNwLFLjeNGLWa', 'base58btc')
-    const id = PeerId.fromBytes(buf)
+    const id = peerIdFromBytes(buf)
     expect(id.equals(buf)).to.be.true()
   })
 
   it('equals a PeerId', async () => {
     const buf = uint8ArrayFromString('12D3KooWbtp1AcgweFSArD7dbKWYpAr8MZR1tofwNwLFLjeNGLWa', 'base58btc')
-    const id = PeerId.fromBytes(buf)
-    expect(id.equals(PeerId.fromBytes(buf))).to.be.true()
+    const id = peerIdFromBytes(buf)
+    expect(id.equals(peerIdFromBytes(buf))).to.be.true()
   })
 
   it('parses a PeerId as Ed25519', async () => {
-    const id = PeerId.fromString('12D3KooWbtp1AcgweFSArD7dbKWYpAr8MZR1tofwNwLFLjeNGLWa')
+    const id = peerIdFromString('12D3KooWbtp1AcgweFSArD7dbKWYpAr8MZR1tofwNwLFLjeNGLWa')
     expect(id).to.have.property('type', 'Ed25519')
   })
 
   it('parses a PeerId as RSA', async () => {
-    const id = PeerId.fromString('QmZHBBrcBtDk7yVzcNUDJBJsZnVGtPHzpTzu16J7Sk6hbp')
+    const id = peerIdFromString('QmZHBBrcBtDk7yVzcNUDJBJsZnVGtPHzpTzu16J7Sk6hbp')
     expect(id).to.have.property('type', 'RSA')
   })
 
   it('parses a PeerId as secp256k1', async () => {
-    const id = PeerId.fromString('16Uiu2HAkxSnqYGDU5iZTQrZyAcQDQHKrZqSNPBmKFifEagS2XfrL')
+    const id = peerIdFromString('16Uiu2HAkxSnqYGDU5iZTQrZyAcQDQHKrZqSNPBmKFifEagS2XfrL')
     expect(id).to.have.property('type', 'secp256k1')
   })
 
   it('decodes a PeerId as Ed25519', async () => {
     const buf = uint8ArrayFromString('12D3KooWbtp1AcgweFSArD7dbKWYpAr8MZR1tofwNwLFLjeNGLWa', 'base58btc')
-    const id = PeerId.fromBytes(buf)
+    const id = peerIdFromBytes(buf)
     expect(id).to.have.property('type', 'Ed25519')
   })
 
   it('decodes a PeerId as RSA', async () => {
     const buf = uint8ArrayFromString('QmZHBBrcBtDk7yVzcNUDJBJsZnVGtPHzpTzu16J7Sk6hbp', 'base58btc')
-    const id = PeerId.fromBytes(buf)
+    const id = peerIdFromBytes(buf)
     expect(id).to.have.property('type', 'RSA')
   })
 
   it('decodes a PeerId as secp256k1', async () => {
     const buf = uint8ArrayFromString('16Uiu2HAkxSnqYGDU5iZTQrZyAcQDQHKrZqSNPBmKFifEagS2XfrL', 'base58btc')
-    const id = PeerId.fromBytes(buf)
+    const id = peerIdFromBytes(buf)
     expect(id).to.have.property('type', 'secp256k1')
   })
 })

--- a/packages/libp2p-peer-id/tsconfig.json
+++ b/packages/libp2p-peer-id/tsconfig.json
@@ -8,5 +8,10 @@
   "include": [
     "src",
     "test"
+  ],
+  "references": [
+    {
+      "path": "../libp2p-interfaces"
+    }
   ]
 }

--- a/packages/libp2p-peer-record/src/envelope/index.ts
+++ b/packages/libp2p-peer-record/src/envelope/index.ts
@@ -6,7 +6,7 @@ import varint from 'varint'
 import { equals as uint8arraysEquals } from 'uint8arrays/equals'
 import { codes } from '../errors.js'
 import { Envelope as Protobuf } from './envelope.js'
-import { PeerId as PeerIdImpl } from '@libp2p/peer-id'
+import { peerIdFromKeys } from '@libp2p/peer-id'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import type { Record, Envelope } from '@libp2p/interfaces/record'
 
@@ -23,7 +23,7 @@ export class RecordEnvelope implements Envelope {
    */
   static createFromProtobuf = async (data: Uint8Array) => {
     const envelopeData = Protobuf.decode(data)
-    const peerId = await PeerIdImpl.fromKeys(envelopeData.publicKey)
+    const peerId = await peerIdFromKeys(envelopeData.publicKey)
 
     return new RecordEnvelope({
       peerId,

--- a/packages/libp2p-peer-record/src/peer-record/index.ts
+++ b/packages/libp2p-peer-record/src/peer-record/index.ts
@@ -1,7 +1,7 @@
 import { Multiaddr } from '@multiformats/multiaddr'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import { arrayEquals } from '@libp2p/utils/array-equals'
-import { PeerId as PeerIdImpl } from '@libp2p/peer-id'
+import { peerIdFromBytes } from '@libp2p/peer-id'
 import { PeerRecord as Protobuf } from './peer-record.js'
 import {
   ENVELOPE_DOMAIN_PEER_RECORD,
@@ -35,7 +35,7 @@ export class PeerRecord {
    */
   static createFromProtobuf = (buf: Uint8Array) => {
     const peerRecord = Protobuf.decode(buf)
-    const peerId = PeerIdImpl.fromBytes(peerRecord.peerId)
+    const peerId = peerIdFromBytes(peerRecord.peerId)
     const multiaddrs = (peerRecord.addresses ?? []).map((a) => new Multiaddr(a.multiaddr))
     const seqNumber = Number(peerRecord.seq)
 

--- a/packages/libp2p-peer-record/test/peer-record.spec.ts
+++ b/packages/libp2p-peer-record/test/peer-record.spec.ts
@@ -3,11 +3,12 @@
 import { expect } from 'aegir/utils/chai.js'
 import tests from '@libp2p/interface-compliance-tests/record'
 import { Multiaddr } from '@multiformats/multiaddr'
-import { PeerId } from '@libp2p/peer-id'
+import { peerIdFromKeys } from '@libp2p/peer-id'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { RecordEnvelope } from '../src/envelope/index.js'
 import { PeerRecord } from '../src/peer-record/index.js'
 import { unmarshalPrivateKey } from '@libp2p/crypto/keys'
+import type { PeerId } from '@libp2p/interfaces/peer-id'
 
 describe('interface-record compliance', () => {
   tests({
@@ -32,7 +33,7 @@ describe('PeerRecord', () => {
     const privKey = Uint8Array.from([8, 1, 18, 64, 133, 251, 231, 43, 96, 100, 40, 144, 4, 165, 49, 249, 103, 137, 141, 245, 49, 158, 224, 41, 146, 253, 216, 64, 33, 250, 80, 82, 67, 75, 246, 238, 17, 187, 163, 237, 23, 33, 148, 140, 239, 180, 229, 11, 10, 11, 181, 202, 216, 166, 181, 45, 199, 177, 164, 15, 79, 102, 82, 16, 92, 145, 226, 196])
     const rawEnvelope = Uint8Array.from([10, 36, 8, 1, 18, 32, 17, 187, 163, 237, 23, 33, 148, 140, 239, 180, 229, 11, 10, 11, 181, 202, 216, 166, 181, 45, 199, 177, 164, 15, 79, 102, 82, 16, 92, 145, 226, 196, 18, 2, 3, 1, 26, 170, 1, 10, 38, 0, 36, 8, 1, 18, 32, 17, 187, 163, 237, 23, 33, 148, 140, 239, 180, 229, 11, 10, 11, 181, 202, 216, 166, 181, 45, 199, 177, 164, 15, 79, 102, 82, 16, 92, 145, 226, 196, 16, 216, 184, 224, 191, 147, 145, 182, 151, 22, 26, 10, 10, 8, 4, 1, 2, 3, 4, 6, 0, 0, 26, 10, 10, 8, 4, 1, 2, 3, 4, 6, 0, 1, 26, 10, 10, 8, 4, 1, 2, 3, 4, 6, 0, 2, 26, 10, 10, 8, 4, 1, 2, 3, 4, 6, 0, 3, 26, 10, 10, 8, 4, 1, 2, 3, 4, 6, 0, 4, 26, 10, 10, 8, 4, 1, 2, 3, 4, 6, 0, 5, 26, 10, 10, 8, 4, 1, 2, 3, 4, 6, 0, 6, 26, 10, 10, 8, 4, 1, 2, 3, 4, 6, 0, 7, 26, 10, 10, 8, 4, 1, 2, 3, 4, 6, 0, 8, 26, 10, 10, 8, 4, 1, 2, 3, 4, 6, 0, 9, 42, 64, 177, 151, 247, 107, 159, 40, 138, 242, 180, 103, 254, 102, 111, 119, 68, 118, 40, 112, 73, 180, 36, 183, 57, 117, 200, 134, 14, 251, 2, 55, 45, 2, 106, 121, 149, 132, 84, 26, 215, 47, 38, 84, 52, 100, 133, 188, 163, 236, 227, 100, 98, 183, 209, 177, 57, 28, 141, 39, 109, 196, 171, 139, 202, 11])
     const key = await unmarshalPrivateKey(privKey)
-    const peerId = await PeerId.fromKeys(key.public.bytes, key.bytes)
+    const peerId = await peerIdFromKeys(key.public.bytes, key.bytes)
 
     const env = await RecordEnvelope.openAndCertify(rawEnvelope, PeerRecord.DOMAIN)
     expect(peerId.equals(env.peerId))

--- a/packages/libp2p-peer-store/src/address-book.ts
+++ b/packages/libp2p-peer-store/src/address-book.ts
@@ -9,7 +9,7 @@ import filter from 'it-filter'
 import map from 'it-map'
 import each from 'it-foreach'
 import { base58btc } from 'multiformats/bases/base58'
-import { PeerId as PeerIdImpl } from '@libp2p/peer-id'
+import { peerIdFromPeerId } from '@libp2p/peer-id'
 import { CustomEvent } from '@libp2p/interfaces'
 import type { PeerStore } from '@libp2p/interfaces/peer-store'
 import type { Store } from './store.js'
@@ -139,7 +139,7 @@ export class PeerStoreAddressBook {
   }
 
   async get (peerId: PeerId) {
-    peerId = PeerIdImpl.fromPeerId(peerId)
+    peerId = peerIdFromPeerId(peerId)
 
     log('get wait for read lock')
     const release = await this.store.lock.readLock()
@@ -162,7 +162,7 @@ export class PeerStoreAddressBook {
   }
 
   async set (peerId: PeerId, multiaddrs: Multiaddr[]) {
-    peerId = PeerIdImpl.fromPeerId(peerId)
+    peerId = peerIdFromPeerId(peerId)
 
     if (!Array.isArray(multiaddrs)) {
       log.error('multiaddrs must be an array of Multiaddrs')
@@ -224,7 +224,7 @@ export class PeerStoreAddressBook {
   }
 
   async add (peerId: PeerId, multiaddrs: Multiaddr[]) {
-    peerId = PeerIdImpl.fromPeerId(peerId)
+    peerId = peerIdFromPeerId(peerId)
 
     if (!Array.isArray(multiaddrs)) {
       log.error('multiaddrs must be an array of Multiaddrs')
@@ -283,7 +283,7 @@ export class PeerStoreAddressBook {
   }
 
   async delete (peerId: PeerId) {
-    peerId = PeerIdImpl.fromPeerId(peerId)
+    peerId = peerIdFromPeerId(peerId)
 
     log('delete await write lock')
     const release = await this.store.lock.writeLock()

--- a/packages/libp2p-peer-store/src/index.ts
+++ b/packages/libp2p-peer-store/src/index.ts
@@ -30,7 +30,7 @@ export interface PeerStoreOptions {
 /**
  * An implementation of PeerStore that stores data in a Datastore
  */
-export class DefaultPeerStore extends EventEmitter<PeerStoreEvents> implements PeerStore {
+export class PeerStoreImpl extends EventEmitter<PeerStoreEvents> implements PeerStore {
   public addressBook: AddressBook
   public keyBook: KeyBook
   public metadataBook: MetadataBook
@@ -120,4 +120,8 @@ export class DefaultPeerStore extends EventEmitter<PeerStoreEvents> implements P
       release()
     }
   }
+}
+
+export function createPeerStore (opts: PeerStoreOptions): PeerStore {
+  return new PeerStoreImpl(opts)
 }

--- a/packages/libp2p-peer-store/src/key-book.ts
+++ b/packages/libp2p-peer-store/src/key-book.ts
@@ -1,7 +1,7 @@
 import { logger } from '@libp2p/logger'
 import errcode from 'err-code'
 import { codes } from './errors.js'
-import { PeerId as PeerIdImpl } from '@libp2p/peer-id'
+import { peerIdFromPeerId } from '@libp2p/peer-id'
 import { equals as uint8arrayEquals } from 'uint8arrays/equals'
 import { CustomEvent } from '@libp2p/interfaces'
 import type { Store } from './store.js'
@@ -28,7 +28,7 @@ export class PeerStoreKeyBook implements KeyBook {
    * Set the Peer public key
    */
   async set (peerId: PeerId, publicKey: Uint8Array) {
-    peerId = PeerIdImpl.fromPeerId(peerId)
+    peerId = peerIdFromPeerId(peerId)
 
     if (!(publicKey instanceof Uint8Array)) {
       log.error('publicKey must be an instance of Uint8Array to store data')
@@ -74,7 +74,7 @@ export class PeerStoreKeyBook implements KeyBook {
    * Get Public key of the given PeerId, if stored
    */
   async get (peerId: PeerId) {
-    peerId = PeerIdImpl.fromPeerId(peerId)
+    peerId = peerIdFromPeerId(peerId)
 
     log('get await write lock')
     const release = await this.store.lock.readLock()
@@ -95,7 +95,7 @@ export class PeerStoreKeyBook implements KeyBook {
   }
 
   async delete (peerId: PeerId) {
-    peerId = PeerIdImpl.fromPeerId(peerId)
+    peerId = peerIdFromPeerId(peerId)
 
     log('delete await write lock')
     const release = await this.store.lock.writeLock()

--- a/packages/libp2p-peer-store/src/metadata-book.ts
+++ b/packages/libp2p-peer-store/src/metadata-book.ts
@@ -1,7 +1,7 @@
 import { logger } from '@libp2p/logger'
 import errcode from 'err-code'
 import { codes } from './errors.js'
-import { PeerId as PeerIdImpl } from '@libp2p/peer-id'
+import { peerIdFromPeerId } from '@libp2p/peer-id'
 import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { CustomEvent } from '@libp2p/interfaces'
 import type { Store } from './store.js'
@@ -29,7 +29,7 @@ export class PeerStoreMetadataBook implements MetadataBook {
    * Get the known data of a provided peer
    */
   async get (peerId: PeerId) {
-    peerId = PeerIdImpl.fromPeerId(peerId)
+    peerId = peerIdFromPeerId(peerId)
 
     log('get await read lock')
     const release = await this.store.lock.readLock()
@@ -55,7 +55,7 @@ export class PeerStoreMetadataBook implements MetadataBook {
    * Get specific metadata value, if it exists
    */
   async getValue (peerId: PeerId, key: string) {
-    peerId = PeerIdImpl.fromPeerId(peerId)
+    peerId = peerIdFromPeerId(peerId)
 
     log('getValue await read lock')
     const release = await this.store.lock.readLock()
@@ -76,7 +76,7 @@ export class PeerStoreMetadataBook implements MetadataBook {
   }
 
   async set (peerId: PeerId, metadata: Map<string, Uint8Array>) {
-    peerId = PeerIdImpl.fromPeerId(peerId)
+    peerId = peerIdFromPeerId(peerId)
 
     if (!(metadata instanceof Map)) {
       log.error('valid metadata must be provided to store data')
@@ -105,7 +105,7 @@ export class PeerStoreMetadataBook implements MetadataBook {
    * Set metadata key and value of a provided peer
    */
   async setValue (peerId: PeerId, key: string, value: Uint8Array) {
-    peerId = PeerIdImpl.fromPeerId(peerId)
+    peerId = peerIdFromPeerId(peerId)
 
     if (typeof key !== 'string' || !(value instanceof Uint8Array)) {
       log.error('valid key and value must be provided to store data')
@@ -146,7 +146,7 @@ export class PeerStoreMetadataBook implements MetadataBook {
   }
 
   async delete (peerId: PeerId) {
-    peerId = PeerIdImpl.fromPeerId(peerId)
+    peerId = peerIdFromPeerId(peerId)
 
     log('delete await write lock')
     const release = await this.store.lock.writeLock()
@@ -175,7 +175,7 @@ export class PeerStoreMetadataBook implements MetadataBook {
   }
 
   async deleteValue (peerId: PeerId, key: string) {
-    peerId = PeerIdImpl.fromPeerId(peerId)
+    peerId = peerIdFromPeerId(peerId)
 
     log('deleteValue await write lock')
     const release = await this.store.lock.writeLock()

--- a/packages/libp2p-peer-store/src/proto-book.ts
+++ b/packages/libp2p-peer-store/src/proto-book.ts
@@ -1,7 +1,7 @@
 import { logger } from '@libp2p/logger'
 import errcode from 'err-code'
 import { codes } from './errors.js'
-import { PeerId as PeerIdImpl } from '@libp2p/peer-id'
+import { peerIdFromPeerId } from '@libp2p/peer-id'
 import { base58btc } from 'multiformats/bases/base58'
 import { CustomEvent } from '@libp2p/interfaces'
 import type { Store } from './store.js'
@@ -47,7 +47,7 @@ export class PeerStoreProtoBook implements ProtoBook {
   }
 
   async set (peerId: PeerId, protocols: string[]) {
-    peerId = PeerIdImpl.fromPeerId(peerId)
+    peerId = peerIdFromPeerId(peerId)
 
     if (!Array.isArray(protocols)) {
       log.error('protocols must be provided to store data')
@@ -91,7 +91,7 @@ export class PeerStoreProtoBook implements ProtoBook {
   }
 
   async add (peerId: PeerId, protocols: string[]) {
-    peerId = PeerIdImpl.fromPeerId(peerId)
+    peerId = peerIdFromPeerId(peerId)
 
     if (!Array.isArray(protocols)) {
       log.error('protocols must be provided to store data')
@@ -136,7 +136,7 @@ export class PeerStoreProtoBook implements ProtoBook {
   }
 
   async remove (peerId: PeerId, protocols: string[]) {
-    peerId = PeerIdImpl.fromPeerId(peerId)
+    peerId = peerIdFromPeerId(peerId)
 
     if (!Array.isArray(protocols)) {
       log.error('protocols must be provided to store data')
@@ -183,7 +183,7 @@ export class PeerStoreProtoBook implements ProtoBook {
   }
 
   async delete (peerId: PeerId) {
-    peerId = PeerIdImpl.fromPeerId(peerId)
+    peerId = peerIdFromPeerId(peerId)
 
     log('delete await write lock')
     const release = await this.store.lock.writeLock()

--- a/packages/libp2p-peer-store/src/store.ts
+++ b/packages/libp2p-peer-store/src/store.ts
@@ -1,5 +1,5 @@
 import { logger } from '@libp2p/logger'
-import { PeerId as PeerIdImpl } from '@libp2p/peer-id'
+import { peerIdFromBytes } from '@libp2p/peer-id'
 import errcode from 'err-code'
 import { codes } from './errors.js'
 import { Key } from 'interface-datastore/key'
@@ -219,7 +219,7 @@ export class PersistentStore {
       const base32Str = key.toString().split('/')[2]
       const buf = base32.decode(base32Str)
 
-      yield this.load(PeerIdImpl.fromBytes(buf))
+      yield this.load(peerIdFromBytes(buf))
     }
   }
 }

--- a/packages/libp2p-peer-store/test/address-book.spec.ts
+++ b/packages/libp2p-peer-store/test/address-book.spec.ts
@@ -8,7 +8,7 @@ import { publicAddressesFirst } from '@libp2p/utils/address-sort'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import pDefer from 'p-defer'
 import { MemoryDatastore } from 'datastore-core/memory'
-import { DefaultPeerStore } from '../src/index.js'
+import { createPeerStore } from '../src/index.js'
 import { RecordEnvelope, PeerRecord } from '@libp2p/peer-record'
 import { mockConnectionGater } from '@libp2p/interface-compliance-tests/mocks'
 import { codes } from '../src/errors.js'
@@ -34,7 +34,7 @@ describe('addressBook', () => {
     let ab: AddressBook
 
     beforeEach(() => {
-      peerStore = new DefaultPeerStore({
+      peerStore = createPeerStore({
         peerId,
         datastore: new MemoryDatastore(),
         addressFilter: connectionGater.filterMultiaddrForPeer
@@ -155,7 +155,7 @@ describe('addressBook', () => {
     let ab: AddressBook
 
     beforeEach(() => {
-      peerStore = new DefaultPeerStore({
+      peerStore = createPeerStore({
         peerId,
         datastore: new MemoryDatastore(),
         addressFilter: connectionGater.filterMultiaddrForPeer
@@ -313,7 +313,7 @@ describe('addressBook', () => {
     let ab: AddressBook
 
     beforeEach(() => {
-      peerStore = new DefaultPeerStore({
+      peerStore = createPeerStore({
         peerId,
         datastore: new MemoryDatastore(),
         addressFilter: connectionGater.filterMultiaddrForPeer
@@ -354,7 +354,7 @@ describe('addressBook', () => {
     let ab: AddressBook
 
     beforeEach(() => {
-      peerStore = new DefaultPeerStore({
+      peerStore = createPeerStore({
         peerId,
         datastore: new MemoryDatastore(),
         addressFilter: connectionGater.filterMultiaddrForPeer
@@ -408,7 +408,7 @@ describe('addressBook', () => {
     let ab: AddressBook
 
     beforeEach(() => {
-      peerStore = new DefaultPeerStore({
+      peerStore = createPeerStore({
         peerId,
         datastore: new MemoryDatastore(),
         addressFilter: connectionGater.filterMultiaddrForPeer
@@ -469,7 +469,7 @@ describe('addressBook', () => {
 
     describe('consumes a valid peer record and stores its data', () => {
       beforeEach(() => {
-        peerStore = new DefaultPeerStore({
+        peerStore = createPeerStore({
           peerId,
           datastore: new MemoryDatastore(),
           addressFilter: connectionGater.filterMultiaddrForPeer
@@ -674,7 +674,7 @@ describe('addressBook', () => {
 
     describe('fails to consume invalid peer records', () => {
       beforeEach(() => {
-        peerStore = new DefaultPeerStore({
+        peerStore = createPeerStore({
           peerId,
           datastore: new MemoryDatastore(),
           addressFilter: connectionGater.filterMultiaddrForPeer

--- a/packages/libp2p-peer-store/test/key-book.spec.ts
+++ b/packages/libp2p-peer-store/test/key-book.spec.ts
@@ -3,7 +3,7 @@
 import { expect } from 'aegir/utils/chai.js'
 import sinon from 'sinon'
 import { MemoryDatastore } from 'datastore-core/memory'
-import { DefaultPeerStore } from '../src/index.js'
+import { createPeerStore } from '../src/index.js'
 import pDefer from 'p-defer'
 import { codes } from '../src/errors.js'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
@@ -20,7 +20,7 @@ describe('keyBook', () => {
   beforeEach(async () => {
     peerId = await createEd25519PeerId()
     datastore = new MemoryDatastore()
-    peerStore = new DefaultPeerStore({
+    peerStore = createPeerStore({
       peerId,
       datastore
     })

--- a/packages/libp2p-peer-store/test/metadata-book.spec.ts
+++ b/packages/libp2p-peer-store/test/metadata-book.spec.ts
@@ -5,7 +5,7 @@ import { expect } from 'aegir/utils/chai.js'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { MemoryDatastore } from 'datastore-core/memory'
 import pDefer from 'p-defer'
-import { DefaultPeerStore } from '../src/index.js'
+import { createPeerStore } from '../src/index.js'
 import { codes } from '../src/errors.js'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
@@ -23,7 +23,7 @@ describe('metadataBook', () => {
     let mb: MetadataBook
 
     beforeEach(() => {
-      peerStore = new DefaultPeerStore({
+      peerStore = createPeerStore({
         peerId,
         datastore: new MemoryDatastore()
       })
@@ -163,7 +163,7 @@ describe('metadataBook', () => {
     let mb: MetadataBook
 
     beforeEach(() => {
-      peerStore = new DefaultPeerStore({
+      peerStore = createPeerStore({
         peerId,
         datastore: new MemoryDatastore()
       })
@@ -206,7 +206,7 @@ describe('metadataBook', () => {
     let mb: MetadataBook
 
     beforeEach(() => {
-      peerStore = new DefaultPeerStore({
+      peerStore = createPeerStore({
         peerId,
         datastore: new MemoryDatastore()
       })
@@ -259,7 +259,7 @@ describe('metadataBook', () => {
     let mb: MetadataBook
 
     beforeEach(() => {
-      peerStore = new DefaultPeerStore({
+      peerStore = createPeerStore({
         peerId,
         datastore: new MemoryDatastore()
       })
@@ -317,7 +317,7 @@ describe('metadataBook', () => {
     let mb: MetadataBook
 
     beforeEach(() => {
-      peerStore = new DefaultPeerStore({
+      peerStore = createPeerStore({
         peerId,
         datastore: new MemoryDatastore()
       })

--- a/packages/libp2p-peer-store/test/peer-store.spec.ts
+++ b/packages/libp2p-peer-store/test/peer-store.spec.ts
@@ -2,7 +2,7 @@
 
 import { expect } from 'aegir/utils/chai.js'
 import all from 'it-all'
-import { DefaultPeerStore } from '../src/index.js'
+import { createPeerStore } from '../src/index.js'
 import { Multiaddr } from '@multiformats/multiaddr'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { MemoryDatastore } from 'datastore-core/memory'
@@ -39,7 +39,7 @@ describe('peer-store', () => {
     let peerStore: PeerStore
 
     beforeEach(() => {
-      peerStore = new DefaultPeerStore({
+      peerStore = createPeerStore({
         peerId: peerIds[4],
         datastore: new MemoryDatastore(),
         addressFilter: connectionGater.filterMultiaddrForPeer
@@ -72,7 +72,7 @@ describe('peer-store', () => {
     let peerStore: PeerStore
 
     beforeEach(async () => {
-      peerStore = new DefaultPeerStore({
+      peerStore = createPeerStore({
         peerId: peerIds[4],
         datastore: new MemoryDatastore(),
         addressFilter: connectionGater.filterMultiaddrForPeer
@@ -176,7 +176,7 @@ describe('peer-store', () => {
     let peerStore: PeerStore
 
     beforeEach(() => {
-      peerStore = new DefaultPeerStore({
+      peerStore = createPeerStore({
         peerId: peerIds[4],
         datastore: new MemoryDatastore(),
         addressFilter: connectionGater.filterMultiaddrForPeer

--- a/packages/libp2p-peer-store/test/proto-book.spec.ts
+++ b/packages/libp2p-peer-store/test/proto-book.spec.ts
@@ -5,7 +5,7 @@ import sinon from 'sinon'
 import { MemoryDatastore } from 'datastore-core/memory'
 import pDefer from 'p-defer'
 import pWaitFor from 'p-wait-for'
-import { DefaultPeerStore } from '../src/index.js'
+import { createPeerStore } from '../src/index.js'
 import { codes } from '../src/errors.js'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
@@ -31,7 +31,7 @@ describe('protoBook', () => {
     let pb: ProtoBook
 
     beforeEach(() => {
-      peerStore = new DefaultPeerStore({
+      peerStore = createPeerStore({
         peerId,
         datastore: new MemoryDatastore()
       })
@@ -126,7 +126,7 @@ describe('protoBook', () => {
     let pb: ProtoBook
 
     beforeEach(() => {
-      peerStore = new DefaultPeerStore({
+      peerStore = createPeerStore({
         peerId,
         datastore: new MemoryDatastore()
       })
@@ -232,7 +232,7 @@ describe('protoBook', () => {
     let pb: ProtoBook
 
     beforeEach(() => {
-      peerStore = new DefaultPeerStore({
+      peerStore = createPeerStore({
         peerId,
         datastore: new MemoryDatastore()
       })
@@ -320,7 +320,7 @@ describe('protoBook', () => {
     let pb: ProtoBook
 
     beforeEach(() => {
-      peerStore = new DefaultPeerStore({
+      peerStore = createPeerStore({
         peerId,
         datastore: new MemoryDatastore()
       })
@@ -353,7 +353,7 @@ describe('protoBook', () => {
     let pb: ProtoBook
 
     beforeEach(() => {
-      peerStore = new DefaultPeerStore({
+      peerStore = createPeerStore({
         peerId,
         datastore: new MemoryDatastore()
       })

--- a/packages/libp2p-pubsub/src/message/sign.ts
+++ b/packages/libp2p-pubsub/src/message/sign.ts
@@ -5,7 +5,7 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { normalizeOutRpcMessage } from '../utils.js'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import { keys } from '@libp2p/crypto'
-import { PeerId as PeerIdImpl } from '@libp2p/peer-id'
+import { peerIdFromBytes } from '@libp2p/peer-id'
 import type { Message } from '@libp2p/interfaces/pubsub'
 
 export const SignPrefix = uint8ArrayFromString('libp2p-pubsub:')
@@ -80,7 +80,7 @@ export async function messagePublicKey (message: Message) {
     throw new Error('Could not get the public key from the originator id')
   }
 
-  const from = PeerIdImpl.fromBytes(message.from)
+  const from = peerIdFromBytes(message.from)
 
   if (message.key != null) {
     const keyPeerId = await PeerIdFactory.createFromPubKey(keys.unmarshalPublicKey(message.key))

--- a/packages/libp2p-pubsub/src/utils.ts
+++ b/packages/libp2p-pubsub/src/utils.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'iso-random-stream'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import { PeerId } from '@libp2p/peer-id'
+import { peerIdFromBytes, peerIdFromString } from '@libp2p/peer-id'
 import { sha256 } from 'multiformats/hashes/sha2'
 import type * as RPC from './message/rpc.js'
 import type { Message } from '@libp2p/interfaces/pubsub'
@@ -16,12 +16,12 @@ export const randomSeqno = () => {
  * Generate a message id, based on the `from` and `seqno`
  */
 export const msgId = (from: Uint8Array | string, seqno: Uint8Array) => {
-  let fromBytes
+  let fromBytes: Uint8Array
 
   if (from instanceof Uint8Array) {
-    fromBytes = PeerId.fromBytes(from).multihash.digest
+    fromBytes = peerIdFromBytes(from).multihash.digest
   } else {
-    fromBytes = PeerId.fromString(from).multihash.digest
+    fromBytes = peerIdFromString(from).multihash.digest
   }
 
   const msgId = new Uint8Array(fromBytes.length + seqno.length)

--- a/packages/libp2p-pubsub/test/utils/index.ts
+++ b/packages/libp2p-pubsub/test/utils/index.ts
@@ -4,12 +4,11 @@ import { PubsubBaseProtocol } from '../../src/index.js'
 import { RPC, IRPC } from '../../src/message/rpc.js'
 import { CustomEvent } from '@libp2p/interfaces'
 import type { IncomingStreamData, Registrar, StreamHandler } from '@libp2p/interfaces/registrar'
-import type { Ed25519PeerId } from '@libp2p/peer-id'
 import type { Topology } from '@libp2p/interfaces/topology'
 import type { Connection } from '@libp2p/interfaces/src/connection'
 import type { PeerId } from '@libp2p/interfaces/src/peer-id'
 
-export const createPeerId = async (): Promise<Ed25519PeerId> => {
+export const createPeerId = async (): Promise<PeerId> => {
   const peerId = await PeerIdFactory.createEd25519PeerId()
 
   return peerId


### PR DESCRIPTION
To avoid leaking concrete implementation classes, hide their defintion and creation behind factory methods that are typed to return the interfaces they implement.