### PR TITLE
fix: remove delays from pubsub tests

### DIFF
--- a/packages/libp2p-interface-compliance-tests/package.json
+++ b/packages/libp2p-interface-compliance-tests/package.json
@@ -218,6 +218,7 @@
     "it-pushable": "^2.0.1",
     "it-stream-types": "^1.0.4",
     "multiformats": "^9.4.10",
+    "p-event": "^5.0.1",
     "p-defer": "^4.0.0",
     "p-limit": "^4.0.0",
     "p-wait-for": "^4.1.0",

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/utils.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/utils.ts
@@ -1,0 +1,12 @@
+import { pEvent } from 'p-event'
+import pWaitFor from 'p-wait-for'
+import type { SubscriptionChangeData } from '@libp2p/interfaces/src/pubsub'
+import type { PubsubBaseProtocol } from '@libp2p/pubsub'
+
+export async function waitForSubscriptionUpdate (a: PubsubBaseProtocol, b: PubsubBaseProtocol) {
+  await pWaitFor(async () => {
+    const event = await pEvent<'pubsub:subscription-change', CustomEvent<SubscriptionChangeData>>(a, 'pubsub:subscription-change')
+
+    return event.detail.peerId.equals(b.peerId)
+  })
+}

--- a/packages/libp2p-interfaces/src/pubsub/index.ts
+++ b/packages/libp2p-interfaces/src/pubsub/index.ts
@@ -99,7 +99,7 @@ interface Subscription {
   subscribe: boolean
 }
 
-interface SubscriptionChangeData {
+export interface SubscriptionChangeData {
   peerId: PeerId
   subscriptions: Subscription[]
 }


### PR DESCRIPTION
Some environments (e.g. browsers) are too slow and miss the subscription change events.

Instead, wait for the subscription change events explicitly.