### PR TITLE
fix: handle empty pubsub messages

### DIFF
--- a/packages/libp2p-pubsub/src/index.ts
+++ b/packages/libp2p-pubsub/src/index.ts
@@ -589,8 +589,14 @@ export abstract class PubSubBaseProtocol extends EventEmitter<PubSubEvents> impl
         topic,
         data: event.detail
       }
-    } else {
+    } else if (event.detail != null) {
       message = event.detail
+    } else {
+      message = {
+        from: this.components.getPeerId(),
+        topic,
+        data: new Uint8Array(0)
+      }
     }
 
     log('publish topic: %s from: %p data: %m', topic, message.from, message.data)

--- a/packages/libp2p-pubsub/test/emit-self.spec.ts
+++ b/packages/libp2p-pubsub/test/emit-self.spec.ts
@@ -47,6 +47,14 @@ describe('emitSelf', () => {
 
       return await promise
     })
+
+    it('should publish a message without data', async () => {
+      const promise = new Promise((resolve) => pubsub.addEventListener(topic, resolve))
+
+      pubsub.dispatchEvent(new CustomEvent<Uint8Array>(topic))
+
+      return await promise
+    })
   })
 
   describe('disabled', () => {

--- a/packages/libp2p-pubsub/test/pubsub.spec.ts
+++ b/packages/libp2p-pubsub/test/pubsub.spec.ts
@@ -267,13 +267,12 @@ describe('pubsub base implementation', () => {
       })
 
       it('should send unsubscribe message to connected peers', async () => {
-        sinon.spy(pubsubA, 'send')
-        sinon.spy(pubsubB, 'processRpcSubOpt')
+        const pubsubASendSpy = sinon.spy(pubsubA, 'send')
+        const pubsubBProcessRpcSubOptSpy = sinon.spy(pubsubB, 'processRpcSubOpt')
 
         pubsubA.subscribe(topic)
         // Should send subscriptions to a peer
-        // @ts-expect-error .callCount is a property added by sinon
-        expect(pubsubA.send.callCount).to.eql(1)
+        expect(pubsubASendSpy.callCount).to.eql(1)
 
         // Other peer should receive subscription message
         await pWaitFor(() => {
@@ -282,15 +281,13 @@ describe('pubsub base implementation', () => {
           return subscribers.length === 1
         })
 
-        // @ts-expect-error .callCount is a property added by sinon
-        expect(pubsubB.processRpcSubOpt.callCount).to.eql(1)
+        expect(pubsubBProcessRpcSubOptSpy.callCount).to.eql(1)
 
         // Unsubscribe
         pubsubA.unsubscribe(topic)
 
         // Should send subscriptions to a peer
-        // @ts-expect-error .callCount is a property added by sinon
-        expect(pubsubA.send.callCount).to.eql(2)
+        expect(pubsubASendSpy.callCount).to.eql(2)
 
         // Other peer should receive subscription message
         await pWaitFor(() => {
@@ -304,15 +301,13 @@ describe('pubsub base implementation', () => {
       })
 
       it('should not send unsubscribe message to connected peers if not subscribed', () => {
-        sinon.spy(pubsubA, 'send')
-        sinon.spy(pubsubB, 'processRpcSubOpt')
+        const pubsubASendSpy = sinon.spy(pubsubA, 'send')
 
         // Unsubscribe
         pubsubA.unsubscribe(topic)
 
         // Should send subscriptions to a peer
-        // @ts-expect-error .callCount is a property added by sinon
-        expect(pubsubA.send.callCount).to.eql(0)
+        expect(pubsubASendSpy.callCount).to.eql(0)
       })
     })
   })


### PR DESCRIPTION
Sometimes we want to send informational pubsub messages that don't contain any data, so handle that case.