### PR TITLE
fix: rename peer data to peer info

### DIFF
--- a/packages/libp2p-interface-compliance-tests/test/peer-discovery/mock-discovery.ts
+++ b/packages/libp2p-interface-compliance-tests/test/peer-discovery/mock-discovery.ts
@@ -2,7 +2,7 @@ import { Multiaddr } from '@multiformats/multiaddr'
 import * as PeerIdFactory from '@libp2p/peer-id-factory'
 import { EventEmitter, CustomEvent } from '@libp2p/interfaces'
 import type { PeerDiscovery, PeerDiscoveryEvents } from '@libp2p/interfaces/peer-discovery'
-import type { PeerData } from '@libp2p/interfaces/peer-data'
+import type { PeerInfo } from '@libp2p/interfaces/peer-info'
 
 interface MockDiscoveryInit {
   discoveryDelay?: number
@@ -43,7 +43,7 @@ export class MockDiscovery extends EventEmitter<PeerDiscoveryEvents> implements 
     PeerIdFactory.createEd25519PeerId()
       .then(peerId => {
         this._timer = setTimeout(() => {
-          this.dispatchEvent(new CustomEvent<PeerData>('peer', {
+          this.dispatchEvent(new CustomEvent<PeerInfo>('peer', {
             detail: {
               id: peerId,
               multiaddrs: [new Multiaddr('/ip4/127.0.0.1/tcp/8000')],

--- a/packages/libp2p-interfaces/package.json
+++ b/packages/libp2p-interfaces/package.json
@@ -96,6 +96,10 @@
       "import": "./dist/src/peer-id/index.js",
       "types": "./dist/src/peer-id/index.d.ts"
     },
+    "./peer-info": {
+      "import": "./dist/src/peer-info/index.js",
+      "types": "./dist/src/peer-info/index.d.ts"
+    },
     "./peer-routing": {
       "import": "./dist/src/peer-routing/index.js",
       "types": "./dist/src/peer-routing/index.d.ts"

--- a/packages/libp2p-interfaces/src/content-routing/index.ts
+++ b/packages/libp2p-interfaces/src/content-routing/index.ts
@@ -1,10 +1,10 @@
 import type { CID } from 'multiformats/cid'
 import type { AbortOptions } from '../index.js'
-import type { PeerData } from '../peer-data/index.js'
+import type { PeerInfo } from '../peer-info/index.js'
 
 export interface ContentRouting {
   provide: (cid: CID, options?: AbortOptions) => Promise<void>
-  findProviders: (cid: CID, options?: AbortOptions) => AsyncIterable<PeerData>
+  findProviders: (cid: CID, options?: AbortOptions) => AsyncIterable<PeerInfo>
   put: (key: Uint8Array, value: Uint8Array, options?: AbortOptions) => Promise<void>
   get: (key: Uint8Array, options?: AbortOptions) => Promise<Uint8Array>
 }

--- a/packages/libp2p-interfaces/src/dht/index.ts
+++ b/packages/libp2p-interfaces/src/dht/index.ts
@@ -1,6 +1,6 @@
 import type { PeerId } from '../peer-id/index.js'
 import type { CID } from 'multiformats/cid'
-import type { PeerData } from '../peer-data/index.js'
+import type { PeerInfo } from '../peer-info/index.js'
 import type { AbortOptions } from '../index.js'
 import type { PeerDiscovery } from '../peer-discovery/index.js'
 
@@ -63,8 +63,8 @@ export interface PeerResponseEvent {
   name: 'PEER_RESPONSE'
   messageName: keyof typeof MessageType
   messageType: MessageType
-  closer: PeerData[]
-  providers: PeerData[]
+  closer: PeerInfo[]
+  providers: PeerInfo[]
   record?: DHTRecord
 }
 
@@ -73,7 +73,7 @@ export interface PeerResponseEvent {
  */
 export interface FinalPeerEvent {
   from: PeerId
-  peer: PeerData
+  peer: PeerInfo
   type: EventTypes.FINAL_PEER
   name: 'FINAL_PEER'
 }
@@ -95,7 +95,7 @@ export interface ProviderEvent {
   from: PeerId
   type: EventTypes.PROVIDER
   name: 'PROVIDER'
-  providers: PeerData[]
+  providers: PeerInfo[]
 }
 
 /**

--- a/packages/libp2p-interfaces/src/peer-discovery/index.ts
+++ b/packages/libp2p-interfaces/src/peer-discovery/index.ts
@@ -1,8 +1,8 @@
-import type { PeerData } from '../peer-data/index.js'
+import type { PeerInfo } from '../peer-info/index.js'
 import type { EventEmitter } from '../index.js'
 
 export interface PeerDiscoveryEvents {
-  'peer': CustomEvent<PeerData>
+  'peer': CustomEvent<PeerInfo>
 }
 
 export interface PeerDiscovery extends EventEmitter<PeerDiscoveryEvents> {

--- a/packages/libp2p-interfaces/src/peer-info/index.ts
+++ b/packages/libp2p-interfaces/src/peer-info/index.ts
@@ -1,7 +1,7 @@
 import type { PeerId } from '../peer-id'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
-export interface PeerData {
+export interface PeerInfo {
   id: PeerId
   multiaddrs: Multiaddr[]
   protocols: string[]

--- a/packages/libp2p-interfaces/src/peer-routing/index.ts
+++ b/packages/libp2p-interfaces/src/peer-routing/index.ts
@@ -1,8 +1,8 @@
 import type { PeerId } from '../peer-id/index.js'
-import type { PeerData } from '../peer-data/index.js'
+import type { PeerInfo } from '../peer-info/index.js'
 import type { AbortOptions } from '../index.js'
 
 export interface PeerRouting {
-  findPeer: (peerId: PeerId, options?: AbortOptions) => Promise<PeerData>
-  getClosestPeers: (key: Uint8Array, options?: AbortOptions) => AsyncIterable<PeerData>
+  findPeer: (peerId: PeerId, options?: AbortOptions) => Promise<PeerInfo>
+  getClosestPeers: (key: Uint8Array, options?: AbortOptions) => AsyncIterable<PeerInfo>
 }

--- a/packages/libp2p-interfaces/src/peer-store/index.ts
+++ b/packages/libp2p-interfaces/src/peer-store/index.ts
@@ -2,7 +2,7 @@ import type { PeerId } from '../peer-id/index.js'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { EventEmitter } from '../index.js'
 import type { Envelope } from '../record/index.js'
-import type { PeerData } from '../peer-data/index.js'
+import type { PeerInfo } from '../peer-info/index.js'
 
 export interface Address {
   /**
@@ -204,7 +204,7 @@ export interface PeerMetadataChangeData {
 export type EventName = 'peer' | 'change:protocols' | 'change:multiaddrs' | 'change:pubkey' | 'change:metadata'
 
 export interface PeerStoreEvents {
-  'peer': CustomEvent<PeerData>
+  'peer': CustomEvent<PeerInfo>
   'change:protocols': CustomEvent<PeerProtocolsChangeData>
   'change:multiaddrs': CustomEvent<PeerMultiaddrsChangeData>
   'change:pubkey': CustomEvent<PeerPublicKeyChangeData>

--- a/packages/libp2p-peer-store/src/address-book.ts
+++ b/packages/libp2p-peer-store/src/address-book.ts
@@ -14,7 +14,7 @@ import type { AddressFilter, Peer, PeerMultiaddrsChangeData, PeerStore } from '@
 import type { Store } from './store.js'
 import type { Envelope } from '@libp2p/interfaces/record'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
-import type { PeerData } from '@libp2p/interfaces/peer-data'
+import type { PeerInfo } from '@libp2p/interfaces/peer-info'
 
 const log = logger('libp2p:peer-store:address-book')
 const EVENT_NAME = 'change:multiaddrs'
@@ -228,7 +228,7 @@ export class PeerStoreAddressBook {
 
     // Notify the existence of a new peer
     if (!hasPeer) {
-      this.dispatchEvent(new CustomEvent<PeerData>('peer', {
+      this.dispatchEvent(new CustomEvent<PeerInfo>('peer', {
         detail: {
           id: peerId,
           multiaddrs: updatedPeer.addresses.map(addr => addr.multiaddr),
@@ -296,7 +296,7 @@ export class PeerStoreAddressBook {
 
     // Notify the existence of a new peer
     if (hasPeer === true) {
-      this.dispatchEvent(new CustomEvent<PeerData>('peer', {
+      this.dispatchEvent(new CustomEvent<PeerInfo>('peer', {
         detail: {
           id: peerId,
           multiaddrs: updatedPeer.addresses.map(addr => addr.multiaddr),

--- a/packages/libp2p-pubsub/package.json
+++ b/packages/libp2p-pubsub/package.json
@@ -178,7 +178,7 @@
     "@libp2p/crypto": "^0.22.8",
     "@libp2p/interfaces": "^1.3.0",
     "@libp2p/logger": "^1.1.0",
-    "@libp2p/peer-collections": "^0.0.0",
+    "@libp2p/peer-collections": "^1.0.0",
     "@libp2p/peer-id": "^1.1.0",
     "@libp2p/topology": "^1.1.0",
     "@multiformats/multiaddr": "^10.1.5",


### PR DESCRIPTION
Peer info is the term used elsewhere so rename for consistency.