### PR TITLE
fix: expand startable interface

### DIFF
--- a/packages/libp2p-interfaces/src/connection/index.ts
+++ b/packages/libp2p-interfaces/src/connection/index.ts
@@ -67,7 +67,7 @@ export interface Connection {
 export const symbol = Symbol.for('@libp2p/connection')
 
 export function isConnection (other: any): other is Connection {
-  return symbol in other
+  return other != null && Boolean(other[symbol])
 }
 
 export interface ConnectionGater {

--- a/packages/libp2p-interfaces/src/index.ts
+++ b/packages/libp2p-interfaces/src/index.ts
@@ -4,10 +4,53 @@ export interface AbortOptions {
   signal?: AbortSignal
 }
 
+/**
+ * Implemented by components that have a lifecycle
+ */
 export interface Startable {
   isStarted: () => boolean
+
+  /**
+   * If implemented, this method will be invoked before the start method.
+   *
+   * It should not assume any other components have been started.
+   */
+  beforeStart?: () => void | Promise<void>
+
+  /**
+   * This method will be invoked to start the component.
+   *
+   * It should not assume that any other components have been started.
+   */
   start: () => void | Promise<void>
+
+  /**
+   * If implemented, this method will be invoked after the start method.
+   *
+   * All other components will have had their start method invoked before this method is called.
+   */
+  afterStart?: () => void | Promise<void>
+
+  /**
+   * If implemented, this method will be invoked before the stop method.
+   *
+   * Any other components will still be running when this method is called.
+   */
+  beforeStop?: () => void | Promise<void>
+
+  /**
+   * This method will be invoked to stop the component.
+   *
+   * It should not assume any other components are running when it is called.
+   */
   stop: () => void | Promise<void>
+
+  /**
+   * If implemented, this method will be invoked after the stop method.
+   *
+   * All other components will have had their stop method invoked before this method is called.
+   */
+  afterStop?: () => void | Promise<void>
 }
 
 export function isStartable (obj: any): obj is Startable {

--- a/packages/libp2p-interfaces/src/peer-id/index.ts
+++ b/packages/libp2p-interfaces/src/peer-id/index.ts
@@ -33,5 +33,5 @@ export type PeerId = RSAPeerId | Ed25519PeerId | Secp256k1PeerId
 export const symbol = Symbol.for('@libp2p/peer-id')
 
 export function isPeerId (other: any): other is PeerId {
-  return symbol in other
+  return other != null && Boolean(other[symbol])
 }

--- a/packages/libp2p-interfaces/src/topology/index.ts
+++ b/packages/libp2p-interfaces/src/topology/index.ts
@@ -37,5 +37,5 @@ export interface Topology {
 export const symbol = Symbol.for('@libp2p/topology')
 
 export function isTopology (other: any): other is Topology {
-  return symbol in other
+  return other != null && Boolean(other[symbol])
 }

--- a/packages/libp2p-interfaces/src/transport/index.ts
+++ b/packages/libp2p-interfaces/src/transport/index.ts
@@ -111,7 +111,7 @@ export interface ProtocolHandler {
 }
 
 export function isTransport (other: any): other is Transport {
-  return symbol in other
+  return other != null && Boolean(other[symbol])
 }
 
 export interface TransportManagerEvents {


### PR DESCRIPTION
Allows for more control over the lifecycle of `Startable`s. For example if you need to interact with another component before you can be considered ready, you can implement the `afterStart` method which will be invoked after all other components have had their `start` method called.

Similarly `beforeStop` will be called while all other components are still running, so if you need to interact with other components during the shutdown process this is the place to do it.