### PR TITLE
fix: add logger methods, fix peer id deserialization

### DIFF
--- a/packages/libp2p-logger/src/index.ts
+++ b/packages/libp2p-logger/src/index.ts
@@ -49,3 +49,15 @@ export function logger (name: string): Logger {
     trace: debug(`${name}:trace`)
   })
 }
+
+export function disable () {
+  debug.disable()
+}
+
+export function enable (namespaces: string) {
+  debug.enable(namespaces)
+}
+
+export function enabled (namespaces: string) {
+  return debug.enabled(namespaces)
+}

--- a/packages/libp2p-peer-id/src/index.ts
+++ b/packages/libp2p-peer-id/src/index.ts
@@ -91,6 +91,13 @@ class PeerIdImpl {
   }
 
   /**
+   * Returns Multiaddr as a JSON encoded object
+   */
+  toJSON () {
+    return this.toString()
+  }
+
+  /**
    * Checks the equality of `this` peer against a given PeerId
    */
   equals (id: PeerId | Uint8Array | string): boolean {
@@ -213,9 +220,9 @@ export function peerIdFromCID (cid: CID): PeerId {
   if (multihash.code === sha256.code) {
     return new RSAPeerIdImpl({ multihash: cid.multihash })
   } else if (multihash.code === identity.code) {
-    if (multihash.bytes.length === MARSHALLED_ED225519_PUBLIC_KEY_LENGTH) {
+    if (multihash.digest.length === MARSHALLED_ED225519_PUBLIC_KEY_LENGTH) {
       return new Ed25519PeerIdImpl({ multihash: cid.multihash })
-    } else if (multihash.bytes.length === MARSHALLED_SECP258K1_PUBLIC_KEY_LENGTH) {
+    } else if (multihash.digest.length === MARSHALLED_SECP258K1_PUBLIC_KEY_LENGTH) {
       return new Secp256k1PeerIdImpl({ multihash: cid.multihash })
     }
   }

--- a/packages/libp2p-peer-id/test/index.spec.ts
+++ b/packages/libp2p-peer-id/test/index.spec.ts
@@ -15,6 +15,14 @@ describe('PeerId', () => {
     expect(id.equals(buf)).to.be.true()
   })
 
+  it('parses a v1 CID with the libp2p-key codec', async () => {
+    const str = 'bafzaajaiaejca24q7uhr7adt3rtai4ixtn2r3q72kccwvwzg6wnfetwqyvrs5n2d'
+    const id = peerIdFromString(str)
+    expect(id.type).to.equal('Ed25519')
+    expect(id.toString()).to.equal('12D3KooWH4G2B3x5BZHH3j2ccMsBLhzR8u1uzrAQshg429xGFGPk')
+    expect(id.toCID().toString()).to.equal('bafzaajaiaejca24q7uhr7adt3rtai4ixtn2r3q72kccwvwzg6wnfetwqyvrs5n2d')
+  })
+
   it('defaults to base58btc when stringifying', async () => {
     const buf = uint8ArrayFromString('12D3KooWbtp1AcgweFSArD7dbKWYpAr8MZR1tofwNwLFLjeNGLWa', 'base58btc')
     const id = peerIdFromBytes(buf)
@@ -81,5 +89,14 @@ describe('PeerId', () => {
     id.toString()
 
     expect(id).to.have.property('string').that.is.ok()
+  })
+
+  it('stringifies as JSON', () => {
+    const buf = uint8ArrayFromString('16Uiu2HAkxSnqYGDU5iZTQrZyAcQDQHKrZqSNPBmKFifEagS2XfrL', 'base58btc')
+    const id = peerIdFromBytes(buf)
+
+    const res = JSON.parse(JSON.stringify({ id }))
+
+    expect(res).to.have.property('id', id.toString())
   })
 })

--- a/packages/libp2p-peer-store/src/store.ts
+++ b/packages/libp2p-peer-store/src/store.ts
@@ -51,7 +51,7 @@ export class PersistentStore {
       throw errcode(new Error('peerId must be an instance of peer-id'), codes.ERR_INVALID_PARAMETERS)
     }
 
-    const b32key = base32.encode(peerId.toBytes())
+    const b32key = peerId.toCID().toString()
     return new Key(`${NAMESPACE_COMMON}${b32key}`)
   }
 


### PR DESCRIPTION
Adds logger methods used by ipfs, also tests the digest length not the multihash length when parsing PeerIds out of CIDs.