### PR TITLE
fix: update pubsub types

### DIFF
--- a/packages/libp2p-interface-compliance-tests/src/pubsub/api.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/api.ts
@@ -9,7 +9,7 @@ import delay from 'delay'
 import { CustomEvent } from '@libp2p/interfaces'
 import type { TestSetup } from '../index.js'
 import type { PubSub } from '@libp2p/interfaces/pubsub'
-import type { EventMap, PubSubArgs } from './index.js'
+import type { PubSubArgs } from './index.js'
 import type { Registrar } from '@libp2p/interfaces/registrar'
 import type { PubSubBaseProtocol } from '@libp2p/pubsub'
 import { Components } from '@libp2p/interfaces/components'
@@ -17,9 +17,9 @@ import { Components } from '@libp2p/interfaces/components'
 const topic = 'foo'
 const data = uint8ArrayFromString('bar')
 
-export default (common: TestSetup<PubSubBaseProtocol<EventMap>, PubSubArgs>) => {
+export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
   describe('pubsub api', () => {
-    let pubsub: PubSub<EventMap>
+    let pubsub: PubSub
     let registrar: Registrar
 
     // Create pubsub router

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/connection-handlers.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/connection-handlers.ts
@@ -9,16 +9,16 @@ import { connectPeers, mockRegistrar } from '../mocks/registrar.js'
 import { CustomEvent } from '@libp2p/interfaces'
 import type { TestSetup } from '../index.js'
 import type { Message } from '@libp2p/interfaces/pubsub'
-import type { EventMap, PubSubArgs } from './index.js'
+import type { PubSubArgs } from './index.js'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import type { Registrar } from '@libp2p/interfaces/registrar'
 import type { PubSubBaseProtocol } from '@libp2p/pubsub'
 import { Components } from '@libp2p/interfaces/components'
 
-export default (common: TestSetup<PubSubBaseProtocol<EventMap>, PubSubArgs>) => {
+export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
   describe('pubsub connection handlers', () => {
-    let psA: PubSubBaseProtocol<EventMap>
-    let psB: PubSubBaseProtocol<EventMap>
+    let psA: PubSubBaseProtocol
+    let psB: PubSubBaseProtocol
     let peerA: PeerId
     let peerB: PeerId
     let registrarA: Registrar
@@ -104,8 +104,8 @@ export default (common: TestSetup<PubSubBaseProtocol<EventMap>, PubSubArgs>) => 
     })
 
     describe('pubsub started before connect', () => {
-      let psA: PubSubBaseProtocol<EventMap>
-      let psB: PubSubBaseProtocol<EventMap>
+      let psA: PubSubBaseProtocol
+      let psB: PubSubBaseProtocol
       let peerA: PeerId
       let peerB: PeerId
       let registrarA: Registrar
@@ -197,8 +197,8 @@ export default (common: TestSetup<PubSubBaseProtocol<EventMap>, PubSubArgs>) => 
     })
 
     describe('pubsub started after connect', () => {
-      let psA: PubSubBaseProtocol<EventMap>
-      let psB: PubSubBaseProtocol<EventMap>
+      let psA: PubSubBaseProtocol
+      let psB: PubSubBaseProtocol
       let peerA: PeerId
       let peerB: PeerId
       let registrarA: Registrar
@@ -301,8 +301,8 @@ export default (common: TestSetup<PubSubBaseProtocol<EventMap>, PubSubArgs>) => 
     })
 
     describe('pubsub with intermittent connections', () => {
-      let psA: PubSubBaseProtocol<EventMap>
-      let psB: PubSubBaseProtocol<EventMap>
+      let psA: PubSubBaseProtocol
+      let psB: PubSubBaseProtocol
       let peerA: PeerId
       let peerB: PeerId
       let registrarA: Registrar

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/emit-self.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/emit-self.ts
@@ -5,7 +5,7 @@ import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { mockRegistrar } from '../mocks/registrar.js'
 import { CustomEvent } from '@libp2p/interfaces'
 import type { TestSetup } from '../index.js'
-import type { EventMap, PubSubArgs } from './index.js'
+import type { PubSubArgs } from './index.js'
 import type { PubSubBaseProtocol } from '@libp2p/pubsub'
 import { Components } from '@libp2p/interfaces/components'
 
@@ -13,9 +13,9 @@ const topic = 'foo'
 const data = uint8ArrayFromString('bar')
 const shouldNotHappen = () => expect.fail()
 
-export default (common: TestSetup<PubSubBaseProtocol<EventMap>, PubSubArgs>) => {
+export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
   describe('emit self', () => {
-    let pubsub: PubSubBaseProtocol<EventMap>
+    let pubsub: PubSubBaseProtocol
 
     describe('enabled', () => {
       before(async () => {

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/index.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/index.ts
@@ -5,26 +5,16 @@ import connectionHandlersTest from './connection-handlers.js'
 import twoNodesTest from './two-nodes.js'
 import multipleNodesTest from './multiple-nodes.js'
 import type { TestSetup } from '../index.js'
-import type { Message, PubSubEvents, PubSubInit } from '@libp2p/interfaces/pubsub'
+import type { PubSubInit } from '@libp2p/interfaces/pubsub'
 import type { PubSubBaseProtocol } from '@libp2p/pubsub'
 import type { Components } from '@libp2p/interfaces/components'
-
-export interface EventMap extends PubSubEvents {
-  'topic': CustomEvent<Message>
-  'foo': CustomEvent<Message>
-  'test-topic': CustomEvent<Message>
-  'reconnect-channel': CustomEvent<Message>
-  'Z': CustomEvent<Message>
-  'Za': CustomEvent<Message>
-  'Zb': CustomEvent<Message>
-}
 
 export interface PubSubArgs {
   components: Components
   init: PubSubInit
 }
 
-export default (common: TestSetup<PubSubBaseProtocol<EventMap>, PubSubArgs>) => {
+export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
   describe('interface-pubsub compliance tests', () => {
     apiTest(common)
     emitSelfTest(common)

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/messages.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/messages.ts
@@ -11,7 +11,7 @@ import pWaitFor from 'p-wait-for'
 import { CustomEvent } from '@libp2p/interfaces'
 import type { TestSetup } from '../index.js'
 import type { PubSubRPC } from '@libp2p/interfaces/pubsub'
-import type { EventMap, PubSubArgs } from './index.js'
+import type { PubSubArgs } from './index.js'
 import type { PubSubBaseProtocol } from '@libp2p/pubsub'
 import { Components } from '@libp2p/interfaces/components'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
@@ -19,10 +19,10 @@ import type { PeerId } from '@libp2p/interfaces/peer-id'
 const topic = 'foo'
 const data = uint8ArrayFromString('bar')
 
-export default (common: TestSetup<PubSubBaseProtocol<EventMap>, PubSubArgs>) => {
+export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
   describe('messages', () => {
     let peerId: PeerId
-    let pubsub: PubSubBaseProtocol<EventMap>
+    let pubsub: PubSubBaseProtocol
 
     // Create pubsub router
     beforeEach(async () => {

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/multiple-nodes.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/multiple-nodes.ts
@@ -11,22 +11,22 @@ import { CustomEvent } from '@libp2p/interfaces'
 import { waitForSubscriptionUpdate } from './utils.js'
 import type { TestSetup } from '../index.js'
 import type { Message } from '@libp2p/interfaces/pubsub'
-import type { EventMap, PubSubArgs } from './index.js'
+import type { PubSubArgs } from './index.js'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import type { Registrar } from '@libp2p/interfaces/registrar'
 import type { PubSubBaseProtocol } from '@libp2p/pubsub'
 import { Components } from '@libp2p/interfaces/components'
 
-export default (common: TestSetup<PubSubBaseProtocol<EventMap>, PubSubArgs>) => {
+export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
   describe('pubsub with multiple nodes', function () {
     describe('every peer subscribes to the topic', () => {
       describe('line', () => {
         // line
         // ◉────◉────◉
         // a    b    c
-        let psA: PubSubBaseProtocol<EventMap>
-        let psB: PubSubBaseProtocol<EventMap>
-        let psC: PubSubBaseProtocol<EventMap>
+        let psA: PubSubBaseProtocol
+        let psB: PubSubBaseProtocol
+        let psC: PubSubBaseProtocol
         let peerIdA: PeerId
         let peerIdB: PeerId
         let peerIdC: PeerId
@@ -276,11 +276,11 @@ export default (common: TestSetup<PubSubBaseProtocol<EventMap>, PubSubArgs>) => 
         //   │b     d│
         // ◉─┘       └─◉
         // a
-        let psA: PubSubBaseProtocol<EventMap>
-        let psB: PubSubBaseProtocol<EventMap>
-        let psC: PubSubBaseProtocol<EventMap>
-        let psD: PubSubBaseProtocol<EventMap>
-        let psE: PubSubBaseProtocol<EventMap>
+        let psA: PubSubBaseProtocol
+        let psB: PubSubBaseProtocol
+        let psC: PubSubBaseProtocol
+        let psD: PubSubBaseProtocol
+        let psE: PubSubBaseProtocol
         let peerIdA: PeerId
         let peerIdB: PeerId
         let peerIdC: PeerId

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/two-nodes.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/two-nodes.ts
@@ -11,7 +11,7 @@ import { CustomEvent } from '@libp2p/interfaces'
 import { waitForSubscriptionUpdate } from './utils.js'
 import type { TestSetup } from '../index.js'
 import type { Message } from '@libp2p/interfaces/pubsub'
-import type { EventMap, PubSubArgs } from './index.js'
+import type { PubSubArgs } from './index.js'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import type { Registrar } from '@libp2p/interfaces/registrar'
 import type { PubSubBaseProtocol } from '@libp2p/pubsub'
@@ -23,10 +23,10 @@ function shouldNotHappen () {
   expect.fail()
 }
 
-export default (common: TestSetup<PubSubBaseProtocol<EventMap>, PubSubArgs>) => {
+export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
   describe('pubsub with two nodes', () => {
-    let psA: PubSubBaseProtocol<EventMap>
-    let psB: PubSubBaseProtocol<EventMap>
+    let psA: PubSubBaseProtocol
+    let psB: PubSubBaseProtocol
     let peerIdA: PeerId
     let peerIdB: PeerId
     let registrarA: Registrar

--- a/packages/libp2p-interfaces/src/pubsub/index.ts
+++ b/packages/libp2p-interfaces/src/pubsub/index.ts
@@ -1,6 +1,6 @@
 import type { PeerId } from '../peer-id/index.js'
 import type { Pushable } from 'it-pushable'
-import type { EventEmitter, Startable } from '../index.js'
+import type { EventEmitter, EventHandler, Startable } from '../index.js'
 import type { Stream } from '../connection/index.js'
 
 /**
@@ -106,7 +106,7 @@ export interface PubSubEvents {
   'pubsub:subscription-change': CustomEvent<SubscriptionChangeData>
 }
 
-export interface PubSub<EventMap = PubSubEvents> extends EventEmitter<EventMap & PubSubEvents>, Startable {
+export interface PubSub extends Startable {
   globalSignaturePolicy: typeof StrictSign | typeof StrictNoSign
   multicodecs: string[]
 
@@ -117,6 +117,9 @@ export interface PubSub<EventMap = PubSubEvents> extends EventEmitter<EventMap &
   getSubscribers: (topic: string) => PeerId[]
 
   dispatchEvent: (event: CustomEvent<Uint8Array | Message>) => boolean
+  addEventListener: ((type: string, callback: EventHandler<CustomEvent<Message>>, options?: AddEventListenerOptions | boolean) => void) & ((type: 'pubsub:subscription-change', callback: EventHandler<CustomEvent<SubscriptionChangeData>>, options?: AddEventListenerOptions | boolean) => void)
+  removeEventListener: ((type: string, callback?: EventHandler<CustomEvent<Message>> | undefined, options?: EventListenerOptions | boolean) => void) & ((type: 'pubsub:subscription-change', callback?: EventHandler<CustomEvent<Message>> | undefined, options?: EventListenerOptions | boolean) => void)
+  listenerCount: (type: string) => number
 }
 
 export interface PeerStreamEvents {

--- a/packages/libp2p-pubsub/package.json
+++ b/packages/libp2p-pubsub/package.json
@@ -72,7 +72,7 @@
     },
     "ignorePatterns": [
       "test/message/*.d.ts",
-      "tes/message/*.js"
+      "test/message/*.js"
     ]
   },
   "release": {

--- a/packages/libp2p-pubsub/src/index.ts
+++ b/packages/libp2p-pubsub/src/index.ts
@@ -26,7 +26,7 @@ export interface TopicValidator { (topic: string, message: Message): Promise<voi
  * PubSubBaseProtocol handles the peers and connections logic for pubsub routers
  * and specifies the API that pubsub routers should have.
  */
-export abstract class PubSubBaseProtocol<EventMap extends PubSubEvents = PubSubEvents> extends EventEmitter<EventMap & PubSubEvents> implements PubSub<EventMap & PubSubEvents>, Initializable {
+export abstract class PubSubBaseProtocol extends EventEmitter<PubSubEvents> implements PubSub, Initializable {
   public started: boolean
   /**
    * Map of topics to which peers are subscribed to
@@ -703,13 +703,15 @@ export abstract class PubSubBaseProtocol<EventMap extends PubSubEvents = PubSubE
     return Array.from(this.peers.keys())
   }
 
-  addEventListener<U extends keyof EventMap> (type: U, callback: EventHandler<EventMap[U]>, options?: AddEventListenerOptions | boolean) {
+  addEventListener (type: string, callback: EventHandler<any>, options?: AddEventListenerOptions | boolean) {
     this.subscribe(type.toString())
 
+    // @ts-expect-error have to ignore types to accommodate custom string event names
     super.addEventListener(type, callback, options)
   }
 
-  removeEventListener<U extends keyof EventMap> (type: U, callback: EventHandler<EventMap[U]> | undefined, options?: EventListenerOptions | boolean) {
+  removeEventListener (type: string, callback: EventHandler<any> | undefined, options?: EventListenerOptions | boolean) {
+    // @ts-expect-error have to ignore types to accommodate custom string event names
     super.removeEventListener(type, callback, options)
 
     const topicStr = type.toString()

--- a/packages/libp2p-pubsub/test/utils/index.ts
+++ b/packages/libp2p-pubsub/test/utils/index.ts
@@ -6,7 +6,7 @@ import type { IncomingStreamData, Registrar, StreamHandler } from '@libp2p/inter
 import type { Topology } from '@libp2p/interfaces/topology'
 import type { Connection } from '@libp2p/interfaces/connection'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
-import type { PubSubEvents, PubSubRPC, PubSubRPCMessage } from '@libp2p/interfaces/pubsub'
+import type { PubSubRPC, PubSubRPCMessage } from '@libp2p/interfaces/pubsub'
 
 export const createPeerId = async (): Promise<PeerId> => {
   const peerId = await PeerIdFactory.createEd25519PeerId()
@@ -14,13 +14,7 @@ export const createPeerId = async (): Promise<PeerId> => {
   return peerId
 }
 
-interface EventMap extends PubSubEvents {
-  'foo': CustomEvent
-  'test-topic': CustomEvent
-  't': CustomEvent
-}
-
-export class PubsubImplementation extends PubSubBaseProtocol<EventMap> {
+export class PubsubImplementation extends PubSubBaseProtocol {
   async publishMessage () {
     // ...
   }


### PR DESCRIPTION
Changes `PubSub` to not be a generic type as we don't know the event types that will be emitted ahead of time.  Also, the message types for anything that isn't a subscription change is the same so there's little to gain type-wise from requiring knowledge of the event types.