### PR TITLE
fix: simpler pubsub

### DIFF
--- a/packages/libp2p-interface-compliance-tests/src/mocks/registrar.ts
+++ b/packages/libp2p-interface-compliance-tests/src/mocks/registrar.ts
@@ -116,18 +116,20 @@ export async function mockIncomingStreamEvent (protocol: string, conn: Connectio
   })
 }
 
-export async function connectPeers (protocol: string, registrarA: Registrar, registrarB: Registrar, peerIdA: PeerId, peerIdB: PeerId) {
-  const topologyA = registrarA.getTopologies(protocol)[0]
-  const topologyB = registrarB.getTopologies(protocol)[0]
-  // const handlerA = registrarA.getHandler(protocol)
-  // const handlerB = registrarB.getHandler(protocol)
+export interface Peer {
+  peerId: PeerId
+  registrar: Registrar
+}
 
+export async function connectPeers (protocol: string, a: Peer, b: Peer) {
   // Notify peers of connection
-  const [bToA, aToB] = connectionPair(peerIdA, peerIdB)
+  const [aToB, bToA] = connectionPair(a, b)
 
-  await topologyA.onConnect(peerIdB, aToB)
-  // await handlerA(await mockIncomingStreamEvent(protocol, aToB, peerIdB))
+  for (const topology of a.registrar.getTopologies(protocol)) {
+    await topology.onConnect(b.peerId, aToB)
+  }
 
-  await topologyB.onConnect(peerIdA, bToA)
-  // await handlerB(await mockIncomingStreamEvent(protocol, bToA, peerIdA))
+  for (const topology of b.registrar.getTopologies(protocol)) {
+    await topology.onConnect(a.peerId, bToA)
+  }
 }

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/api.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/api.ts
@@ -3,17 +3,20 @@ import sinon from 'sinon'
 import pDefer from 'p-defer'
 import pWaitFor from 'p-wait-for'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import { mockRegistrar } from '../mocks/registrar.js'
+import { createEd25519PeerId } from '@libp2p/peer-id-factory'
+import delay from 'delay'
+import { CustomEvent } from '@libp2p/interfaces'
 import type { TestSetup } from '../index.js'
 import type { PubSub, PubSubOptions } from '@libp2p/interfaces/pubsub'
 import type { EventMap } from './index.js'
 import type { Registrar } from '@libp2p/interfaces/src/registrar'
-import { mockRegistrar } from '../mocks/registrar.js'
-import { createEd25519PeerId } from '@libp2p/peer-id-factory'
+import type { PubsubBaseProtocol } from '@libp2p/pubsub'
 
 const topic = 'foo'
 const data = uint8ArrayFromString('bar')
 
-export default (common: TestSetup<PubSub<EventMap>, PubSubOptions>) => {
+export default (common: TestSetup<PubsubBaseProtocol<EventMap>, PubSubOptions>) => {
   describe('pubsub api', () => {
     let pubsub: PubSub<EventMap>
     let registrar: Registrar
@@ -60,20 +63,22 @@ export default (common: TestSetup<PubSub<EventMap>, PubSubOptions>) => {
       }
 
       await pubsub.start()
-      pubsub.subscribe(topic)
-      pubsub.addEventListener('topic', handler)
+      pubsub.addEventListener(topic, handler)
 
       await pWaitFor(() => {
         const topics = pubsub.getTopics()
         return topics.length === 1 && topics[0] === topic
       })
 
-      pubsub.unsubscribe(topic)
+      pubsub.removeEventListener(topic, handler)
 
       await pWaitFor(() => pubsub.getTopics().length === 0)
 
       // Publish to guarantee the handler is not called
-      await pubsub.publish(topic, data)
+      pubsub.dispatchEvent(new CustomEvent(topic, { detail: data }))
+
+      // handlers are called async
+      await delay(100)
 
       await pubsub.stop()
     })
@@ -83,13 +88,12 @@ export default (common: TestSetup<PubSub<EventMap>, PubSubOptions>) => {
 
       await pubsub.start()
 
-      pubsub.subscribe(topic)
       pubsub.addEventListener(topic, (evt) => {
         const msg = evt.detail
         expect(msg).to.not.eql(undefined)
         defer.resolve()
       })
-      await pubsub.publish(topic, data)
+      pubsub.dispatchEvent(new CustomEvent(topic, { detail: data }))
       await defer.promise
 
       await pubsub.stop()

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/emit-self.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/emit-self.ts
@@ -1,19 +1,21 @@
 import { expect } from 'aegir/utils/chai.js'
 import sinon from 'sinon'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import type { TestSetup } from '../index.js'
-import type { PubSub, PubSubOptions } from '@libp2p/interfaces/pubsub'
-import type { EventMap } from './index.js'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { mockRegistrar } from '../mocks/registrar.js'
+import { CustomEvent } from '@libp2p/interfaces'
+import type { TestSetup } from '../index.js'
+import type { PubSubOptions } from '@libp2p/interfaces/pubsub'
+import type { EventMap } from './index.js'
+import type { PubsubBaseProtocol } from '@libp2p/pubsub'
 
 const topic = 'foo'
 const data = uint8ArrayFromString('bar')
 const shouldNotHappen = () => expect.fail()
 
-export default (common: TestSetup<PubSub<EventMap>, PubSubOptions>) => {
+export default (common: TestSetup<PubsubBaseProtocol<EventMap>, PubSubOptions>) => {
   describe('emit self', () => {
-    let pubsub: PubSub<EventMap>
+    let pubsub: PubsubBaseProtocol<EventMap>
 
     describe('enabled', () => {
       before(async () => {
@@ -40,7 +42,7 @@ export default (common: TestSetup<PubSub<EventMap>, PubSubOptions>) => {
           once: true
         }))
 
-        void pubsub.publish(topic, data)
+        void pubsub.dispatchEvent(new CustomEvent(topic, { detail: data }))
 
         return await promise
       })
@@ -71,7 +73,7 @@ export default (common: TestSetup<PubSub<EventMap>, PubSubOptions>) => {
           once: true
         })
 
-        void pubsub.publish(topic, data)
+        void pubsub.dispatchEvent(new CustomEvent(topic, { detail: data }))
 
         // Wait 1 second to guarantee that self is not noticed
         return await new Promise((resolve) => setTimeout(resolve, 1000))

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/index.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/index.ts
@@ -5,7 +5,8 @@ import connectionHandlersTest from './connection-handlers.js'
 import twoNodesTest from './two-nodes.js'
 import multipleNodesTest from './multiple-nodes.js'
 import type { TestSetup } from '../index.js'
-import type { PubSub, Message, PubSubEvents, PubSubOptions } from '@libp2p/interfaces/pubsub'
+import type { Message, PubSubEvents, PubSubOptions } from '@libp2p/interfaces/pubsub'
+import type { PubsubBaseProtocol } from '@libp2p/pubsub'
 
 export interface EventMap extends PubSubEvents {
   'topic': CustomEvent<Message>
@@ -13,9 +14,11 @@ export interface EventMap extends PubSubEvents {
   'test-topic': CustomEvent<Message>
   'reconnect-channel': CustomEvent<Message>
   'Z': CustomEvent<Message>
+  'Za': CustomEvent<Message>
+  'Zb': CustomEvent<Message>
 }
 
-export default (common: TestSetup<PubSub<EventMap>, PubSubOptions>) => {
+export default (common: TestSetup<PubsubBaseProtocol<EventMap>, PubSubOptions>) => {
   describe('interface-pubsub compliance tests', () => {
     apiTest(common)
     emitSelfTest(common)

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/messages.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/messages.ts
@@ -4,19 +4,22 @@ import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { noSignMsgId } from '@libp2p/pubsub/utils'
 import { PeerStreams } from '@libp2p/pubsub/peer-streams'
-import type { TestSetup } from '../index.js'
-import type { PubSub, PubSubOptions, RPC } from '@libp2p/interfaces/pubsub'
-import type { EventMap } from './index.js'
 import { mockRegistrar } from '../mocks/registrar.js'
 import pDefer from 'p-defer'
 import delay from 'delay'
+import pWaitFor from 'p-wait-for'
+import { CustomEvent } from '@libp2p/interfaces'
+import type { TestSetup } from '../index.js'
+import type { PubSubOptions, RPC } from '@libp2p/interfaces/pubsub'
+import type { EventMap } from './index.js'
+import type { PubsubBaseProtocol } from '@libp2p/pubsub'
 
 const topic = 'foo'
 const data = uint8ArrayFromString('bar')
 
-export default (common: TestSetup<PubSub<EventMap>, PubSubOptions>) => {
+export default (common: TestSetup<PubsubBaseProtocol<EventMap>, PubSubOptions>) => {
   describe('messages', () => {
-    let pubsub: PubSub<EventMap>
+    let pubsub: PubsubBaseProtocol<EventMap>
 
     // Create pubsub router
     beforeEach(async () => {
@@ -37,23 +40,26 @@ export default (common: TestSetup<PubSub<EventMap>, PubSubOptions>) => {
     it('should emit normalized signed messages on publish', async () => {
       pubsub.globalSignaturePolicy = 'StrictSign'
 
-      const spy = sinon.spy(pubsub, 'emitMessage')
+      const spy = sinon.spy(pubsub, 'publishMessage')
 
-      await pubsub.publish(topic, data)
+      await pubsub.dispatchEvent(new CustomEvent(topic, { detail: data }))
+
+      await pWaitFor(async () => {
+        return spy.callCount === 1
+      })
 
       expect(spy).to.have.property('callCount', 1)
 
-      const [messageToEmit] = spy.getCall(0).args
+      const [from, messageToEmit] = spy.getCall(0).args
 
+      expect(from.toString()).to.equal(pubsub.peerId.toString())
       expect(messageToEmit.seqno).to.not.eql(undefined)
       expect(messageToEmit.key).to.not.eql(undefined)
       expect(messageToEmit.signature).to.not.eql(undefined)
     })
 
     it('should drop unsigned messages', async () => {
-      const emitMessageSpy = sinon.spy(pubsub, 'emitMessage')
-      // @ts-expect-error protected abstract field
-      const publishSpy = sinon.spy(pubsub, '_publish')
+      const publishSpy = sinon.spy(pubsub, 'publishMessage')
       sinon.spy(pubsub, 'validate')
 
       const peerStream = new PeerStreams({
@@ -62,11 +68,11 @@ export default (common: TestSetup<PubSub<EventMap>, PubSubOptions>) => {
       })
       const rpc: RPC = {
         subscriptions: [],
-        msgs: [{
+        messages: [{
           from: peerStream.id.toBytes(),
           data,
           seqno: await noSignMsgId(data),
-          topicIDs: [topic]
+          topic: topic
         }]
       }
 
@@ -77,17 +83,13 @@ export default (common: TestSetup<PubSub<EventMap>, PubSubOptions>) => {
       // message should not be delivered
       await delay(1000)
 
-      expect(pubsub.validate).to.have.property('callCount', 1)
-      expect(emitMessageSpy).to.have.property('called', false)
       expect(publishSpy).to.have.property('called', false)
     })
 
     it('should not drop unsigned messages if strict signing is disabled', async () => {
       pubsub.globalSignaturePolicy = 'StrictNoSign'
 
-      const emitMessageSpy = sinon.spy(pubsub, 'emitMessage')
-      // @ts-expect-error protected field
-      const publishSpy = sinon.spy(pubsub, '_publish')
+      const publishSpy = sinon.spy(pubsub, 'publishMessage')
       sinon.spy(pubsub, 'validate')
 
       const peerStream = new PeerStreams({
@@ -97,10 +99,10 @@ export default (common: TestSetup<PubSub<EventMap>, PubSubOptions>) => {
 
       const rpc: RPC = {
         subscriptions: [],
-        msgs: [{
+        messages: [{
           from: peerStream.id.toBytes(),
           data,
-          topicIDs: [topic]
+          topic
         }]
       }
 
@@ -108,17 +110,16 @@ export default (common: TestSetup<PubSub<EventMap>, PubSubOptions>) => {
 
       const deferred = pDefer()
 
-      await pubsub.processRpc(peerStream.id, peerStream, rpc)
-
       pubsub.addEventListener(topic, () => {
         deferred.resolve()
       })
+
+      await pubsub.processRpc(peerStream.id, peerStream, rpc)
 
       // await message delivery
       await deferred.promise
 
       expect(pubsub.validate).to.have.property('callCount', 1)
-      expect(emitMessageSpy).to.have.property('callCount', 1)
       expect(publishSpy).to.have.property('callCount', 1)
     })
   })

--- a/packages/libp2p-interfaces/src/pubsub/index.ts
+++ b/packages/libp2p-interfaces/src/pubsub/index.ts
@@ -28,17 +28,17 @@ export const StrictNoSign = 'StrictNoSign'
 
 export interface Message {
   from: PeerId
-  topicIDs: string[]
-  seqno?: BigInt
+  topic: string
   data: Uint8Array
+  seqno?: BigInt
   signature?: Uint8Array
   key?: Uint8Array
 }
 
 export interface RPCMessage {
   from: Uint8Array
+  topic: string
   data: Uint8Array
-  topicIDs: string[]
   seqno?: Uint8Array
   signature?: Uint8Array
   key?: Uint8Array
@@ -46,12 +46,12 @@ export interface RPCMessage {
 
 export interface RPCSubscription {
   subscribe: boolean
-  topicID: string
+  topic: string
 }
 
 export interface RPC {
   subscriptions: RPCSubscription[]
-  msgs: RPCMessage[]
+  messages: RPCMessage[]
 }
 
 export interface PeerStreams extends EventEmitter<PeerStreamEvents> {
@@ -95,7 +95,7 @@ export interface PubSubOptions {
 }
 
 interface Subscription {
-  topicID: string
+  topic: string
   subscribe: boolean
 }
 
@@ -108,20 +108,16 @@ export interface PubSubEvents {
   'pubsub:subscription-change': CustomEvent<SubscriptionChangeData>
 }
 
-export interface PubSub<EventMap extends PubSubEvents> extends EventEmitter<EventMap>, Startable {
+export interface PubSub<EventMap = PubSubEvents> extends EventEmitter<EventMap & PubSubEvents>, Startable {
   globalSignaturePolicy: typeof StrictSign | typeof StrictNoSign
   multicodecs: string[]
 
   getPeers: () => PeerId[]
   getTopics: () => string[]
   subscribe: (topic: string) => void
-  getSubscribers: (topic: string) => PeerId[]
   unsubscribe: (topic: string) => void
-  publish: (topic: string, data: Uint8Array) => Promise<void>
+  getSubscribers: (topic: string) => PeerId[]
   validate: (message: Message) => Promise<void>
-
-  processRpc: (from: PeerId, peerStreams: PeerStreams, rpc: RPC) => Promise<boolean>
-  emitMessage: (message: Message) => void
 }
 
 export interface PeerStreamEvents {

--- a/packages/libp2p-peer-id/src/index.ts
+++ b/packages/libp2p-peer-id/src/index.ts
@@ -65,7 +65,7 @@ class PeerIdImpl {
   }
 
   get [Symbol.toStringTag] () {
-    return symbol.toString()
+    return `PeerId(${this.toString()})`
   }
 
   get [symbol] () {

--- a/packages/libp2p-peer-map/package.json
+++ b/packages/libp2p-peer-map/package.json
@@ -137,7 +137,6 @@
   "devDependencies": {
     "@libp2p/peer-id": "^1.1.3",
     "@libp2p/peer-id-factory": "^1.0.5",
-    "aegir": "^36.1.3",
-    "sinon": "^13.0.1"
+    "aegir": "^36.1.3"
   }
 }

--- a/packages/libp2p-peer-map/tsconfig.json
+++ b/packages/libp2p-peer-map/tsconfig.json
@@ -8,5 +8,16 @@
   "include": [
     "src",
     "test"
+  ],
+  "references": [
+    {
+      "path": "../libp2p-interfaces"
+    },
+    {
+      "path": "../libp2p-peer-id"
+    },
+    {
+      "path": "../libp2p-peer-id-factory"
+    }
   ]
 }

--- a/packages/libp2p-pubsub/package.json
+++ b/packages/libp2p-pubsub/package.json
@@ -176,12 +176,9 @@
     "test:firefox-webworker": "npm run test -- -t webworker -- --browser firefox",
     "test:node": "npm run test -- -t node --cov",
     "test:electron-main": "npm run test -- -t electron-main",
-    "build:proto": "npm run build:proto:rpc && npm run build:proto:topic-descriptor",
-    "build:proto:rpc": "pbjs -t static-module -w es6 -r libp2p-pubsub-rpc --force-number --no-verify --no-delimited --no-create --no-beautify --no-defaults --lint eslint-disable -o src/message/rpc.js ./src/message/rpc.proto",
-    "build:proto:topic-descriptor": "pbjs -t static-module -w es6 -r libp2p-pubsub-topic-descriptor --force-number --no-verify --no-delimited --no-create --no-beautify --no-defaults --lint eslint-disable -o src/message/topic-descriptor.js ./src/message/topic-descriptor.proto",
-    "build:proto-types": "npm run build:proto-types:rpc && npm run build:proto-types:topic-descriptor",
-    "build:proto-types:rpc": "pbts -o src/message/rpc.d.ts src/message/rpc.js",
-    "build:proto-types:topic-descriptor": "pbts -o src/message/topic-descriptor.d.ts src/message/topic-descriptor.js",
+    "generate": "npm run generate:proto:rpc && npm run generate:proto-types:rpc",
+    "generate:proto:rpc": "pbjs -t static-module -w es6 -r libp2p-pubsub-rpc --force-number --no-verify --no-delimited --no-create --no-beautify --no-defaults --lint eslint-disable -o src/message/rpc.js ./src/message/rpc.proto",
+    "generate:proto-types:rpc": "pbts -o src/message/rpc.d.ts src/message/rpc.js",
     "build:copy-proto-files": "cp src/message/*.js dist/src/message && cp src/message/*.d.ts dist/src/message"
   },
   "dependencies": {
@@ -189,7 +186,6 @@
     "@libp2p/interfaces": "^1.0.0",
     "@libp2p/logger": "^1.0.1",
     "@libp2p/peer-id": "^1.0.0",
-    "@libp2p/peer-id-factory": "^1.0.0",
     "@libp2p/peer-map": "^1.0.0",
     "@libp2p/topology": "^1.0.0",
     "@multiformats/multiaddr": "^10.1.1",
@@ -202,7 +198,7 @@
     "uint8arrays": "^3.0.0"
   },
   "devDependencies": {
-    "@types/bl": "^5.0.2",
+    "@libp2p/peer-id-factory": "^1.0.0",
     "abortable-iterator": "^4.0.2",
     "aegir": "^36.1.3",
     "it-pair": "^2.0.2",

--- a/packages/libp2p-pubsub/src/errors.ts
+++ b/packages/libp2p-pubsub/src/errors.ts
@@ -20,6 +20,10 @@ export const codes = {
    */
   ERR_MISSING_SEQNO: 'ERR_MISSING_SEQNO',
   /**
+   * Message expected to have a `key`, but doesn't
+   */
+  ERR_MISSING_KEY: 'ERR_MISSING_KEY',
+  /**
    * Message `signature` is invalid
    */
   ERR_INVALID_SIGNATURE: 'ERR_INVALID_SIGNATURE',

--- a/packages/libp2p-pubsub/src/message/rpc.d.ts
+++ b/packages/libp2p-pubsub/src/message/rpc.d.ts
@@ -1,258 +1,669 @@
-import * as $protobuf from 'protobufjs'
+import * as $protobuf from "protobufjs";
 /** Properties of a RPC. */
 export interface IRPC {
 
-  /** RPC subscriptions */
-  subscriptions?: (RPC.ISubOpts[]|null)
+    /** RPC subscriptions */
+    subscriptions?: (RPC.ISubOpts[]|null);
 
-  /** RPC msgs */
-  msgs?: (RPC.IMessage[]|null)
+    /** RPC messages */
+    messages?: (RPC.IMessage[]|null);
+
+    /** RPC control */
+    control?: (IControlMessage|null);
 }
 
 /** Represents a RPC. */
 export class RPC implements IRPC {
-  /**
-   * Constructs a new RPC.
-   *
-   * @param [p] - Properties to set
-   */
-  constructor (p?: IRPC);
 
-  /** RPC subscriptions. */
-  public subscriptions: RPC.ISubOpts[]
+    /**
+     * Constructs a new RPC.
+     * @param [p] Properties to set
+     */
+    constructor(p?: IRPC);
 
-  /** RPC msgs. */
-  public msgs: RPC.IMessage[]
+    /** RPC subscriptions. */
+    public subscriptions: RPC.ISubOpts[];
 
-  /**
-   * Encodes the specified RPC message. Does not implicitly {@link RPC.verify|verify} messages.
-   *
-   * @param m - RPC message or plain object to encode
-   * @param [w] - Writer to encode to
-   * @returns Writer
-   */
-  public static encode (m: IRPC, w?: $protobuf.Writer): $protobuf.Writer;
+    /** RPC messages. */
+    public messages: RPC.IMessage[];
 
-  /**
-   * Decodes a RPC message from the specified reader or buffer.
-   *
-   * @param r - Reader or buffer to decode from
-   * @param [l] - Message length if known beforehand
-   * @returns RPC
-   * @throws {Error} If the payload is not a reader or valid buffer
-   * @throws {$protobuf.util.ProtocolError} If required fields are missing
-   */
-  public static decode (r: ($protobuf.Reader|Uint8Array), l?: number): RPC;
+    /** RPC control. */
+    public control?: (IControlMessage|null);
 
-  /**
-   * Creates a RPC message from a plain object. Also converts values to their respective internal types.
-   *
-   * @param d - Plain object
-   * @returns RPC
-   */
-  public static fromObject (d: { [k: string]: any }): RPC;
+    /** RPC _control. */
+    public _control?: "control";
 
-  /**
-   * Creates a plain object from a RPC message. Also converts values to other types if specified.
-   *
-   * @param m - RPC
-   * @param [o] - Conversion options
-   * @returns Plain object
-   */
-  public static toObject (m: RPC, o?: $protobuf.IConversionOptions): { [k: string]: any };
+    /**
+     * Encodes the specified RPC message. Does not implicitly {@link RPC.verify|verify} messages.
+     * @param m RPC message or plain object to encode
+     * @param [w] Writer to encode to
+     * @returns Writer
+     */
+    public static encode(m: IRPC, w?: $protobuf.Writer): $protobuf.Writer;
 
-  /**
-   * Converts this RPC to JSON.
-   *
-   * @returns JSON object
-   */
-  public toJSON (): { [k: string]: any };
+    /**
+     * Decodes a RPC message from the specified reader or buffer.
+     * @param r Reader or buffer to decode from
+     * @param [l] Message length if known beforehand
+     * @returns RPC
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    public static decode(r: ($protobuf.Reader|Uint8Array), l?: number): RPC;
+
+    /**
+     * Creates a RPC message from a plain object. Also converts values to their respective internal types.
+     * @param d Plain object
+     * @returns RPC
+     */
+    public static fromObject(d: { [k: string]: any }): RPC;
+
+    /**
+     * Creates a plain object from a RPC message. Also converts values to other types if specified.
+     * @param m RPC
+     * @param [o] Conversion options
+     * @returns Plain object
+     */
+    public static toObject(m: RPC, o?: $protobuf.IConversionOptions): { [k: string]: any };
+
+    /**
+     * Converts this RPC to JSON.
+     * @returns JSON object
+     */
+    public toJSON(): { [k: string]: any };
 }
 
 export namespace RPC {
 
-  /** Properties of a SubOpts. */
-  interface ISubOpts {
+    /** Properties of a SubOpts. */
+    interface ISubOpts {
 
-    /** SubOpts subscribe */
-    subscribe?: (boolean|null)
+        /** SubOpts subscribe */
+        subscribe?: (boolean|null);
 
-    /** SubOpts topicID */
-    topicID?: (string|null)
-  }
+        /** SubOpts topic */
+        topic?: (string|null);
+    }
 
-  /** Represents a SubOpts. */
-  class SubOpts implements ISubOpts {
+    /** Represents a SubOpts. */
+    class SubOpts implements ISubOpts {
+
+        /**
+         * Constructs a new SubOpts.
+         * @param [p] Properties to set
+         */
+        constructor(p?: RPC.ISubOpts);
+
+        /** SubOpts subscribe. */
+        public subscribe?: (boolean|null);
+
+        /** SubOpts topic. */
+        public topic?: (string|null);
+
+        /** SubOpts _subscribe. */
+        public _subscribe?: "subscribe";
+
+        /** SubOpts _topic. */
+        public _topic?: "topic";
+
+        /**
+         * Encodes the specified SubOpts message. Does not implicitly {@link RPC.SubOpts.verify|verify} messages.
+         * @param m SubOpts message or plain object to encode
+         * @param [w] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(m: RPC.ISubOpts, w?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a SubOpts message from the specified reader or buffer.
+         * @param r Reader or buffer to decode from
+         * @param [l] Message length if known beforehand
+         * @returns SubOpts
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(r: ($protobuf.Reader|Uint8Array), l?: number): RPC.SubOpts;
+
+        /**
+         * Creates a SubOpts message from a plain object. Also converts values to their respective internal types.
+         * @param d Plain object
+         * @returns SubOpts
+         */
+        public static fromObject(d: { [k: string]: any }): RPC.SubOpts;
+
+        /**
+         * Creates a plain object from a SubOpts message. Also converts values to other types if specified.
+         * @param m SubOpts
+         * @param [o] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(m: RPC.SubOpts, o?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this SubOpts to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
+    /** Properties of a Message. */
+    interface IMessage {
+
+        /** Message from */
+        from?: (Uint8Array|null);
+
+        /** Message data */
+        data?: (Uint8Array|null);
+
+        /** Message seqno */
+        seqno?: (Uint8Array|null);
+
+        /** Message topic */
+        topic?: (string|null);
+
+        /** Message signature */
+        signature?: (Uint8Array|null);
+
+        /** Message key */
+        key?: (Uint8Array|null);
+    }
+
+    /** Represents a Message. */
+    class Message implements IMessage {
+
+        /**
+         * Constructs a new Message.
+         * @param [p] Properties to set
+         */
+        constructor(p?: RPC.IMessage);
+
+        /** Message from. */
+        public from?: (Uint8Array|null);
+
+        /** Message data. */
+        public data?: (Uint8Array|null);
+
+        /** Message seqno. */
+        public seqno?: (Uint8Array|null);
+
+        /** Message topic. */
+        public topic?: (string|null);
+
+        /** Message signature. */
+        public signature?: (Uint8Array|null);
+
+        /** Message key. */
+        public key?: (Uint8Array|null);
+
+        /** Message _from. */
+        public _from?: "from";
+
+        /** Message _data. */
+        public _data?: "data";
+
+        /** Message _seqno. */
+        public _seqno?: "seqno";
+
+        /** Message _topic. */
+        public _topic?: "topic";
+
+        /** Message _signature. */
+        public _signature?: "signature";
+
+        /** Message _key. */
+        public _key?: "key";
+
+        /**
+         * Encodes the specified Message message. Does not implicitly {@link RPC.Message.verify|verify} messages.
+         * @param m Message message or plain object to encode
+         * @param [w] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(m: RPC.IMessage, w?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a Message message from the specified reader or buffer.
+         * @param r Reader or buffer to decode from
+         * @param [l] Message length if known beforehand
+         * @returns Message
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(r: ($protobuf.Reader|Uint8Array), l?: number): RPC.Message;
+
+        /**
+         * Creates a Message message from a plain object. Also converts values to their respective internal types.
+         * @param d Plain object
+         * @returns Message
+         */
+        public static fromObject(d: { [k: string]: any }): RPC.Message;
+
+        /**
+         * Creates a plain object from a Message message. Also converts values to other types if specified.
+         * @param m Message
+         * @param [o] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(m: RPC.Message, o?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this Message to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+}
+
+/** Properties of a ControlMessage. */
+export interface IControlMessage {
+
+    /** ControlMessage ihave */
+    ihave?: (IControlIHave[]|null);
+
+    /** ControlMessage iwant */
+    iwant?: (IControlIWant[]|null);
+
+    /** ControlMessage graft */
+    graft?: (IControlGraft[]|null);
+
+    /** ControlMessage prune */
+    prune?: (IControlPrune[]|null);
+}
+
+/** Represents a ControlMessage. */
+export class ControlMessage implements IControlMessage {
+
     /**
-     * Constructs a new SubOpts.
-     *
-     * @param [p] - Properties to set
+     * Constructs a new ControlMessage.
+     * @param [p] Properties to set
      */
-    constructor (p?: RPC.ISubOpts);
+    constructor(p?: IControlMessage);
 
-    /** SubOpts subscribe. */
-    public subscribe?: (boolean|null)
+    /** ControlMessage ihave. */
+    public ihave: IControlIHave[];
 
-    /** SubOpts topicID. */
-    public topicID?: (string|null)
+    /** ControlMessage iwant. */
+    public iwant: IControlIWant[];
 
-    /** SubOpts _subscribe. */
-    public _subscribe?: 'subscribe'
+    /** ControlMessage graft. */
+    public graft: IControlGraft[];
 
-    /** SubOpts _topicID. */
-    public _topicID?: 'topicID'
+    /** ControlMessage prune. */
+    public prune: IControlPrune[];
 
     /**
-     * Encodes the specified SubOpts message. Does not implicitly {@link RPC.SubOpts.verify|verify} messages.
-     *
-     * @param m - SubOpts message or plain object to encode
-     * @param [w] - Writer to encode to
+     * Encodes the specified ControlMessage message. Does not implicitly {@link ControlMessage.verify|verify} messages.
+     * @param m ControlMessage message or plain object to encode
+     * @param [w] Writer to encode to
      * @returns Writer
      */
-    public static encode (m: RPC.ISubOpts, w?: $protobuf.Writer): $protobuf.Writer;
+    public static encode(m: IControlMessage, w?: $protobuf.Writer): $protobuf.Writer;
 
     /**
-     * Decodes a SubOpts message from the specified reader or buffer.
-     *
-     * @param r - Reader or buffer to decode from
-     * @param [l] - Message length if known beforehand
-     * @returns SubOpts
+     * Decodes a ControlMessage message from the specified reader or buffer.
+     * @param r Reader or buffer to decode from
+     * @param [l] Message length if known beforehand
+     * @returns ControlMessage
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decode (r: ($protobuf.Reader|Uint8Array), l?: number): RPC.SubOpts;
+    public static decode(r: ($protobuf.Reader|Uint8Array), l?: number): ControlMessage;
 
     /**
-     * Creates a SubOpts message from a plain object. Also converts values to their respective internal types.
-     *
-     * @param d - Plain object
-     * @returns SubOpts
+     * Creates a ControlMessage message from a plain object. Also converts values to their respective internal types.
+     * @param d Plain object
+     * @returns ControlMessage
      */
-    public static fromObject (d: { [k: string]: any }): RPC.SubOpts;
+    public static fromObject(d: { [k: string]: any }): ControlMessage;
 
     /**
-     * Creates a plain object from a SubOpts message. Also converts values to other types if specified.
-     *
-     * @param m - SubOpts
-     * @param [o] - Conversion options
+     * Creates a plain object from a ControlMessage message. Also converts values to other types if specified.
+     * @param m ControlMessage
+     * @param [o] Conversion options
      * @returns Plain object
      */
-    public static toObject (m: RPC.SubOpts, o?: $protobuf.IConversionOptions): { [k: string]: any };
+    public static toObject(m: ControlMessage, o?: $protobuf.IConversionOptions): { [k: string]: any };
 
     /**
-     * Converts this SubOpts to JSON.
-     *
+     * Converts this ControlMessage to JSON.
      * @returns JSON object
      */
-    public toJSON (): { [k: string]: any };
-  }
+    public toJSON(): { [k: string]: any };
+}
 
-  /** Properties of a Message. */
-  interface IMessage {
+/** Properties of a ControlIHave. */
+export interface IControlIHave {
 
-    /** Message from */
-    from?: (Uint8Array|null)
+    /** ControlIHave topicID */
+    topicID?: (string|null);
 
-    /** Message data */
-    data?: (Uint8Array|null)
+    /** ControlIHave messageIDs */
+    messageIDs?: (string[]|null);
+}
 
-    /** Message seqno */
-    seqno?: (Uint8Array|null)
+/** Represents a ControlIHave. */
+export class ControlIHave implements IControlIHave {
 
-    /** Message topicIDs */
-    topicIDs?: (string[]|null)
-
-    /** Message signature */
-    signature?: (Uint8Array|null)
-
-    /** Message key */
-    key?: (Uint8Array|null)
-  }
-
-  /** Represents a Message. */
-  class Message implements IMessage {
     /**
-     * Constructs a new Message.
-     *
-     * @param [p] - Properties to set
+     * Constructs a new ControlIHave.
+     * @param [p] Properties to set
      */
-    constructor (p?: RPC.IMessage);
+    constructor(p?: IControlIHave);
 
-    /** Message from. */
-    public from?: (Uint8Array|null)
+    /** ControlIHave topicID. */
+    public topicID?: (string|null);
 
-    /** Message data. */
-    public data?: (Uint8Array|null)
+    /** ControlIHave messageIDs. */
+    public messageIDs: string[];
 
-    /** Message seqno. */
-    public seqno?: (Uint8Array|null)
-
-    /** Message topicIDs. */
-    public topicIDs: string[]
-
-    /** Message signature. */
-    public signature?: (Uint8Array|null)
-
-    /** Message key. */
-    public key?: (Uint8Array|null)
-
-    /** Message _from. */
-    public _from?: 'from'
-
-    /** Message _data. */
-    public _data?: 'data'
-
-    /** Message _seqno. */
-    public _seqno?: 'seqno'
-
-    /** Message _signature. */
-    public _signature?: 'signature'
-
-    /** Message _key. */
-    public _key?: 'key'
+    /** ControlIHave _topicID. */
+    public _topicID?: "topicID";
 
     /**
-     * Encodes the specified Message message. Does not implicitly {@link RPC.Message.verify|verify} messages.
-     *
-     * @param m - Message message or plain object to encode
-     * @param [w] - Writer to encode to
+     * Encodes the specified ControlIHave message. Does not implicitly {@link ControlIHave.verify|verify} messages.
+     * @param m ControlIHave message or plain object to encode
+     * @param [w] Writer to encode to
      * @returns Writer
      */
-    public static encode (m: RPC.IMessage, w?: $protobuf.Writer): $protobuf.Writer;
+    public static encode(m: IControlIHave, w?: $protobuf.Writer): $protobuf.Writer;
 
     /**
-     * Decodes a Message message from the specified reader or buffer.
-     *
-     * @param r - Reader or buffer to decode from
-     * @param [l] - Message length if known beforehand
-     * @returns Message
+     * Decodes a ControlIHave message from the specified reader or buffer.
+     * @param r Reader or buffer to decode from
+     * @param [l] Message length if known beforehand
+     * @returns ControlIHave
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {$protobuf.util.ProtocolError} If required fields are missing
      */
-    public static decode (r: ($protobuf.Reader|Uint8Array), l?: number): RPC.Message;
+    public static decode(r: ($protobuf.Reader|Uint8Array), l?: number): ControlIHave;
 
     /**
-     * Creates a Message message from a plain object. Also converts values to their respective internal types.
-     *
-     * @param d - Plain object
-     * @returns Message
+     * Creates a ControlIHave message from a plain object. Also converts values to their respective internal types.
+     * @param d Plain object
+     * @returns ControlIHave
      */
-    public static fromObject (d: { [k: string]: any }): RPC.Message;
+    public static fromObject(d: { [k: string]: any }): ControlIHave;
 
     /**
-     * Creates a plain object from a Message message. Also converts values to other types if specified.
-     *
-     * @param m - Message
-     * @param [o] - Conversion options
+     * Creates a plain object from a ControlIHave message. Also converts values to other types if specified.
+     * @param m ControlIHave
+     * @param [o] Conversion options
      * @returns Plain object
      */
-    public static toObject (m: RPC.Message, o?: $protobuf.IConversionOptions): { [k: string]: any };
+    public static toObject(m: ControlIHave, o?: $protobuf.IConversionOptions): { [k: string]: any };
 
     /**
-     * Converts this Message to JSON.
-     *
+     * Converts this ControlIHave to JSON.
      * @returns JSON object
      */
-    public toJSON (): { [k: string]: any };
-  }
+    public toJSON(): { [k: string]: any };
+}
+
+/** Properties of a ControlIWant. */
+export interface IControlIWant {
+
+    /** ControlIWant messageIDs */
+    messageIDs?: (string[]|null);
+}
+
+/** Represents a ControlIWant. */
+export class ControlIWant implements IControlIWant {
+
+    /**
+     * Constructs a new ControlIWant.
+     * @param [p] Properties to set
+     */
+    constructor(p?: IControlIWant);
+
+    /** ControlIWant messageIDs. */
+    public messageIDs: string[];
+
+    /**
+     * Encodes the specified ControlIWant message. Does not implicitly {@link ControlIWant.verify|verify} messages.
+     * @param m ControlIWant message or plain object to encode
+     * @param [w] Writer to encode to
+     * @returns Writer
+     */
+    public static encode(m: IControlIWant, w?: $protobuf.Writer): $protobuf.Writer;
+
+    /**
+     * Decodes a ControlIWant message from the specified reader or buffer.
+     * @param r Reader or buffer to decode from
+     * @param [l] Message length if known beforehand
+     * @returns ControlIWant
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    public static decode(r: ($protobuf.Reader|Uint8Array), l?: number): ControlIWant;
+
+    /**
+     * Creates a ControlIWant message from a plain object. Also converts values to their respective internal types.
+     * @param d Plain object
+     * @returns ControlIWant
+     */
+    public static fromObject(d: { [k: string]: any }): ControlIWant;
+
+    /**
+     * Creates a plain object from a ControlIWant message. Also converts values to other types if specified.
+     * @param m ControlIWant
+     * @param [o] Conversion options
+     * @returns Plain object
+     */
+    public static toObject(m: ControlIWant, o?: $protobuf.IConversionOptions): { [k: string]: any };
+
+    /**
+     * Converts this ControlIWant to JSON.
+     * @returns JSON object
+     */
+    public toJSON(): { [k: string]: any };
+}
+
+/** Properties of a ControlGraft. */
+export interface IControlGraft {
+
+    /** ControlGraft topicID */
+    topicID?: (string|null);
+}
+
+/** Represents a ControlGraft. */
+export class ControlGraft implements IControlGraft {
+
+    /**
+     * Constructs a new ControlGraft.
+     * @param [p] Properties to set
+     */
+    constructor(p?: IControlGraft);
+
+    /** ControlGraft topicID. */
+    public topicID?: (string|null);
+
+    /** ControlGraft _topicID. */
+    public _topicID?: "topicID";
+
+    /**
+     * Encodes the specified ControlGraft message. Does not implicitly {@link ControlGraft.verify|verify} messages.
+     * @param m ControlGraft message or plain object to encode
+     * @param [w] Writer to encode to
+     * @returns Writer
+     */
+    public static encode(m: IControlGraft, w?: $protobuf.Writer): $protobuf.Writer;
+
+    /**
+     * Decodes a ControlGraft message from the specified reader or buffer.
+     * @param r Reader or buffer to decode from
+     * @param [l] Message length if known beforehand
+     * @returns ControlGraft
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    public static decode(r: ($protobuf.Reader|Uint8Array), l?: number): ControlGraft;
+
+    /**
+     * Creates a ControlGraft message from a plain object. Also converts values to their respective internal types.
+     * @param d Plain object
+     * @returns ControlGraft
+     */
+    public static fromObject(d: { [k: string]: any }): ControlGraft;
+
+    /**
+     * Creates a plain object from a ControlGraft message. Also converts values to other types if specified.
+     * @param m ControlGraft
+     * @param [o] Conversion options
+     * @returns Plain object
+     */
+    public static toObject(m: ControlGraft, o?: $protobuf.IConversionOptions): { [k: string]: any };
+
+    /**
+     * Converts this ControlGraft to JSON.
+     * @returns JSON object
+     */
+    public toJSON(): { [k: string]: any };
+}
+
+/** Properties of a ControlPrune. */
+export interface IControlPrune {
+
+    /** ControlPrune topicID */
+    topicID?: (string|null);
+
+    /** ControlPrune peers */
+    peers?: (IPeerInfo[]|null);
+
+    /** ControlPrune backoff */
+    backoff?: (number|null);
+}
+
+/** Represents a ControlPrune. */
+export class ControlPrune implements IControlPrune {
+
+    /**
+     * Constructs a new ControlPrune.
+     * @param [p] Properties to set
+     */
+    constructor(p?: IControlPrune);
+
+    /** ControlPrune topicID. */
+    public topicID?: (string|null);
+
+    /** ControlPrune peers. */
+    public peers: IPeerInfo[];
+
+    /** ControlPrune backoff. */
+    public backoff?: (number|null);
+
+    /** ControlPrune _topicID. */
+    public _topicID?: "topicID";
+
+    /** ControlPrune _backoff. */
+    public _backoff?: "backoff";
+
+    /**
+     * Encodes the specified ControlPrune message. Does not implicitly {@link ControlPrune.verify|verify} messages.
+     * @param m ControlPrune message or plain object to encode
+     * @param [w] Writer to encode to
+     * @returns Writer
+     */
+    public static encode(m: IControlPrune, w?: $protobuf.Writer): $protobuf.Writer;
+
+    /**
+     * Decodes a ControlPrune message from the specified reader or buffer.
+     * @param r Reader or buffer to decode from
+     * @param [l] Message length if known beforehand
+     * @returns ControlPrune
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    public static decode(r: ($protobuf.Reader|Uint8Array), l?: number): ControlPrune;
+
+    /**
+     * Creates a ControlPrune message from a plain object. Also converts values to their respective internal types.
+     * @param d Plain object
+     * @returns ControlPrune
+     */
+    public static fromObject(d: { [k: string]: any }): ControlPrune;
+
+    /**
+     * Creates a plain object from a ControlPrune message. Also converts values to other types if specified.
+     * @param m ControlPrune
+     * @param [o] Conversion options
+     * @returns Plain object
+     */
+    public static toObject(m: ControlPrune, o?: $protobuf.IConversionOptions): { [k: string]: any };
+
+    /**
+     * Converts this ControlPrune to JSON.
+     * @returns JSON object
+     */
+    public toJSON(): { [k: string]: any };
+}
+
+/** Properties of a PeerInfo. */
+export interface IPeerInfo {
+
+    /** PeerInfo peerID */
+    peerID?: (Uint8Array|null);
+
+    /** PeerInfo signedPeerRecord */
+    signedPeerRecord?: (Uint8Array|null);
+}
+
+/** Represents a PeerInfo. */
+export class PeerInfo implements IPeerInfo {
+
+    /**
+     * Constructs a new PeerInfo.
+     * @param [p] Properties to set
+     */
+    constructor(p?: IPeerInfo);
+
+    /** PeerInfo peerID. */
+    public peerID?: (Uint8Array|null);
+
+    /** PeerInfo signedPeerRecord. */
+    public signedPeerRecord?: (Uint8Array|null);
+
+    /** PeerInfo _peerID. */
+    public _peerID?: "peerID";
+
+    /** PeerInfo _signedPeerRecord. */
+    public _signedPeerRecord?: "signedPeerRecord";
+
+    /**
+     * Encodes the specified PeerInfo message. Does not implicitly {@link PeerInfo.verify|verify} messages.
+     * @param m PeerInfo message or plain object to encode
+     * @param [w] Writer to encode to
+     * @returns Writer
+     */
+    public static encode(m: IPeerInfo, w?: $protobuf.Writer): $protobuf.Writer;
+
+    /**
+     * Decodes a PeerInfo message from the specified reader or buffer.
+     * @param r Reader or buffer to decode from
+     * @param [l] Message length if known beforehand
+     * @returns PeerInfo
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    public static decode(r: ($protobuf.Reader|Uint8Array), l?: number): PeerInfo;
+
+    /**
+     * Creates a PeerInfo message from a plain object. Also converts values to their respective internal types.
+     * @param d Plain object
+     * @returns PeerInfo
+     */
+    public static fromObject(d: { [k: string]: any }): PeerInfo;
+
+    /**
+     * Creates a plain object from a PeerInfo message. Also converts values to other types if specified.
+     * @param m PeerInfo
+     * @param [o] Conversion options
+     * @returns Plain object
+     */
+    public static toObject(m: PeerInfo, o?: $protobuf.IConversionOptions): { [k: string]: any };
+
+    /**
+     * Converts this PeerInfo to JSON.
+     * @returns JSON object
+     */
+    public toJSON(): { [k: string]: any };
 }

--- a/packages/libp2p-pubsub/src/message/rpc.js
+++ b/packages/libp2p-pubsub/src/message/rpc.js
@@ -14,7 +14,8 @@ export const RPC = $root.RPC = (() => {
      * @exports IRPC
      * @interface IRPC
      * @property {Array.<RPC.ISubOpts>|null} [subscriptions] RPC subscriptions
-     * @property {Array.<RPC.IMessage>|null} [msgs] RPC msgs
+     * @property {Array.<RPC.IMessage>|null} [messages] RPC messages
+     * @property {IControlMessage|null} [control] RPC control
      */
 
     /**
@@ -27,7 +28,7 @@ export const RPC = $root.RPC = (() => {
      */
     function RPC(p) {
         this.subscriptions = [];
-        this.msgs = [];
+        this.messages = [];
         if (p)
             for (var ks = Object.keys(p), i = 0; i < ks.length; ++i)
                 if (p[ks[i]] != null)
@@ -43,12 +44,34 @@ export const RPC = $root.RPC = (() => {
     RPC.prototype.subscriptions = $util.emptyArray;
 
     /**
-     * RPC msgs.
-     * @member {Array.<RPC.IMessage>} msgs
+     * RPC messages.
+     * @member {Array.<RPC.IMessage>} messages
      * @memberof RPC
      * @instance
      */
-    RPC.prototype.msgs = $util.emptyArray;
+    RPC.prototype.messages = $util.emptyArray;
+
+    /**
+     * RPC control.
+     * @member {IControlMessage|null|undefined} control
+     * @memberof RPC
+     * @instance
+     */
+    RPC.prototype.control = null;
+
+    // OneOf field names bound to virtual getters and setters
+    let $oneOfFields;
+
+    /**
+     * RPC _control.
+     * @member {"control"|undefined} _control
+     * @memberof RPC
+     * @instance
+     */
+    Object.defineProperty(RPC.prototype, "_control", {
+        get: $util.oneOfGetter($oneOfFields = ["control"]),
+        set: $util.oneOfSetter($oneOfFields)
+    });
 
     /**
      * Encodes the specified RPC message. Does not implicitly {@link RPC.verify|verify} messages.
@@ -66,10 +89,12 @@ export const RPC = $root.RPC = (() => {
             for (var i = 0; i < m.subscriptions.length; ++i)
                 $root.RPC.SubOpts.encode(m.subscriptions[i], w.uint32(10).fork()).ldelim();
         }
-        if (m.msgs != null && m.msgs.length) {
-            for (var i = 0; i < m.msgs.length; ++i)
-                $root.RPC.Message.encode(m.msgs[i], w.uint32(18).fork()).ldelim();
+        if (m.messages != null && m.messages.length) {
+            for (var i = 0; i < m.messages.length; ++i)
+                $root.RPC.Message.encode(m.messages[i], w.uint32(18).fork()).ldelim();
         }
+        if (m.control != null && Object.hasOwnProperty.call(m, "control"))
+            $root.ControlMessage.encode(m.control, w.uint32(26).fork()).ldelim();
         return w;
     };
 
@@ -97,9 +122,12 @@ export const RPC = $root.RPC = (() => {
                 m.subscriptions.push($root.RPC.SubOpts.decode(r, r.uint32()));
                 break;
             case 2:
-                if (!(m.msgs && m.msgs.length))
-                    m.msgs = [];
-                m.msgs.push($root.RPC.Message.decode(r, r.uint32()));
+                if (!(m.messages && m.messages.length))
+                    m.messages = [];
+                m.messages.push($root.RPC.Message.decode(r, r.uint32()));
+                break;
+            case 3:
+                m.control = $root.ControlMessage.decode(r, r.uint32());
                 break;
             default:
                 r.skipType(t & 7);
@@ -131,15 +159,20 @@ export const RPC = $root.RPC = (() => {
                 m.subscriptions[i] = $root.RPC.SubOpts.fromObject(d.subscriptions[i]);
             }
         }
-        if (d.msgs) {
-            if (!Array.isArray(d.msgs))
-                throw TypeError(".RPC.msgs: array expected");
-            m.msgs = [];
-            for (var i = 0; i < d.msgs.length; ++i) {
-                if (typeof d.msgs[i] !== "object")
-                    throw TypeError(".RPC.msgs: object expected");
-                m.msgs[i] = $root.RPC.Message.fromObject(d.msgs[i]);
+        if (d.messages) {
+            if (!Array.isArray(d.messages))
+                throw TypeError(".RPC.messages: array expected");
+            m.messages = [];
+            for (var i = 0; i < d.messages.length; ++i) {
+                if (typeof d.messages[i] !== "object")
+                    throw TypeError(".RPC.messages: object expected");
+                m.messages[i] = $root.RPC.Message.fromObject(d.messages[i]);
             }
+        }
+        if (d.control != null) {
+            if (typeof d.control !== "object")
+                throw TypeError(".RPC.control: object expected");
+            m.control = $root.ControlMessage.fromObject(d.control);
         }
         return m;
     };
@@ -159,7 +192,7 @@ export const RPC = $root.RPC = (() => {
         var d = {};
         if (o.arrays || o.defaults) {
             d.subscriptions = [];
-            d.msgs = [];
+            d.messages = [];
         }
         if (m.subscriptions && m.subscriptions.length) {
             d.subscriptions = [];
@@ -167,11 +200,16 @@ export const RPC = $root.RPC = (() => {
                 d.subscriptions[j] = $root.RPC.SubOpts.toObject(m.subscriptions[j], o);
             }
         }
-        if (m.msgs && m.msgs.length) {
-            d.msgs = [];
-            for (var j = 0; j < m.msgs.length; ++j) {
-                d.msgs[j] = $root.RPC.Message.toObject(m.msgs[j], o);
+        if (m.messages && m.messages.length) {
+            d.messages = [];
+            for (var j = 0; j < m.messages.length; ++j) {
+                d.messages[j] = $root.RPC.Message.toObject(m.messages[j], o);
             }
+        }
+        if (m.control != null && m.hasOwnProperty("control")) {
+            d.control = $root.ControlMessage.toObject(m.control, o);
+            if (o.oneofs)
+                d._control = "control";
         }
         return d;
     };
@@ -194,7 +232,7 @@ export const RPC = $root.RPC = (() => {
          * @memberof RPC
          * @interface ISubOpts
          * @property {boolean|null} [subscribe] SubOpts subscribe
-         * @property {string|null} [topicID] SubOpts topicID
+         * @property {string|null} [topic] SubOpts topic
          */
 
         /**
@@ -221,12 +259,12 @@ export const RPC = $root.RPC = (() => {
         SubOpts.prototype.subscribe = null;
 
         /**
-         * SubOpts topicID.
-         * @member {string|null|undefined} topicID
+         * SubOpts topic.
+         * @member {string|null|undefined} topic
          * @memberof RPC.SubOpts
          * @instance
          */
-        SubOpts.prototype.topicID = null;
+        SubOpts.prototype.topic = null;
 
         // OneOf field names bound to virtual getters and setters
         let $oneOfFields;
@@ -243,13 +281,13 @@ export const RPC = $root.RPC = (() => {
         });
 
         /**
-         * SubOpts _topicID.
-         * @member {"topicID"|undefined} _topicID
+         * SubOpts _topic.
+         * @member {"topic"|undefined} _topic
          * @memberof RPC.SubOpts
          * @instance
          */
-        Object.defineProperty(SubOpts.prototype, "_topicID", {
-            get: $util.oneOfGetter($oneOfFields = ["topicID"]),
+        Object.defineProperty(SubOpts.prototype, "_topic", {
+            get: $util.oneOfGetter($oneOfFields = ["topic"]),
             set: $util.oneOfSetter($oneOfFields)
         });
 
@@ -267,8 +305,8 @@ export const RPC = $root.RPC = (() => {
                 w = $Writer.create();
             if (m.subscribe != null && Object.hasOwnProperty.call(m, "subscribe"))
                 w.uint32(8).bool(m.subscribe);
-            if (m.topicID != null && Object.hasOwnProperty.call(m, "topicID"))
-                w.uint32(18).string(m.topicID);
+            if (m.topic != null && Object.hasOwnProperty.call(m, "topic"))
+                w.uint32(18).string(m.topic);
             return w;
         };
 
@@ -294,7 +332,7 @@ export const RPC = $root.RPC = (() => {
                     m.subscribe = r.bool();
                     break;
                 case 2:
-                    m.topicID = r.string();
+                    m.topic = r.string();
                     break;
                 default:
                     r.skipType(t & 7);
@@ -319,8 +357,8 @@ export const RPC = $root.RPC = (() => {
             if (d.subscribe != null) {
                 m.subscribe = Boolean(d.subscribe);
             }
-            if (d.topicID != null) {
-                m.topicID = String(d.topicID);
+            if (d.topic != null) {
+                m.topic = String(d.topic);
             }
             return m;
         };
@@ -343,10 +381,10 @@ export const RPC = $root.RPC = (() => {
                 if (o.oneofs)
                     d._subscribe = "subscribe";
             }
-            if (m.topicID != null && m.hasOwnProperty("topicID")) {
-                d.topicID = m.topicID;
+            if (m.topic != null && m.hasOwnProperty("topic")) {
+                d.topic = m.topic;
                 if (o.oneofs)
-                    d._topicID = "topicID";
+                    d._topic = "topic";
             }
             return d;
         };
@@ -374,7 +412,7 @@ export const RPC = $root.RPC = (() => {
          * @property {Uint8Array|null} [from] Message from
          * @property {Uint8Array|null} [data] Message data
          * @property {Uint8Array|null} [seqno] Message seqno
-         * @property {Array.<string>|null} [topicIDs] Message topicIDs
+         * @property {string|null} [topic] Message topic
          * @property {Uint8Array|null} [signature] Message signature
          * @property {Uint8Array|null} [key] Message key
          */
@@ -388,7 +426,6 @@ export const RPC = $root.RPC = (() => {
          * @param {RPC.IMessage=} [p] Properties to set
          */
         function Message(p) {
-            this.topicIDs = [];
             if (p)
                 for (var ks = Object.keys(p), i = 0; i < ks.length; ++i)
                     if (p[ks[i]] != null)
@@ -420,12 +457,12 @@ export const RPC = $root.RPC = (() => {
         Message.prototype.seqno = null;
 
         /**
-         * Message topicIDs.
-         * @member {Array.<string>} topicIDs
+         * Message topic.
+         * @member {string|null|undefined} topic
          * @memberof RPC.Message
          * @instance
          */
-        Message.prototype.topicIDs = $util.emptyArray;
+        Message.prototype.topic = null;
 
         /**
          * Message signature.
@@ -480,6 +517,17 @@ export const RPC = $root.RPC = (() => {
         });
 
         /**
+         * Message _topic.
+         * @member {"topic"|undefined} _topic
+         * @memberof RPC.Message
+         * @instance
+         */
+        Object.defineProperty(Message.prototype, "_topic", {
+            get: $util.oneOfGetter($oneOfFields = ["topic"]),
+            set: $util.oneOfSetter($oneOfFields)
+        });
+
+        /**
          * Message _signature.
          * @member {"signature"|undefined} _signature
          * @memberof RPC.Message
@@ -519,10 +567,8 @@ export const RPC = $root.RPC = (() => {
                 w.uint32(18).bytes(m.data);
             if (m.seqno != null && Object.hasOwnProperty.call(m, "seqno"))
                 w.uint32(26).bytes(m.seqno);
-            if (m.topicIDs != null && m.topicIDs.length) {
-                for (var i = 0; i < m.topicIDs.length; ++i)
-                    w.uint32(34).string(m.topicIDs[i]);
-            }
+            if (m.topic != null && Object.hasOwnProperty.call(m, "topic"))
+                w.uint32(34).string(m.topic);
             if (m.signature != null && Object.hasOwnProperty.call(m, "signature"))
                 w.uint32(42).bytes(m.signature);
             if (m.key != null && Object.hasOwnProperty.call(m, "key"))
@@ -558,9 +604,7 @@ export const RPC = $root.RPC = (() => {
                     m.seqno = r.bytes();
                     break;
                 case 4:
-                    if (!(m.topicIDs && m.topicIDs.length))
-                        m.topicIDs = [];
-                    m.topicIDs.push(r.string());
+                    m.topic = r.string();
                     break;
                 case 5:
                     m.signature = r.bytes();
@@ -606,13 +650,8 @@ export const RPC = $root.RPC = (() => {
                 else if (d.seqno.length)
                     m.seqno = d.seqno;
             }
-            if (d.topicIDs) {
-                if (!Array.isArray(d.topicIDs))
-                    throw TypeError(".RPC.Message.topicIDs: array expected");
-                m.topicIDs = [];
-                for (var i = 0; i < d.topicIDs.length; ++i) {
-                    m.topicIDs[i] = String(d.topicIDs[i]);
-                }
+            if (d.topic != null) {
+                m.topic = String(d.topic);
             }
             if (d.signature != null) {
                 if (typeof d.signature === "string")
@@ -642,9 +681,6 @@ export const RPC = $root.RPC = (() => {
             if (!o)
                 o = {};
             var d = {};
-            if (o.arrays || o.defaults) {
-                d.topicIDs = [];
-            }
             if (m.from != null && m.hasOwnProperty("from")) {
                 d.from = o.bytes === String ? $util.base64.encode(m.from, 0, m.from.length) : o.bytes === Array ? Array.prototype.slice.call(m.from) : m.from;
                 if (o.oneofs)
@@ -660,11 +696,10 @@ export const RPC = $root.RPC = (() => {
                 if (o.oneofs)
                     d._seqno = "seqno";
             }
-            if (m.topicIDs && m.topicIDs.length) {
-                d.topicIDs = [];
-                for (var j = 0; j < m.topicIDs.length; ++j) {
-                    d.topicIDs[j] = m.topicIDs[j];
-                }
+            if (m.topic != null && m.hasOwnProperty("topic")) {
+                d.topic = m.topic;
+                if (o.oneofs)
+                    d._topic = "topic";
             }
             if (m.signature != null && m.hasOwnProperty("signature")) {
                 d.signature = o.bytes === String ? $util.base64.encode(m.signature, 0, m.signature.length) : o.bytes === Array ? Array.prototype.slice.call(m.signature) : m.signature;
@@ -694,6 +729,1142 @@ export const RPC = $root.RPC = (() => {
     })();
 
     return RPC;
+})();
+
+export const ControlMessage = $root.ControlMessage = (() => {
+
+    /**
+     * Properties of a ControlMessage.
+     * @exports IControlMessage
+     * @interface IControlMessage
+     * @property {Array.<IControlIHave>|null} [ihave] ControlMessage ihave
+     * @property {Array.<IControlIWant>|null} [iwant] ControlMessage iwant
+     * @property {Array.<IControlGraft>|null} [graft] ControlMessage graft
+     * @property {Array.<IControlPrune>|null} [prune] ControlMessage prune
+     */
+
+    /**
+     * Constructs a new ControlMessage.
+     * @exports ControlMessage
+     * @classdesc Represents a ControlMessage.
+     * @implements IControlMessage
+     * @constructor
+     * @param {IControlMessage=} [p] Properties to set
+     */
+    function ControlMessage(p) {
+        this.ihave = [];
+        this.iwant = [];
+        this.graft = [];
+        this.prune = [];
+        if (p)
+            for (var ks = Object.keys(p), i = 0; i < ks.length; ++i)
+                if (p[ks[i]] != null)
+                    this[ks[i]] = p[ks[i]];
+    }
+
+    /**
+     * ControlMessage ihave.
+     * @member {Array.<IControlIHave>} ihave
+     * @memberof ControlMessage
+     * @instance
+     */
+    ControlMessage.prototype.ihave = $util.emptyArray;
+
+    /**
+     * ControlMessage iwant.
+     * @member {Array.<IControlIWant>} iwant
+     * @memberof ControlMessage
+     * @instance
+     */
+    ControlMessage.prototype.iwant = $util.emptyArray;
+
+    /**
+     * ControlMessage graft.
+     * @member {Array.<IControlGraft>} graft
+     * @memberof ControlMessage
+     * @instance
+     */
+    ControlMessage.prototype.graft = $util.emptyArray;
+
+    /**
+     * ControlMessage prune.
+     * @member {Array.<IControlPrune>} prune
+     * @memberof ControlMessage
+     * @instance
+     */
+    ControlMessage.prototype.prune = $util.emptyArray;
+
+    /**
+     * Encodes the specified ControlMessage message. Does not implicitly {@link ControlMessage.verify|verify} messages.
+     * @function encode
+     * @memberof ControlMessage
+     * @static
+     * @param {IControlMessage} m ControlMessage message or plain object to encode
+     * @param {$protobuf.Writer} [w] Writer to encode to
+     * @returns {$protobuf.Writer} Writer
+     */
+    ControlMessage.encode = function encode(m, w) {
+        if (!w)
+            w = $Writer.create();
+        if (m.ihave != null && m.ihave.length) {
+            for (var i = 0; i < m.ihave.length; ++i)
+                $root.ControlIHave.encode(m.ihave[i], w.uint32(10).fork()).ldelim();
+        }
+        if (m.iwant != null && m.iwant.length) {
+            for (var i = 0; i < m.iwant.length; ++i)
+                $root.ControlIWant.encode(m.iwant[i], w.uint32(18).fork()).ldelim();
+        }
+        if (m.graft != null && m.graft.length) {
+            for (var i = 0; i < m.graft.length; ++i)
+                $root.ControlGraft.encode(m.graft[i], w.uint32(26).fork()).ldelim();
+        }
+        if (m.prune != null && m.prune.length) {
+            for (var i = 0; i < m.prune.length; ++i)
+                $root.ControlPrune.encode(m.prune[i], w.uint32(34).fork()).ldelim();
+        }
+        return w;
+    };
+
+    /**
+     * Decodes a ControlMessage message from the specified reader or buffer.
+     * @function decode
+     * @memberof ControlMessage
+     * @static
+     * @param {$protobuf.Reader|Uint8Array} r Reader or buffer to decode from
+     * @param {number} [l] Message length if known beforehand
+     * @returns {ControlMessage} ControlMessage
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    ControlMessage.decode = function decode(r, l) {
+        if (!(r instanceof $Reader))
+            r = $Reader.create(r);
+        var c = l === undefined ? r.len : r.pos + l, m = new $root.ControlMessage();
+        while (r.pos < c) {
+            var t = r.uint32();
+            switch (t >>> 3) {
+            case 1:
+                if (!(m.ihave && m.ihave.length))
+                    m.ihave = [];
+                m.ihave.push($root.ControlIHave.decode(r, r.uint32()));
+                break;
+            case 2:
+                if (!(m.iwant && m.iwant.length))
+                    m.iwant = [];
+                m.iwant.push($root.ControlIWant.decode(r, r.uint32()));
+                break;
+            case 3:
+                if (!(m.graft && m.graft.length))
+                    m.graft = [];
+                m.graft.push($root.ControlGraft.decode(r, r.uint32()));
+                break;
+            case 4:
+                if (!(m.prune && m.prune.length))
+                    m.prune = [];
+                m.prune.push($root.ControlPrune.decode(r, r.uint32()));
+                break;
+            default:
+                r.skipType(t & 7);
+                break;
+            }
+        }
+        return m;
+    };
+
+    /**
+     * Creates a ControlMessage message from a plain object. Also converts values to their respective internal types.
+     * @function fromObject
+     * @memberof ControlMessage
+     * @static
+     * @param {Object.<string,*>} d Plain object
+     * @returns {ControlMessage} ControlMessage
+     */
+    ControlMessage.fromObject = function fromObject(d) {
+        if (d instanceof $root.ControlMessage)
+            return d;
+        var m = new $root.ControlMessage();
+        if (d.ihave) {
+            if (!Array.isArray(d.ihave))
+                throw TypeError(".ControlMessage.ihave: array expected");
+            m.ihave = [];
+            for (var i = 0; i < d.ihave.length; ++i) {
+                if (typeof d.ihave[i] !== "object")
+                    throw TypeError(".ControlMessage.ihave: object expected");
+                m.ihave[i] = $root.ControlIHave.fromObject(d.ihave[i]);
+            }
+        }
+        if (d.iwant) {
+            if (!Array.isArray(d.iwant))
+                throw TypeError(".ControlMessage.iwant: array expected");
+            m.iwant = [];
+            for (var i = 0; i < d.iwant.length; ++i) {
+                if (typeof d.iwant[i] !== "object")
+                    throw TypeError(".ControlMessage.iwant: object expected");
+                m.iwant[i] = $root.ControlIWant.fromObject(d.iwant[i]);
+            }
+        }
+        if (d.graft) {
+            if (!Array.isArray(d.graft))
+                throw TypeError(".ControlMessage.graft: array expected");
+            m.graft = [];
+            for (var i = 0; i < d.graft.length; ++i) {
+                if (typeof d.graft[i] !== "object")
+                    throw TypeError(".ControlMessage.graft: object expected");
+                m.graft[i] = $root.ControlGraft.fromObject(d.graft[i]);
+            }
+        }
+        if (d.prune) {
+            if (!Array.isArray(d.prune))
+                throw TypeError(".ControlMessage.prune: array expected");
+            m.prune = [];
+            for (var i = 0; i < d.prune.length; ++i) {
+                if (typeof d.prune[i] !== "object")
+                    throw TypeError(".ControlMessage.prune: object expected");
+                m.prune[i] = $root.ControlPrune.fromObject(d.prune[i]);
+            }
+        }
+        return m;
+    };
+
+    /**
+     * Creates a plain object from a ControlMessage message. Also converts values to other types if specified.
+     * @function toObject
+     * @memberof ControlMessage
+     * @static
+     * @param {ControlMessage} m ControlMessage
+     * @param {$protobuf.IConversionOptions} [o] Conversion options
+     * @returns {Object.<string,*>} Plain object
+     */
+    ControlMessage.toObject = function toObject(m, o) {
+        if (!o)
+            o = {};
+        var d = {};
+        if (o.arrays || o.defaults) {
+            d.ihave = [];
+            d.iwant = [];
+            d.graft = [];
+            d.prune = [];
+        }
+        if (m.ihave && m.ihave.length) {
+            d.ihave = [];
+            for (var j = 0; j < m.ihave.length; ++j) {
+                d.ihave[j] = $root.ControlIHave.toObject(m.ihave[j], o);
+            }
+        }
+        if (m.iwant && m.iwant.length) {
+            d.iwant = [];
+            for (var j = 0; j < m.iwant.length; ++j) {
+                d.iwant[j] = $root.ControlIWant.toObject(m.iwant[j], o);
+            }
+        }
+        if (m.graft && m.graft.length) {
+            d.graft = [];
+            for (var j = 0; j < m.graft.length; ++j) {
+                d.graft[j] = $root.ControlGraft.toObject(m.graft[j], o);
+            }
+        }
+        if (m.prune && m.prune.length) {
+            d.prune = [];
+            for (var j = 0; j < m.prune.length; ++j) {
+                d.prune[j] = $root.ControlPrune.toObject(m.prune[j], o);
+            }
+        }
+        return d;
+    };
+
+    /**
+     * Converts this ControlMessage to JSON.
+     * @function toJSON
+     * @memberof ControlMessage
+     * @instance
+     * @returns {Object.<string,*>} JSON object
+     */
+    ControlMessage.prototype.toJSON = function toJSON() {
+        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+    };
+
+    return ControlMessage;
+})();
+
+export const ControlIHave = $root.ControlIHave = (() => {
+
+    /**
+     * Properties of a ControlIHave.
+     * @exports IControlIHave
+     * @interface IControlIHave
+     * @property {string|null} [topicID] ControlIHave topicID
+     * @property {Array.<string>|null} [messageIDs] ControlIHave messageIDs
+     */
+
+    /**
+     * Constructs a new ControlIHave.
+     * @exports ControlIHave
+     * @classdesc Represents a ControlIHave.
+     * @implements IControlIHave
+     * @constructor
+     * @param {IControlIHave=} [p] Properties to set
+     */
+    function ControlIHave(p) {
+        this.messageIDs = [];
+        if (p)
+            for (var ks = Object.keys(p), i = 0; i < ks.length; ++i)
+                if (p[ks[i]] != null)
+                    this[ks[i]] = p[ks[i]];
+    }
+
+    /**
+     * ControlIHave topicID.
+     * @member {string|null|undefined} topicID
+     * @memberof ControlIHave
+     * @instance
+     */
+    ControlIHave.prototype.topicID = null;
+
+    /**
+     * ControlIHave messageIDs.
+     * @member {Array.<string>} messageIDs
+     * @memberof ControlIHave
+     * @instance
+     */
+    ControlIHave.prototype.messageIDs = $util.emptyArray;
+
+    // OneOf field names bound to virtual getters and setters
+    let $oneOfFields;
+
+    /**
+     * ControlIHave _topicID.
+     * @member {"topicID"|undefined} _topicID
+     * @memberof ControlIHave
+     * @instance
+     */
+    Object.defineProperty(ControlIHave.prototype, "_topicID", {
+        get: $util.oneOfGetter($oneOfFields = ["topicID"]),
+        set: $util.oneOfSetter($oneOfFields)
+    });
+
+    /**
+     * Encodes the specified ControlIHave message. Does not implicitly {@link ControlIHave.verify|verify} messages.
+     * @function encode
+     * @memberof ControlIHave
+     * @static
+     * @param {IControlIHave} m ControlIHave message or plain object to encode
+     * @param {$protobuf.Writer} [w] Writer to encode to
+     * @returns {$protobuf.Writer} Writer
+     */
+    ControlIHave.encode = function encode(m, w) {
+        if (!w)
+            w = $Writer.create();
+        if (m.topicID != null && Object.hasOwnProperty.call(m, "topicID"))
+            w.uint32(10).string(m.topicID);
+        if (m.messageIDs != null && m.messageIDs.length) {
+            for (var i = 0; i < m.messageIDs.length; ++i)
+                w.uint32(18).string(m.messageIDs[i]);
+        }
+        return w;
+    };
+
+    /**
+     * Decodes a ControlIHave message from the specified reader or buffer.
+     * @function decode
+     * @memberof ControlIHave
+     * @static
+     * @param {$protobuf.Reader|Uint8Array} r Reader or buffer to decode from
+     * @param {number} [l] Message length if known beforehand
+     * @returns {ControlIHave} ControlIHave
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    ControlIHave.decode = function decode(r, l) {
+        if (!(r instanceof $Reader))
+            r = $Reader.create(r);
+        var c = l === undefined ? r.len : r.pos + l, m = new $root.ControlIHave();
+        while (r.pos < c) {
+            var t = r.uint32();
+            switch (t >>> 3) {
+            case 1:
+                m.topicID = r.string();
+                break;
+            case 2:
+                if (!(m.messageIDs && m.messageIDs.length))
+                    m.messageIDs = [];
+                m.messageIDs.push(r.string());
+                break;
+            default:
+                r.skipType(t & 7);
+                break;
+            }
+        }
+        return m;
+    };
+
+    /**
+     * Creates a ControlIHave message from a plain object. Also converts values to their respective internal types.
+     * @function fromObject
+     * @memberof ControlIHave
+     * @static
+     * @param {Object.<string,*>} d Plain object
+     * @returns {ControlIHave} ControlIHave
+     */
+    ControlIHave.fromObject = function fromObject(d) {
+        if (d instanceof $root.ControlIHave)
+            return d;
+        var m = new $root.ControlIHave();
+        if (d.topicID != null) {
+            m.topicID = String(d.topicID);
+        }
+        if (d.messageIDs) {
+            if (!Array.isArray(d.messageIDs))
+                throw TypeError(".ControlIHave.messageIDs: array expected");
+            m.messageIDs = [];
+            for (var i = 0; i < d.messageIDs.length; ++i) {
+                m.messageIDs[i] = String(d.messageIDs[i]);
+            }
+        }
+        return m;
+    };
+
+    /**
+     * Creates a plain object from a ControlIHave message. Also converts values to other types if specified.
+     * @function toObject
+     * @memberof ControlIHave
+     * @static
+     * @param {ControlIHave} m ControlIHave
+     * @param {$protobuf.IConversionOptions} [o] Conversion options
+     * @returns {Object.<string,*>} Plain object
+     */
+    ControlIHave.toObject = function toObject(m, o) {
+        if (!o)
+            o = {};
+        var d = {};
+        if (o.arrays || o.defaults) {
+            d.messageIDs = [];
+        }
+        if (m.topicID != null && m.hasOwnProperty("topicID")) {
+            d.topicID = m.topicID;
+            if (o.oneofs)
+                d._topicID = "topicID";
+        }
+        if (m.messageIDs && m.messageIDs.length) {
+            d.messageIDs = [];
+            for (var j = 0; j < m.messageIDs.length; ++j) {
+                d.messageIDs[j] = m.messageIDs[j];
+            }
+        }
+        return d;
+    };
+
+    /**
+     * Converts this ControlIHave to JSON.
+     * @function toJSON
+     * @memberof ControlIHave
+     * @instance
+     * @returns {Object.<string,*>} JSON object
+     */
+    ControlIHave.prototype.toJSON = function toJSON() {
+        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+    };
+
+    return ControlIHave;
+})();
+
+export const ControlIWant = $root.ControlIWant = (() => {
+
+    /**
+     * Properties of a ControlIWant.
+     * @exports IControlIWant
+     * @interface IControlIWant
+     * @property {Array.<string>|null} [messageIDs] ControlIWant messageIDs
+     */
+
+    /**
+     * Constructs a new ControlIWant.
+     * @exports ControlIWant
+     * @classdesc Represents a ControlIWant.
+     * @implements IControlIWant
+     * @constructor
+     * @param {IControlIWant=} [p] Properties to set
+     */
+    function ControlIWant(p) {
+        this.messageIDs = [];
+        if (p)
+            for (var ks = Object.keys(p), i = 0; i < ks.length; ++i)
+                if (p[ks[i]] != null)
+                    this[ks[i]] = p[ks[i]];
+    }
+
+    /**
+     * ControlIWant messageIDs.
+     * @member {Array.<string>} messageIDs
+     * @memberof ControlIWant
+     * @instance
+     */
+    ControlIWant.prototype.messageIDs = $util.emptyArray;
+
+    /**
+     * Encodes the specified ControlIWant message. Does not implicitly {@link ControlIWant.verify|verify} messages.
+     * @function encode
+     * @memberof ControlIWant
+     * @static
+     * @param {IControlIWant} m ControlIWant message or plain object to encode
+     * @param {$protobuf.Writer} [w] Writer to encode to
+     * @returns {$protobuf.Writer} Writer
+     */
+    ControlIWant.encode = function encode(m, w) {
+        if (!w)
+            w = $Writer.create();
+        if (m.messageIDs != null && m.messageIDs.length) {
+            for (var i = 0; i < m.messageIDs.length; ++i)
+                w.uint32(10).string(m.messageIDs[i]);
+        }
+        return w;
+    };
+
+    /**
+     * Decodes a ControlIWant message from the specified reader or buffer.
+     * @function decode
+     * @memberof ControlIWant
+     * @static
+     * @param {$protobuf.Reader|Uint8Array} r Reader or buffer to decode from
+     * @param {number} [l] Message length if known beforehand
+     * @returns {ControlIWant} ControlIWant
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    ControlIWant.decode = function decode(r, l) {
+        if (!(r instanceof $Reader))
+            r = $Reader.create(r);
+        var c = l === undefined ? r.len : r.pos + l, m = new $root.ControlIWant();
+        while (r.pos < c) {
+            var t = r.uint32();
+            switch (t >>> 3) {
+            case 1:
+                if (!(m.messageIDs && m.messageIDs.length))
+                    m.messageIDs = [];
+                m.messageIDs.push(r.string());
+                break;
+            default:
+                r.skipType(t & 7);
+                break;
+            }
+        }
+        return m;
+    };
+
+    /**
+     * Creates a ControlIWant message from a plain object. Also converts values to their respective internal types.
+     * @function fromObject
+     * @memberof ControlIWant
+     * @static
+     * @param {Object.<string,*>} d Plain object
+     * @returns {ControlIWant} ControlIWant
+     */
+    ControlIWant.fromObject = function fromObject(d) {
+        if (d instanceof $root.ControlIWant)
+            return d;
+        var m = new $root.ControlIWant();
+        if (d.messageIDs) {
+            if (!Array.isArray(d.messageIDs))
+                throw TypeError(".ControlIWant.messageIDs: array expected");
+            m.messageIDs = [];
+            for (var i = 0; i < d.messageIDs.length; ++i) {
+                m.messageIDs[i] = String(d.messageIDs[i]);
+            }
+        }
+        return m;
+    };
+
+    /**
+     * Creates a plain object from a ControlIWant message. Also converts values to other types if specified.
+     * @function toObject
+     * @memberof ControlIWant
+     * @static
+     * @param {ControlIWant} m ControlIWant
+     * @param {$protobuf.IConversionOptions} [o] Conversion options
+     * @returns {Object.<string,*>} Plain object
+     */
+    ControlIWant.toObject = function toObject(m, o) {
+        if (!o)
+            o = {};
+        var d = {};
+        if (o.arrays || o.defaults) {
+            d.messageIDs = [];
+        }
+        if (m.messageIDs && m.messageIDs.length) {
+            d.messageIDs = [];
+            for (var j = 0; j < m.messageIDs.length; ++j) {
+                d.messageIDs[j] = m.messageIDs[j];
+            }
+        }
+        return d;
+    };
+
+    /**
+     * Converts this ControlIWant to JSON.
+     * @function toJSON
+     * @memberof ControlIWant
+     * @instance
+     * @returns {Object.<string,*>} JSON object
+     */
+    ControlIWant.prototype.toJSON = function toJSON() {
+        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+    };
+
+    return ControlIWant;
+})();
+
+export const ControlGraft = $root.ControlGraft = (() => {
+
+    /**
+     * Properties of a ControlGraft.
+     * @exports IControlGraft
+     * @interface IControlGraft
+     * @property {string|null} [topicID] ControlGraft topicID
+     */
+
+    /**
+     * Constructs a new ControlGraft.
+     * @exports ControlGraft
+     * @classdesc Represents a ControlGraft.
+     * @implements IControlGraft
+     * @constructor
+     * @param {IControlGraft=} [p] Properties to set
+     */
+    function ControlGraft(p) {
+        if (p)
+            for (var ks = Object.keys(p), i = 0; i < ks.length; ++i)
+                if (p[ks[i]] != null)
+                    this[ks[i]] = p[ks[i]];
+    }
+
+    /**
+     * ControlGraft topicID.
+     * @member {string|null|undefined} topicID
+     * @memberof ControlGraft
+     * @instance
+     */
+    ControlGraft.prototype.topicID = null;
+
+    // OneOf field names bound to virtual getters and setters
+    let $oneOfFields;
+
+    /**
+     * ControlGraft _topicID.
+     * @member {"topicID"|undefined} _topicID
+     * @memberof ControlGraft
+     * @instance
+     */
+    Object.defineProperty(ControlGraft.prototype, "_topicID", {
+        get: $util.oneOfGetter($oneOfFields = ["topicID"]),
+        set: $util.oneOfSetter($oneOfFields)
+    });
+
+    /**
+     * Encodes the specified ControlGraft message. Does not implicitly {@link ControlGraft.verify|verify} messages.
+     * @function encode
+     * @memberof ControlGraft
+     * @static
+     * @param {IControlGraft} m ControlGraft message or plain object to encode
+     * @param {$protobuf.Writer} [w] Writer to encode to
+     * @returns {$protobuf.Writer} Writer
+     */
+    ControlGraft.encode = function encode(m, w) {
+        if (!w)
+            w = $Writer.create();
+        if (m.topicID != null && Object.hasOwnProperty.call(m, "topicID"))
+            w.uint32(10).string(m.topicID);
+        return w;
+    };
+
+    /**
+     * Decodes a ControlGraft message from the specified reader or buffer.
+     * @function decode
+     * @memberof ControlGraft
+     * @static
+     * @param {$protobuf.Reader|Uint8Array} r Reader or buffer to decode from
+     * @param {number} [l] Message length if known beforehand
+     * @returns {ControlGraft} ControlGraft
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    ControlGraft.decode = function decode(r, l) {
+        if (!(r instanceof $Reader))
+            r = $Reader.create(r);
+        var c = l === undefined ? r.len : r.pos + l, m = new $root.ControlGraft();
+        while (r.pos < c) {
+            var t = r.uint32();
+            switch (t >>> 3) {
+            case 1:
+                m.topicID = r.string();
+                break;
+            default:
+                r.skipType(t & 7);
+                break;
+            }
+        }
+        return m;
+    };
+
+    /**
+     * Creates a ControlGraft message from a plain object. Also converts values to their respective internal types.
+     * @function fromObject
+     * @memberof ControlGraft
+     * @static
+     * @param {Object.<string,*>} d Plain object
+     * @returns {ControlGraft} ControlGraft
+     */
+    ControlGraft.fromObject = function fromObject(d) {
+        if (d instanceof $root.ControlGraft)
+            return d;
+        var m = new $root.ControlGraft();
+        if (d.topicID != null) {
+            m.topicID = String(d.topicID);
+        }
+        return m;
+    };
+
+    /**
+     * Creates a plain object from a ControlGraft message. Also converts values to other types if specified.
+     * @function toObject
+     * @memberof ControlGraft
+     * @static
+     * @param {ControlGraft} m ControlGraft
+     * @param {$protobuf.IConversionOptions} [o] Conversion options
+     * @returns {Object.<string,*>} Plain object
+     */
+    ControlGraft.toObject = function toObject(m, o) {
+        if (!o)
+            o = {};
+        var d = {};
+        if (m.topicID != null && m.hasOwnProperty("topicID")) {
+            d.topicID = m.topicID;
+            if (o.oneofs)
+                d._topicID = "topicID";
+        }
+        return d;
+    };
+
+    /**
+     * Converts this ControlGraft to JSON.
+     * @function toJSON
+     * @memberof ControlGraft
+     * @instance
+     * @returns {Object.<string,*>} JSON object
+     */
+    ControlGraft.prototype.toJSON = function toJSON() {
+        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+    };
+
+    return ControlGraft;
+})();
+
+export const ControlPrune = $root.ControlPrune = (() => {
+
+    /**
+     * Properties of a ControlPrune.
+     * @exports IControlPrune
+     * @interface IControlPrune
+     * @property {string|null} [topicID] ControlPrune topicID
+     * @property {Array.<IPeerInfo>|null} [peers] ControlPrune peers
+     * @property {number|null} [backoff] ControlPrune backoff
+     */
+
+    /**
+     * Constructs a new ControlPrune.
+     * @exports ControlPrune
+     * @classdesc Represents a ControlPrune.
+     * @implements IControlPrune
+     * @constructor
+     * @param {IControlPrune=} [p] Properties to set
+     */
+    function ControlPrune(p) {
+        this.peers = [];
+        if (p)
+            for (var ks = Object.keys(p), i = 0; i < ks.length; ++i)
+                if (p[ks[i]] != null)
+                    this[ks[i]] = p[ks[i]];
+    }
+
+    /**
+     * ControlPrune topicID.
+     * @member {string|null|undefined} topicID
+     * @memberof ControlPrune
+     * @instance
+     */
+    ControlPrune.prototype.topicID = null;
+
+    /**
+     * ControlPrune peers.
+     * @member {Array.<IPeerInfo>} peers
+     * @memberof ControlPrune
+     * @instance
+     */
+    ControlPrune.prototype.peers = $util.emptyArray;
+
+    /**
+     * ControlPrune backoff.
+     * @member {number|null|undefined} backoff
+     * @memberof ControlPrune
+     * @instance
+     */
+    ControlPrune.prototype.backoff = null;
+
+    // OneOf field names bound to virtual getters and setters
+    let $oneOfFields;
+
+    /**
+     * ControlPrune _topicID.
+     * @member {"topicID"|undefined} _topicID
+     * @memberof ControlPrune
+     * @instance
+     */
+    Object.defineProperty(ControlPrune.prototype, "_topicID", {
+        get: $util.oneOfGetter($oneOfFields = ["topicID"]),
+        set: $util.oneOfSetter($oneOfFields)
+    });
+
+    /**
+     * ControlPrune _backoff.
+     * @member {"backoff"|undefined} _backoff
+     * @memberof ControlPrune
+     * @instance
+     */
+    Object.defineProperty(ControlPrune.prototype, "_backoff", {
+        get: $util.oneOfGetter($oneOfFields = ["backoff"]),
+        set: $util.oneOfSetter($oneOfFields)
+    });
+
+    /**
+     * Encodes the specified ControlPrune message. Does not implicitly {@link ControlPrune.verify|verify} messages.
+     * @function encode
+     * @memberof ControlPrune
+     * @static
+     * @param {IControlPrune} m ControlPrune message or plain object to encode
+     * @param {$protobuf.Writer} [w] Writer to encode to
+     * @returns {$protobuf.Writer} Writer
+     */
+    ControlPrune.encode = function encode(m, w) {
+        if (!w)
+            w = $Writer.create();
+        if (m.topicID != null && Object.hasOwnProperty.call(m, "topicID"))
+            w.uint32(10).string(m.topicID);
+        if (m.peers != null && m.peers.length) {
+            for (var i = 0; i < m.peers.length; ++i)
+                $root.PeerInfo.encode(m.peers[i], w.uint32(18).fork()).ldelim();
+        }
+        if (m.backoff != null && Object.hasOwnProperty.call(m, "backoff"))
+            w.uint32(24).uint64(m.backoff);
+        return w;
+    };
+
+    /**
+     * Decodes a ControlPrune message from the specified reader or buffer.
+     * @function decode
+     * @memberof ControlPrune
+     * @static
+     * @param {$protobuf.Reader|Uint8Array} r Reader or buffer to decode from
+     * @param {number} [l] Message length if known beforehand
+     * @returns {ControlPrune} ControlPrune
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    ControlPrune.decode = function decode(r, l) {
+        if (!(r instanceof $Reader))
+            r = $Reader.create(r);
+        var c = l === undefined ? r.len : r.pos + l, m = new $root.ControlPrune();
+        while (r.pos < c) {
+            var t = r.uint32();
+            switch (t >>> 3) {
+            case 1:
+                m.topicID = r.string();
+                break;
+            case 2:
+                if (!(m.peers && m.peers.length))
+                    m.peers = [];
+                m.peers.push($root.PeerInfo.decode(r, r.uint32()));
+                break;
+            case 3:
+                m.backoff = r.uint64();
+                break;
+            default:
+                r.skipType(t & 7);
+                break;
+            }
+        }
+        return m;
+    };
+
+    /**
+     * Creates a ControlPrune message from a plain object. Also converts values to their respective internal types.
+     * @function fromObject
+     * @memberof ControlPrune
+     * @static
+     * @param {Object.<string,*>} d Plain object
+     * @returns {ControlPrune} ControlPrune
+     */
+    ControlPrune.fromObject = function fromObject(d) {
+        if (d instanceof $root.ControlPrune)
+            return d;
+        var m = new $root.ControlPrune();
+        if (d.topicID != null) {
+            m.topicID = String(d.topicID);
+        }
+        if (d.peers) {
+            if (!Array.isArray(d.peers))
+                throw TypeError(".ControlPrune.peers: array expected");
+            m.peers = [];
+            for (var i = 0; i < d.peers.length; ++i) {
+                if (typeof d.peers[i] !== "object")
+                    throw TypeError(".ControlPrune.peers: object expected");
+                m.peers[i] = $root.PeerInfo.fromObject(d.peers[i]);
+            }
+        }
+        if (d.backoff != null) {
+            if ($util.Long)
+                (m.backoff = $util.Long.fromValue(d.backoff)).unsigned = true;
+            else if (typeof d.backoff === "string")
+                m.backoff = parseInt(d.backoff, 10);
+            else if (typeof d.backoff === "number")
+                m.backoff = d.backoff;
+            else if (typeof d.backoff === "object")
+                m.backoff = new $util.LongBits(d.backoff.low >>> 0, d.backoff.high >>> 0).toNumber(true);
+        }
+        return m;
+    };
+
+    /**
+     * Creates a plain object from a ControlPrune message. Also converts values to other types if specified.
+     * @function toObject
+     * @memberof ControlPrune
+     * @static
+     * @param {ControlPrune} m ControlPrune
+     * @param {$protobuf.IConversionOptions} [o] Conversion options
+     * @returns {Object.<string,*>} Plain object
+     */
+    ControlPrune.toObject = function toObject(m, o) {
+        if (!o)
+            o = {};
+        var d = {};
+        if (o.arrays || o.defaults) {
+            d.peers = [];
+        }
+        if (m.topicID != null && m.hasOwnProperty("topicID")) {
+            d.topicID = m.topicID;
+            if (o.oneofs)
+                d._topicID = "topicID";
+        }
+        if (m.peers && m.peers.length) {
+            d.peers = [];
+            for (var j = 0; j < m.peers.length; ++j) {
+                d.peers[j] = $root.PeerInfo.toObject(m.peers[j], o);
+            }
+        }
+        if (m.backoff != null && m.hasOwnProperty("backoff")) {
+            if (typeof m.backoff === "number")
+                d.backoff = o.longs === String ? String(m.backoff) : m.backoff;
+            else
+                d.backoff = o.longs === String ? $util.Long.prototype.toString.call(m.backoff) : o.longs === Number ? new $util.LongBits(m.backoff.low >>> 0, m.backoff.high >>> 0).toNumber(true) : m.backoff;
+            if (o.oneofs)
+                d._backoff = "backoff";
+        }
+        return d;
+    };
+
+    /**
+     * Converts this ControlPrune to JSON.
+     * @function toJSON
+     * @memberof ControlPrune
+     * @instance
+     * @returns {Object.<string,*>} JSON object
+     */
+    ControlPrune.prototype.toJSON = function toJSON() {
+        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+    };
+
+    return ControlPrune;
+})();
+
+export const PeerInfo = $root.PeerInfo = (() => {
+
+    /**
+     * Properties of a PeerInfo.
+     * @exports IPeerInfo
+     * @interface IPeerInfo
+     * @property {Uint8Array|null} [peerID] PeerInfo peerID
+     * @property {Uint8Array|null} [signedPeerRecord] PeerInfo signedPeerRecord
+     */
+
+    /**
+     * Constructs a new PeerInfo.
+     * @exports PeerInfo
+     * @classdesc Represents a PeerInfo.
+     * @implements IPeerInfo
+     * @constructor
+     * @param {IPeerInfo=} [p] Properties to set
+     */
+    function PeerInfo(p) {
+        if (p)
+            for (var ks = Object.keys(p), i = 0; i < ks.length; ++i)
+                if (p[ks[i]] != null)
+                    this[ks[i]] = p[ks[i]];
+    }
+
+    /**
+     * PeerInfo peerID.
+     * @member {Uint8Array|null|undefined} peerID
+     * @memberof PeerInfo
+     * @instance
+     */
+    PeerInfo.prototype.peerID = null;
+
+    /**
+     * PeerInfo signedPeerRecord.
+     * @member {Uint8Array|null|undefined} signedPeerRecord
+     * @memberof PeerInfo
+     * @instance
+     */
+    PeerInfo.prototype.signedPeerRecord = null;
+
+    // OneOf field names bound to virtual getters and setters
+    let $oneOfFields;
+
+    /**
+     * PeerInfo _peerID.
+     * @member {"peerID"|undefined} _peerID
+     * @memberof PeerInfo
+     * @instance
+     */
+    Object.defineProperty(PeerInfo.prototype, "_peerID", {
+        get: $util.oneOfGetter($oneOfFields = ["peerID"]),
+        set: $util.oneOfSetter($oneOfFields)
+    });
+
+    /**
+     * PeerInfo _signedPeerRecord.
+     * @member {"signedPeerRecord"|undefined} _signedPeerRecord
+     * @memberof PeerInfo
+     * @instance
+     */
+    Object.defineProperty(PeerInfo.prototype, "_signedPeerRecord", {
+        get: $util.oneOfGetter($oneOfFields = ["signedPeerRecord"]),
+        set: $util.oneOfSetter($oneOfFields)
+    });
+
+    /**
+     * Encodes the specified PeerInfo message. Does not implicitly {@link PeerInfo.verify|verify} messages.
+     * @function encode
+     * @memberof PeerInfo
+     * @static
+     * @param {IPeerInfo} m PeerInfo message or plain object to encode
+     * @param {$protobuf.Writer} [w] Writer to encode to
+     * @returns {$protobuf.Writer} Writer
+     */
+    PeerInfo.encode = function encode(m, w) {
+        if (!w)
+            w = $Writer.create();
+        if (m.peerID != null && Object.hasOwnProperty.call(m, "peerID"))
+            w.uint32(10).bytes(m.peerID);
+        if (m.signedPeerRecord != null && Object.hasOwnProperty.call(m, "signedPeerRecord"))
+            w.uint32(18).bytes(m.signedPeerRecord);
+        return w;
+    };
+
+    /**
+     * Decodes a PeerInfo message from the specified reader or buffer.
+     * @function decode
+     * @memberof PeerInfo
+     * @static
+     * @param {$protobuf.Reader|Uint8Array} r Reader or buffer to decode from
+     * @param {number} [l] Message length if known beforehand
+     * @returns {PeerInfo} PeerInfo
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    PeerInfo.decode = function decode(r, l) {
+        if (!(r instanceof $Reader))
+            r = $Reader.create(r);
+        var c = l === undefined ? r.len : r.pos + l, m = new $root.PeerInfo();
+        while (r.pos < c) {
+            var t = r.uint32();
+            switch (t >>> 3) {
+            case 1:
+                m.peerID = r.bytes();
+                break;
+            case 2:
+                m.signedPeerRecord = r.bytes();
+                break;
+            default:
+                r.skipType(t & 7);
+                break;
+            }
+        }
+        return m;
+    };
+
+    /**
+     * Creates a PeerInfo message from a plain object. Also converts values to their respective internal types.
+     * @function fromObject
+     * @memberof PeerInfo
+     * @static
+     * @param {Object.<string,*>} d Plain object
+     * @returns {PeerInfo} PeerInfo
+     */
+    PeerInfo.fromObject = function fromObject(d) {
+        if (d instanceof $root.PeerInfo)
+            return d;
+        var m = new $root.PeerInfo();
+        if (d.peerID != null) {
+            if (typeof d.peerID === "string")
+                $util.base64.decode(d.peerID, m.peerID = $util.newBuffer($util.base64.length(d.peerID)), 0);
+            else if (d.peerID.length)
+                m.peerID = d.peerID;
+        }
+        if (d.signedPeerRecord != null) {
+            if (typeof d.signedPeerRecord === "string")
+                $util.base64.decode(d.signedPeerRecord, m.signedPeerRecord = $util.newBuffer($util.base64.length(d.signedPeerRecord)), 0);
+            else if (d.signedPeerRecord.length)
+                m.signedPeerRecord = d.signedPeerRecord;
+        }
+        return m;
+    };
+
+    /**
+     * Creates a plain object from a PeerInfo message. Also converts values to other types if specified.
+     * @function toObject
+     * @memberof PeerInfo
+     * @static
+     * @param {PeerInfo} m PeerInfo
+     * @param {$protobuf.IConversionOptions} [o] Conversion options
+     * @returns {Object.<string,*>} Plain object
+     */
+    PeerInfo.toObject = function toObject(m, o) {
+        if (!o)
+            o = {};
+        var d = {};
+        if (m.peerID != null && m.hasOwnProperty("peerID")) {
+            d.peerID = o.bytes === String ? $util.base64.encode(m.peerID, 0, m.peerID.length) : o.bytes === Array ? Array.prototype.slice.call(m.peerID) : m.peerID;
+            if (o.oneofs)
+                d._peerID = "peerID";
+        }
+        if (m.signedPeerRecord != null && m.hasOwnProperty("signedPeerRecord")) {
+            d.signedPeerRecord = o.bytes === String ? $util.base64.encode(m.signedPeerRecord, 0, m.signedPeerRecord.length) : o.bytes === Array ? Array.prototype.slice.call(m.signedPeerRecord) : m.signedPeerRecord;
+            if (o.oneofs)
+                d._signedPeerRecord = "signedPeerRecord";
+        }
+        return d;
+    };
+
+    /**
+     * Converts this PeerInfo to JSON.
+     * @function toJSON
+     * @memberof PeerInfo
+     * @instance
+     * @returns {Object.<string,*>} JSON object
+     */
+    PeerInfo.prototype.toJSON = function toJSON() {
+        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+    };
+
+    return PeerInfo;
 })();
 
 export { $root as default };

--- a/packages/libp2p-pubsub/src/message/rpc.proto
+++ b/packages/libp2p-pubsub/src/message/rpc.proto
@@ -2,19 +2,53 @@ syntax = "proto3";
 
 message RPC {
   repeated SubOpts subscriptions = 1;
-  repeated Message msgs = 2;
+  repeated Message messages = 2;
+  optional ControlMessage control = 3;
 
   message SubOpts {
     optional bool subscribe = 1; // subscribe or unsubcribe
-    optional string topicID = 2;
+    optional string topic = 2;
   }
 
   message Message {
     optional bytes from = 1;
     optional bytes data = 2;
     optional bytes seqno = 3;
-    repeated string topicIDs = 4;
+    optional string topic = 4;
     optional bytes signature = 5;
     optional bytes key = 6;
   }
+}
+
+message ControlMessage {
+  repeated ControlIHave ihave = 1;
+  repeated ControlIWant iwant = 2;
+  repeated ControlGraft graft = 3;
+  repeated ControlPrune prune = 4;
+}
+
+message ControlIHave {
+  optional string topicID = 1;
+  // implementors from other languages should use bytes here - go protobuf emits invalid utf8 strings
+  repeated string messageIDs = 2;
+}
+
+message ControlIWant {
+  // implementors from other languages should use bytes here - go protobuf emits invalid utf8 strings
+  repeated string messageIDs = 1;
+}
+
+message ControlGraft {
+  optional string topicID = 1;
+}
+
+message ControlPrune {
+  optional string topicID = 1;
+  repeated PeerInfo peers = 2;
+  optional uint64 backoff = 3;
+}
+
+message PeerInfo {
+  optional bytes peerID = 1;
+  optional bytes signedPeerRecord = 2;
 }

--- a/packages/libp2p-pubsub/test/emit-self.spec.ts
+++ b/packages/libp2p-pubsub/test/emit-self.spec.ts
@@ -6,6 +6,7 @@ import {
 } from './utils/index.js'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import delay from 'delay'
+import { CustomEvent } from '@libp2p/interfaces'
 
 const protocol = '/pubsub/1.0.0'
 const topic = 'foo'
@@ -39,7 +40,7 @@ describe('emitSelf', () => {
     it('should emit to self on publish', async () => {
       const promise = new Promise((resolve) => pubsub.addEventListener(topic, resolve))
 
-      await pubsub.publish(topic, data)
+      pubsub.dispatchEvent(new CustomEvent(topic, { detail: data }))
 
       return await promise
     })
@@ -71,7 +72,7 @@ describe('emitSelf', () => {
         once: true
       })
 
-      await pubsub.publish(topic, data)
+      pubsub.dispatchEvent(new CustomEvent(topic, { detail: data }))
 
       // Wait 1 second to guarantee that self is not noticed
       await delay(1000)

--- a/packages/libp2p-pubsub/test/instance.spec.ts
+++ b/packages/libp2p-pubsub/test/instance.spec.ts
@@ -5,10 +5,9 @@ import {
   MockRegistrar
 } from './utils/index.js'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
-import type { RPCMessage } from '@libp2p/interfaces/pubsub'
 
-class PubsubProtocol extends PubsubBaseProtocol<{}> {
-  async _publish (message: RPCMessage): Promise<void> {
+class PubsubProtocol extends PubsubBaseProtocol {
+  async publishMessage (): Promise<void> {
     throw new Error('Method not implemented.')
   }
 }

--- a/packages/libp2p-pubsub/test/lifecycle.spec.ts
+++ b/packages/libp2p-pubsub/test/lifecycle.spec.ts
@@ -10,10 +10,9 @@ import {
 } from './utils/index.js'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import type { Registrar } from '@libp2p/interfaces/registrar'
-import type { RPCMessage } from '@libp2p/interfaces/pubsub'
 
-class PubsubProtocol extends PubsubBaseProtocol<{}> {
-  async _publish (message: RPCMessage): Promise<void> {
+class PubsubProtocol extends PubsubBaseProtocol {
+  async publishMessage (): Promise<void> {
     throw new Error('Method not implemented.')
   }
 }

--- a/packages/libp2p-pubsub/test/message.spec.ts
+++ b/packages/libp2p-pubsub/test/message.spec.ts
@@ -8,15 +8,11 @@ import {
   MockRegistrar
 } from './utils/index.js'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
-import type { Message, RPCMessage } from '@libp2p/interfaces/pubsub'
+import type { Message } from '@libp2p/interfaces/src/pubsub'
 
-class PubsubProtocol extends PubsubBaseProtocol<{}> {
-  async _publish (message: RPCMessage): Promise<void> {
-    throw new Error('Method not implemented')
-  }
-
-  async buildMessage (message: Message) {
-    return await this._maybeSignMessage(message)
+class PubsubProtocol extends PubsubBaseProtocol {
+  async publishMessage (): Promise<void> {
+    throw new Error('Method not implemented.')
   }
 }
 
@@ -38,11 +34,11 @@ describe('pubsub base messages', () => {
     sinon.restore()
   })
 
-  it('_buildMessage normalizes and signs messages', async () => {
-    const message = {
+  it('buildMessage normalizes and signs messages', async () => {
+    const message: Message = {
       from: peerId,
       data: uint8ArrayFromString('hello'),
-      topicIDs: ['test-topic']
+      topic: 'test-topic'
     }
 
     const signedMessage = await pubsub.buildMessage(message)
@@ -51,10 +47,10 @@ describe('pubsub base messages', () => {
   })
 
   it('validate with StrictNoSign will reject a message with from, signature, key, seqno present', async () => {
-    const message = {
+    const message: Message = {
       from: peerId,
       data: uint8ArrayFromString('hello'),
-      topicIDs: ['test-topic']
+      topic: 'test-topic'
     }
 
     sinon.stub(pubsub, 'globalSignaturePolicy').value('StrictSign')
@@ -75,10 +71,10 @@ describe('pubsub base messages', () => {
   })
 
   it('validate with StrictNoSign will validate a message without a signature, key, and seqno', async () => {
-    const message = {
+    const message: Message = {
       from: peerId,
       data: uint8ArrayFromString('hello'),
-      topicIDs: ['test-topic']
+      topic: 'test-topic'
     }
 
     sinon.stub(pubsub, 'globalSignaturePolicy').value('StrictNoSign')
@@ -88,10 +84,10 @@ describe('pubsub base messages', () => {
   })
 
   it('validate with StrictSign requires a signature', async () => {
-    const message = {
+    const message: Message = {
       from: peerId,
       data: uint8ArrayFromString('hello'),
-      topicIDs: ['test-topic']
+      topic: 'test-topic'
     }
 
     await expect(pubsub.validate(message)).to.be.rejectedWith(Error, 'Signing required and no signature was present')

--- a/packages/libp2p-pubsub/test/sign.spec.ts
+++ b/packages/libp2p-pubsub/test/sign.spec.ts
@@ -27,7 +27,7 @@ describe('message signing', () => {
       from: peerId,
       data: uint8ArrayFromString('hello'),
       seqno: randomSeqno(),
-      topicIDs: ['test-topic']
+      topic: 'test-topic'
     }
 
     const bytesToSign = uint8ArrayConcat([SignPrefix, RPC.Message.encode(toRpcMessage(message)).finish()])
@@ -60,7 +60,7 @@ describe('message signing', () => {
       from: secPeerId,
       data: uint8ArrayFromString('hello'),
       seqno: randomSeqno(),
-      topicIDs: ['test-topic']
+      topic: 'test-topic'
     }
 
     const bytesToSign = uint8ArrayConcat([SignPrefix, RPC.Message.encode(toRpcMessage(message)).finish()])
@@ -91,7 +91,7 @@ describe('message signing', () => {
       from: peerId,
       data: uint8ArrayFromString('hello'),
       seqno: randomSeqno(),
-      topicIDs: ['test-topic']
+      topic: 'test-topic'
     }
 
     const bytesToSign = uint8ArrayConcat([SignPrefix, RPC.Message.encode(toRpcMessage(message)).finish()])

--- a/packages/libp2p-pubsub/test/utils.spec.ts
+++ b/packages/libp2p-pubsub/test/utils.spec.ts
@@ -16,8 +16,8 @@ describe('utils', () => {
 
   it('msgId should not generate same ID for two different Uint8Arrays', () => {
     const peerId = peerIdFromString('QmPNdSYk5Rfpo5euNqwtyizzmKXMNHdXeLjTQhcN4yfX22')
-    const msgId0 = utils.msgId(peerId, 1n)
-    const msgId1 = utils.msgId(peerId, 2n)
+    const msgId0 = utils.msgId(peerId.multihash.bytes, 1n)
+    const msgId1 = utils.msgId(peerId.multihash.bytes, 2n)
     expect(msgId0).to.not.deep.equal(msgId1)
   })
 
@@ -45,23 +45,23 @@ describe('utils', () => {
     const stringId = 'QmdZEWgtaWAxBh93fELFT298La1rsZfhiC2pqwMVwy3jZM'
     const m: Message[] = [{
       from: peerIdFromBytes(binaryId),
-      topicIDs: [],
+      topic: '',
       data: new Uint8Array()
     }, {
       from: peerIdFromString(stringId),
-      topicIDs: [],
+      topic: '',
       data: new Uint8Array()
     }]
     const expected: RPCMessage[] = [{
       from: binaryId,
-      topicIDs: [],
+      topic: '',
       data: new Uint8Array(),
       seqno: undefined,
       signature: undefined,
       key: undefined
     }, {
       from: binaryId,
-      topicIDs: [],
+      topic: '',
       data: new Uint8Array(),
       seqno: undefined,
       signature: undefined,

--- a/packages/libp2p-pubsub/test/utils/index.ts
+++ b/packages/libp2p-pubsub/test/utils/index.ts
@@ -7,6 +7,7 @@ import type { IncomingStreamData, Registrar, StreamHandler } from '@libp2p/inter
 import type { Topology } from '@libp2p/interfaces/topology'
 import type { Connection } from '@libp2p/interfaces/src/connection'
 import type { PeerId } from '@libp2p/interfaces/src/peer-id'
+import type { PubSubEvents } from '@libp2p/interfaces/src/pubsub'
 
 export const createPeerId = async (): Promise<PeerId> => {
   const peerId = await PeerIdFactory.createEd25519PeerId()
@@ -14,12 +15,14 @@ export const createPeerId = async (): Promise<PeerId> => {
   return peerId
 }
 
-interface EventMap {
+interface EventMap extends PubSubEvents {
   'foo': CustomEvent
+  'test-topic': CustomEvent
+  't': CustomEvent
 }
 
 export class PubsubImplementation extends PubsubBaseProtocol<EventMap> {
-  async _publish () {
+  async publishMessage () {
     // ...
   }
 


### PR DESCRIPTION
Pubsub is an EventTarget instead of an EventEmitter, and extending classes don't need to worry about RPC details (unless they want to).

Updates the RPC definitions to be the same as go-libp2p.

Interface tests are also run using proper mocks that do multistream select, etc so they are more realistic.