### PR TITLE
chore: update aegir

### DIFF
--- a/packages/libp2p-connection/package.json
+++ b/packages/libp2p-connection/package.json
@@ -162,7 +162,7 @@
   "devDependencies": {
     "@libp2p/interface-compliance-tests": "^1.1.0",
     "@libp2p/peer-id-factory": "^1.0.0",
-    "aegir": "^37.0.6",
+    "aegir": "^37.0.7",
     "it-pair": "^2.0.2"
   }
 }

--- a/packages/libp2p-interface-compliance-tests/package.json
+++ b/packages/libp2p-interface-compliance-tests/package.json
@@ -208,7 +208,7 @@
     "@libp2p/pubsub": "^1.2.0",
     "@multiformats/multiaddr": "^10.1.5",
     "abortable-iterator": "^4.0.2",
-    "aegir": "^37.0.6",
+    "aegir": "^37.0.7",
     "any-signal": "^3.0.0",
     "delay": "^5.0.0",
     "err-code": "^3.0.1",

--- a/packages/libp2p-interfaces/package.json
+++ b/packages/libp2p-interfaces/package.json
@@ -234,6 +234,6 @@
     "multiformats": "^9.6.3"
   },
   "devDependencies": {
-    "aegir": "^37.0.6"
+    "aegir": "^37.0.7"
   }
 }

--- a/packages/libp2p-logger/package.json
+++ b/packages/libp2p-logger/package.json
@@ -140,6 +140,6 @@
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",
-    "aegir": "^37.0.6"
+    "aegir": "^37.0.7"
   }
 }

--- a/packages/libp2p-multistream-select/package.json
+++ b/packages/libp2p-multistream-select/package.json
@@ -153,7 +153,7 @@
     "uint8arrays": "^3.0.0"
   },
   "devDependencies": {
-    "aegir": "^37.0.6",
+    "aegir": "^37.0.7",
     "iso-random-stream": "^2.0.2",
     "it-all": "^1.0.6",
     "it-map": "^1.0.6",

--- a/packages/libp2p-peer-collections/package.json
+++ b/packages/libp2p-peer-collections/package.json
@@ -138,6 +138,6 @@
   "devDependencies": {
     "@libp2p/peer-id": "^1.1.0",
     "@libp2p/peer-id-factory": "^1.0.0",
-    "aegir": "^37.0.6"
+    "aegir": "^37.0.7"
   }
 }

--- a/packages/libp2p-peer-id-factory/package.json
+++ b/packages/libp2p-peer-id-factory/package.json
@@ -145,7 +145,7 @@
     "uint8arrays": "^3.0.0"
   },
   "devDependencies": {
-    "aegir": "^37.0.6",
+    "aegir": "^37.0.7",
     "protons": "^3.0.2",
     "util": "^0.12.4"
   }

--- a/packages/libp2p-peer-id/package.json
+++ b/packages/libp2p-peer-id/package.json
@@ -139,6 +139,6 @@
     "uint8arrays": "^3.0.0"
   },
   "devDependencies": {
-    "aegir": "^37.0.6"
+    "aegir": "^37.0.7"
   }
 }

--- a/packages/libp2p-peer-record/package.json
+++ b/packages/libp2p-peer-record/package.json
@@ -161,7 +161,7 @@
     "@libp2p/interface-compliance-tests": "^1.1.0",
     "@libp2p/peer-id-factory": "^1.0.0",
     "@types/varint": "^6.0.0",
-    "aegir": "^37.0.6",
+    "aegir": "^37.0.7",
     "protons": "^3.0.2",
     "sinon": "^13.0.1"
   }

--- a/packages/libp2p-peer-store/package.json
+++ b/packages/libp2p-peer-store/package.json
@@ -156,7 +156,7 @@
     "@libp2p/peer-id": "^1.1.0",
     "@libp2p/peer-id-factory": "^1.0.0",
     "@libp2p/utils": "^1.0.9",
-    "aegir": "^37.0.6",
+    "aegir": "^37.0.7",
     "datastore-core": "^7.0.1",
     "err-code": "^3.0.1",
     "p-defer": "^4.0.0",

--- a/packages/libp2p-pubsub/package.json
+++ b/packages/libp2p-pubsub/package.json
@@ -190,7 +190,7 @@
   "devDependencies": {
     "@libp2p/peer-id-factory": "^1.0.0",
     "abortable-iterator": "^4.0.2",
-    "aegir": "^37.0.6",
+    "aegir": "^37.0.7",
     "delay": "^5.0.0",
     "it-pair": "^2.0.2",
     "it-pushable": "^2.0.1",

--- a/packages/libp2p-topology/package.json
+++ b/packages/libp2p-topology/package.json
@@ -155,6 +155,6 @@
     "it-all": "^1.0.6"
   },
   "devDependencies": {
-    "aegir": "^37.0.6"
+    "aegir": "^37.0.7"
   }
 }

--- a/packages/libp2p-tracked-map/package.json
+++ b/packages/libp2p-tracked-map/package.json
@@ -136,7 +136,7 @@
     "@libp2p/interfaces": "^1.3.0"
   },
   "devDependencies": {
-    "aegir": "^37.0.6",
+    "aegir": "^37.0.7",
     "sinon": "^13.0.1"
   }
 }


### PR DESCRIPTION
Use version of aegir that has version of `@semantic-release/github` that respects GitHub rate limiting so we can publish more reliably.