### PR TITLE
fix: update content routing get return type

### DIFF
--- a/packages/libp2p-interfaces/src/content-routing/index.ts
+++ b/packages/libp2p-interfaces/src/content-routing/index.ts
@@ -1,16 +1,10 @@
 import type { CID } from 'multiformats/cid'
 import type { AbortOptions } from '../index.js'
 import type { PeerData } from '../peer-data/index.js'
-import type { PeerId } from '../peer-id/index.js'
-
-export interface GetResult {
-  from: PeerId
-  val: Uint8Array
-}
 
 export interface ContentRouting {
   provide: (cid: CID, options?: AbortOptions) => Promise<void>
   findProviders: (cid: CID, options?: AbortOptions) => AsyncIterable<PeerData>
   put: (key: Uint8Array, value: Uint8Array, options?: AbortOptions) => Promise<void>
-  get: (key: Uint8Array, options?: AbortOptions) => Promise<GetResult>
+  get: (key: Uint8Array, options?: AbortOptions) => Promise<Uint8Array>
 }


### PR DESCRIPTION
There is no way of knowing where the result came from when talking to go-ipfs over http so remove the field.