### PR TITLE
fix: emit pubsub messages using 'message' event

### DIFF
--- a/packages/libp2p-interface-compliance-tests/src/pubsub/api.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/api.ts
@@ -6,7 +6,6 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { mockRegistrar } from '../mocks/registrar.js'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import delay from 'delay'
-import { CustomEvent } from '@libp2p/interfaces'
 import type { TestSetup } from '../index.js'
 import type { PubSub } from '@libp2p/interfaces/pubsub'
 import type { PubSubArgs } from './index.js'
@@ -68,19 +67,19 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
       }
 
       await pubsub.start()
-      pubsub.addEventListener(topic, handler)
+      pubsub.addEventListener('message', handler)
 
       await pWaitFor(() => {
         const topics = pubsub.getTopics()
         return topics.length === 1 && topics[0] === topic
       })
 
-      pubsub.removeEventListener(topic, handler)
+      pubsub.removeEventListener('message', handler)
 
       await pWaitFor(() => pubsub.getTopics().length === 0)
 
       // Publish to guarantee the handler is not called
-      pubsub.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: data }))
+      pubsub.publish(topic, data)
 
       // handlers are called async
       await delay(100)
@@ -93,12 +92,13 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
 
       await pubsub.start()
 
-      pubsub.addEventListener(topic, (evt) => {
+      pubsub.addEventListener('message', (evt) => {
+        expect(evt.type).to.equal(topic)
         const msg = evt.detail
         expect(msg).to.not.eql(undefined)
         defer.resolve()
       })
-      pubsub.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: data }))
+      pubsub.publish(topic, data)
       await defer.promise
 
       await pubsub.stop()

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/api.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/api.ts
@@ -67,6 +67,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
       }
 
       await pubsub.start()
+      pubsub.subscribe(topic)
       pubsub.addEventListener('message', handler)
 
       await pWaitFor(() => {
@@ -75,6 +76,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
       })
 
       pubsub.removeEventListener('message', handler)
+      pubsub.unsubscribe(topic)
 
       await pWaitFor(() => pubsub.getTopics().length === 0)
 
@@ -92,10 +94,10 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
 
       await pubsub.start()
 
+      pubsub.subscribe(topic)
       pubsub.addEventListener('message', (evt) => {
-        expect(evt.type).to.equal(topic)
-        const msg = evt.detail
-        expect(msg).to.not.eql(undefined)
+        expect(evt).to.have.nested.property('detail.topic', topic)
+        expect(evt).to.have.deep.nested.property('detail.data', data)
         defer.resolve()
       })
       pubsub.publish(topic, data)

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/connection-handlers.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/connection-handlers.ts
@@ -6,7 +6,6 @@ import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { connectPeers, mockRegistrar } from '../mocks/registrar.js'
-import { CustomEvent } from '@libp2p/interfaces'
 import type { TestSetup } from '../index.js'
 import type { Message } from '@libp2p/interfaces/pubsub'
 import type { PubSubArgs } from './index.js'
@@ -189,7 +188,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
           const subscribedPeers = psB.getSubscribers(topic)
           return subscribedPeers.map(p => p.toString()).includes(peerA.toString())
         })
-        void psB.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: data }))
+        psB.publish(topic, data)
 
         await defer.promise
       })
@@ -290,7 +289,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
           const subscribedPeers = psB.getSubscribers(topic)
           return subscribedPeers.map(p => p.toString()).includes(peerA.toString())
         })
-        void psB.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: data }))
+        psB.publish(topic, data)
 
         await defer.promise
       })
@@ -373,7 +372,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
           const subscribedPeers = psB.getSubscribers(topic)
           return subscribedPeers.map(p => p.toString()).includes(peerA.toString())
         })
-        void psB.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: data }))
+        psB.publish(topic, data)
 
         await defer1.promise
 
@@ -406,7 +405,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
           return subscribedPeers.toString().includes(peerA.toString())
         })
 
-        void psB.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: data }))
+        psB.publish(topic, data)
 
         await defer2.promise
       })
@@ -470,8 +469,8 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
         })
 
         // Verify messages go both ways
-        void psA.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: uint8ArrayFromString('message-from-a-1') }))
-        void psB.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: uint8ArrayFromString('message-from-b-1') }))
+        void psA.publish(topic, uint8ArrayFromString('message-from-a-1'))
+        void psB.publish(topic, uint8ArrayFromString('message-from-b-1'))
         await pWaitFor(() => {
           return aReceivedFirstMessageFromB && bReceivedFirstMessageFromA
         })
@@ -484,8 +483,8 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
         await pWaitFor(() => psAConnUpdateSpy.callCount === 1)
 
         // Verify messages go both ways after the disconnect
-        void psA.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: uint8ArrayFromString('message-from-a-2') }))
-        void psB.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: uint8ArrayFromString('message-from-b-2') }))
+        void psA.publish(topic, uint8ArrayFromString('message-from-a-2'))
+        void psB.publish(topic, uint8ArrayFromString('message-from-b-2'))
         await pWaitFor(() => {
           return aReceivedSecondMessageFromB && bReceivedSecondMessageFromA
         })

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/emit-self.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/emit-self.ts
@@ -42,9 +42,15 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
       })
 
       it('should emit to self on publish', async () => {
-        const promise = new Promise((resolve) => pubsub.addEventListener(topic, resolve, {
-          once: true
-        }))
+        const promise = new Promise<void>((resolve) => {
+          pubsub.addEventListener('message', (evt) => {
+            if (evt.detail.topic === topic) {
+              resolve()
+            }
+          }, {
+            once: true
+          })
+        })
 
         pubsub.publish(topic, data)
 
@@ -77,7 +83,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
       })
 
       it('should not emit to self on publish', async () => {
-        pubsub.addEventListener(topic, () => shouldNotHappen, {
+        pubsub.addEventListener('message', shouldNotHappen, {
           once: true
         })
 

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/emit-self.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/emit-self.ts
@@ -3,7 +3,6 @@ import sinon from 'sinon'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { mockRegistrar } from '../mocks/registrar.js'
-import { CustomEvent } from '@libp2p/interfaces'
 import type { TestSetup } from '../index.js'
 import type { PubSubArgs } from './index.js'
 import type { PubSubBaseProtocol } from '@libp2p/pubsub'
@@ -47,7 +46,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
           once: true
         }))
 
-        void pubsub.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: data }))
+        pubsub.publish(topic, data)
 
         return await promise
       })
@@ -82,7 +81,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
           once: true
         })
 
-        void pubsub.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: data }))
+        pubsub.publish(topic, data)
 
         // Wait 1 second to guarantee that self is not noticed
         return await new Promise((resolve) => setTimeout(resolve, 1000))

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/messages.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/messages.ts
@@ -8,7 +8,6 @@ import { mockRegistrar } from '../mocks/registrar.js'
 import pDefer from 'p-defer'
 import delay from 'delay'
 import pWaitFor from 'p-wait-for'
-import { CustomEvent } from '@libp2p/interfaces'
 import type { TestSetup } from '../index.js'
 import type { PubSubRPC } from '@libp2p/interfaces/pubsub'
 import type { PubSubArgs } from './index.js'
@@ -52,7 +51,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
 
       const spy = sinon.spy(pubsub, 'publishMessage')
 
-      await pubsub.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: data }))
+      await pubsub.publish(topic, data)
 
       await pWaitFor(async () => {
         return spy.callCount === 1

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/messages.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/messages.ts
@@ -119,8 +119,10 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
 
       const deferred = pDefer()
 
-      pubsub.addEventListener(topic, () => {
-        deferred.resolve()
+      pubsub.addEventListener('message', (evt) => {
+        if (evt.detail.topic === topic) {
+          deferred.resolve()
+        }
       })
 
       await pubsub.processRpc(peerStream.id, peerStream, rpc)

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/multiple-nodes.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/multiple-nodes.ts
@@ -148,7 +148,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
           psC.subscribe(topic)
           expect(psC.getTopics()).to.deep.equal([topic])
 
-          psB.addEventListener('pubsub:subscription-change', () => {
+          psB.addEventListener('subscription-change', () => {
             expect(psA.getPeers().length).to.equal(1)
             expect(psB.getPeers().length).to.equal(2)
             expect(psB.getSubscribers(topic).map(p => p.toString())).to.deep.equal([peerIdC.toString()])
@@ -171,9 +171,21 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
 
           let counter = 0
 
-          psA.addEventListener(topic, incMsg)
-          psB.addEventListener(topic, incMsg)
-          psC.addEventListener(topic, incMsg)
+          psA.addEventListener('message', (evt) => {
+            if (evt.detail.topic === topic) {
+              incMsg(evt)
+            }
+          })
+          psB.addEventListener('message', (evt) => {
+            if (evt.detail.topic === topic) {
+              incMsg(evt)
+            }
+          })
+          psC.addEventListener('message', (evt) => {
+            if (evt.detail.topic === topic) {
+              incMsg(evt)
+            }
+          })
 
           await Promise.all([
             waitForSubscriptionUpdate(psA, psB),
@@ -181,7 +193,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
             waitForSubscriptionUpdate(psC, psB)
           ])
 
-          void psA.publish(topic, uint8ArrayFromString('hey'))
+          psA.publish(topic, uint8ArrayFromString('hey'))
 
           function incMsg (evt: CustomEvent<Message>) {
             const msg = evt.detail
@@ -191,9 +203,21 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
 
           function check () {
             if (++counter === 3) {
-              psA.removeEventListener(topic, incMsg)
-              psB.removeEventListener(topic, incMsg)
-              psC.removeEventListener(topic, incMsg)
+              psA.removeEventListener('message', (evt) => {
+                if (evt.detail.topic === topic) {
+                  incMsg(evt)
+                }
+              })
+              psB.removeEventListener('message', (evt) => {
+                if (evt.detail.topic === topic) {
+                  incMsg(evt)
+                }
+              })
+              psC.removeEventListener('message', (evt) => {
+                if (evt.detail.topic === topic) {
+                  incMsg(evt)
+                }
+              })
               defer.resolve()
             }
           }
@@ -215,26 +239,25 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
             const defer = pDefer()
             let counter = 0
 
+            psA.addEventListener('message', (evt) => {
+              if (evt.detail.topic === topic) {
+                incMsg(evt)
+              }
+            })
+            psB.addEventListener('message', (evt) => {
+              if (evt.detail.topic === topic) {
+                incMsg(evt)
+              }
+            })
+            psC.addEventListener('message', (evt) => {
+              if (evt.detail.topic === topic) {
+                incMsg(evt)
+              }
+            })
+
             psA.subscribe(topic)
             psB.subscribe(topic)
             psC.subscribe(topic)
-
-            // await subscription change
-            await Promise.all([
-              new Promise(resolve => psA.addEventListener('pubsub:subscription-change', () => resolve(null), {
-                once: true
-              })),
-              new Promise(resolve => psB.addEventListener('pubsub:subscription-change', () => resolve(null), {
-                once: true
-              })),
-              new Promise(resolve => psC.addEventListener('pubsub:subscription-change', () => resolve(null), {
-                once: true
-              }))
-            ])
-
-            psA.addEventListener(topic, incMsg)
-            psB.addEventListener(topic, incMsg)
-            psC.addEventListener(topic, incMsg)
 
             await Promise.all([
               waitForSubscriptionUpdate(psA, psB),
@@ -242,7 +265,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
               waitForSubscriptionUpdate(psC, psB)
             ])
 
-            void psB.publish(topic, uint8ArrayFromString('hey'))
+            psB.publish(topic, uint8ArrayFromString('hey'))
 
             function incMsg (evt: CustomEvent<Message>) {
               const msg = evt.detail
@@ -252,9 +275,21 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
 
             function check () {
               if (++counter === 3) {
-                psA.removeEventListener(topic, incMsg)
-                psB.removeEventListener(topic, incMsg)
-                psC.removeEventListener(topic, incMsg)
+                psA.removeEventListener('message', (evt) => {
+                  if (evt.detail.topic === topic) {
+                    incMsg(evt)
+                  }
+                })
+                psB.removeEventListener('message', (evt) => {
+                  if (evt.detail.topic === topic) {
+                    incMsg(evt)
+                  }
+                })
+                psC.removeEventListener('message', (evt) => {
+                  if (evt.detail.topic === topic) {
+                    incMsg(evt)
+                  }
+                })
                 defer.resolve()
               }
             }
@@ -414,17 +449,38 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
         it('publishes from c', async function () {
           const defer = pDefer()
           let counter = 0
+          const topic = 'Z'
 
-          psA.subscribe('Z')
-          psA.addEventListener('Z', incMsg)
-          psB.subscribe('Z')
-          psB.addEventListener('Z', incMsg)
-          psC.subscribe('Z')
-          psC.addEventListener('Z', incMsg)
-          psD.subscribe('Z')
-          psD.addEventListener('Z', incMsg)
-          psE.subscribe('Z')
-          psE.addEventListener('Z', incMsg)
+          psA.subscribe(topic)
+          psA.addEventListener('message', (evt) => {
+            if (evt.detail.topic === topic) {
+              incMsg(evt)
+            }
+          })
+          psB.subscribe(topic)
+          psB.addEventListener('message', (evt) => {
+            if (evt.detail.topic === topic) {
+              incMsg(evt)
+            }
+          })
+          psC.subscribe(topic)
+          psC.addEventListener('message', (evt) => {
+            if (evt.detail.topic === topic) {
+              incMsg(evt)
+            }
+          })
+          psD.subscribe(topic)
+          psD.addEventListener('message', (evt) => {
+            if (evt.detail.topic === topic) {
+              incMsg(evt)
+            }
+          })
+          psE.subscribe(topic)
+          psE.addEventListener('message', (evt) => {
+            if (evt.detail.topic === topic) {
+              incMsg(evt)
+            }
+          })
 
           await Promise.all([
             waitForSubscriptionUpdate(psA, psB),
@@ -434,7 +490,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
             waitForSubscriptionUpdate(psE, psD)
           ])
 
-          void psC.publish('Z', uint8ArrayFromString('hey from c'))
+          psC.publish('Z', uint8ArrayFromString('hey from c'))
 
           function incMsg (evt: CustomEvent<Message>) {
             const msg = evt.detail

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/multiple-nodes.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/multiple-nodes.ts
@@ -7,7 +7,6 @@ import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { connectPeers, mockRegistrar } from '../mocks/registrar.js'
-import { CustomEvent } from '@libp2p/interfaces'
 import { waitForSubscriptionUpdate } from './utils.js'
 import type { TestSetup } from '../index.js'
 import type { Message } from '@libp2p/interfaces/pubsub'
@@ -182,7 +181,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
             waitForSubscriptionUpdate(psC, psB)
           ])
 
-          void psA.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: uint8ArrayFromString('hey') }))
+          void psA.publish(topic, uint8ArrayFromString('hey'))
 
           function incMsg (evt: CustomEvent<Message>) {
             const msg = evt.detail
@@ -243,7 +242,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
               waitForSubscriptionUpdate(psC, psB)
             ])
 
-            void psB.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: uint8ArrayFromString('hey') }))
+            void psB.publish(topic, uint8ArrayFromString('hey'))
 
             function incMsg (evt: CustomEvent<Message>) {
               const msg = evt.detail
@@ -435,7 +434,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
             waitForSubscriptionUpdate(psE, psD)
           ])
 
-          void psC.dispatchEvent(new CustomEvent<Uint8Array>('Z', { detail: uint8ArrayFromString('hey from c') }))
+          void psC.publish('Z', uint8ArrayFromString('hey from c'))
 
           function incMsg (evt: CustomEvent<Message>) {
             const msg = evt.detail

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/two-nodes.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/two-nodes.ts
@@ -88,7 +88,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
     it('Subscribe to a topic in nodeA', async () => {
       const defer = pDefer()
 
-      psB.addEventListener('pubsub:subscription-change', (evt) => {
+      psB.addEventListener('subscription-change', (evt) => {
         const { peerId: changedPeerId, subscriptions: changedSubs } = evt.detail
         expect(psA.getTopics()).to.deep.equal([topic])
         expect(psB.getPeers()).to.have.lengthOf(1)
@@ -109,25 +109,26 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
     it('Publish to a topic in nodeA', async () => {
       const defer = pDefer()
 
-      psA.addEventListener(topic, (evt) => {
-        const msg = evt.detail
-        expect(uint8ArrayToString(msg.data)).to.equal('hey')
-        psB.removeEventListener(topic, shouldNotHappen)
-        defer.resolve()
+      psA.addEventListener('message', (evt) => {
+        if (evt.detail.topic === topic) {
+          const msg = evt.detail
+          expect(uint8ArrayToString(msg.data)).to.equal('hey')
+          psB.removeEventListener('message', shouldNotHappen)
+          defer.resolve()
+        }
       }, {
         once: true
       })
 
-      psB.addEventListener(topic, shouldNotHappen, {
-        once: true
-      })
+      psA.subscribe(topic)
+      psB.subscribe(topic)
 
       await Promise.all([
         waitForSubscriptionUpdate(psA, psB),
         waitForSubscriptionUpdate(psB, psA)
       ])
 
-      void psA.publish(topic, uint8ArrayFromString('hey'))
+      psA.publish(topic, uint8ArrayFromString('hey'))
 
       return await defer.promise
     })
@@ -135,16 +136,24 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
     it('Publish to a topic in nodeB', async () => {
       const defer = pDefer()
 
-      psA.addEventListener(topic, (evt) => {
+      psA.addEventListener('message', (evt) => {
+        if (evt.detail.topic !== topic) {
+          return
+        }
+
         const msg = evt.detail
-        psA.addEventListener(topic, shouldNotHappen, {
+        psA.addEventListener('message', (evt) => {
+          if (evt.detail.topic === topic) {
+            shouldNotHappen()
+          }
+        }, {
           once: true
         })
         expect(uint8ArrayToString(msg.data)).to.equal('banana')
 
         setTimeout(() => {
-          psA.removeEventListener(topic, shouldNotHappen)
-          psB.removeEventListener(topic, shouldNotHappen)
+          psA.removeEventListener('message')
+          psB.removeEventListener('message')
 
           defer.resolve()
         }, 100)
@@ -152,16 +161,17 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
         once: true
       })
 
-      psB.addEventListener(topic, shouldNotHappen, {
-        once: true
-      })
+      psB.addEventListener('message', shouldNotHappen)
+
+      psA.subscribe(topic)
+      psB.subscribe(topic)
 
       await Promise.all([
         waitForSubscriptionUpdate(psA, psB),
         waitForSubscriptionUpdate(psB, psA)
       ])
 
-      void psB.publish(topic, uint8ArrayFromString('banana'))
+      psB.publish(topic, uint8ArrayFromString('banana'))
 
       return await defer.promise
     })
@@ -170,10 +180,8 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
       const defer = pDefer()
       let counter = 0
 
-      psB.addEventListener(topic, shouldNotHappen, {
-        once: true
-      })
-      psA.addEventListener(topic, receivedMsg)
+      psB.addEventListener('message', shouldNotHappen)
+      psA.addEventListener('message', receivedMsg)
 
       function receivedMsg (evt: CustomEvent<Message>) {
         const msg = evt.detail
@@ -183,12 +191,15 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
         expect(msg.topic).to.be.equal(topic)
 
         if (++counter === 10) {
-          psA.removeEventListener(topic, receivedMsg)
-          psB.removeEventListener(topic, shouldNotHappen)
+          psA.removeEventListener('message', receivedMsg)
+          psB.removeEventListener('message', shouldNotHappen)
 
           defer.resolve()
         }
       }
+
+      psA.subscribe(topic)
+      psB.subscribe(topic)
 
       await Promise.all([
         waitForSubscriptionUpdate(psA, psB),
@@ -204,7 +215,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
       const defer = pDefer()
       let callCount = 0
 
-      psB.addEventListener('pubsub:subscription-change', (evt) => {
+      psB.addEventListener('subscription-change', (evt) => {
         callCount++
 
         if (callCount === 1) {
@@ -235,34 +246,6 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
 
       psA.unsubscribe(topic)
       expect(psA.getTopics()).to.be.empty()
-
-      return await defer.promise
-    })
-
-    it.skip('Publish to a topic:Z in nodeA nodeB', async () => {
-      const defer = pDefer()
-      const topic = 'Z'
-
-      psA.addEventListener(topic, shouldNotHappen, {
-        once: true
-      })
-      psB.addEventListener(topic, shouldNotHappen, {
-        once: true
-      })
-
-      await Promise.all([
-        waitForSubscriptionUpdate(psA, psB),
-        waitForSubscriptionUpdate(psB, psA)
-      ])
-
-      setTimeout(() => {
-        psA.removeEventListener(topic, shouldNotHappen)
-        psB.removeEventListener(topic, shouldNotHappen)
-        defer.resolve()
-      }, 100)
-
-      void psB.publish(topic, uint8ArrayFromString('banana'))
-      void psA.publish(topic, uint8ArrayFromString('banana'))
 
       return await defer.promise
     })

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/two-nodes.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/two-nodes.ts
@@ -7,7 +7,6 @@ import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { connectPeers, mockRegistrar } from '../mocks/registrar.js'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
-import { CustomEvent } from '@libp2p/interfaces'
 import { waitForSubscriptionUpdate } from './utils.js'
 import type { TestSetup } from '../index.js'
 import type { Message } from '@libp2p/interfaces/pubsub'
@@ -128,7 +127,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
         waitForSubscriptionUpdate(psB, psA)
       ])
 
-      void psA.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: uint8ArrayFromString('hey') }))
+      void psA.publish(topic, uint8ArrayFromString('hey'))
 
       return await defer.promise
     })
@@ -162,7 +161,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
         waitForSubscriptionUpdate(psB, psA)
       ])
 
-      void psB.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: uint8ArrayFromString('banana') }))
+      void psB.publish(topic, uint8ArrayFromString('banana'))
 
       return await defer.promise
     })
@@ -196,7 +195,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
         waitForSubscriptionUpdate(psB, psA)
       ])
 
-      Array.from({ length: 10 }, (_, i) => psB.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: uint8ArrayFromString('banana') })))
+      Array.from({ length: 10 }, (_, i) => psB.publish(topic, uint8ArrayFromString('banana')))
 
       return await defer.promise
     })
@@ -262,8 +261,8 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
         defer.resolve()
       }, 100)
 
-      void psB.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: uint8ArrayFromString('banana') }))
-      void psA.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: uint8ArrayFromString('banana') }))
+      void psB.publish(topic, uint8ArrayFromString('banana'))
+      void psA.publish(topic, uint8ArrayFromString('banana'))
 
       return await defer.promise
     })

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/utils.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/utils.ts
@@ -5,7 +5,7 @@ import type { PubSubBaseProtocol } from '@libp2p/pubsub'
 
 export async function waitForSubscriptionUpdate (a: PubSubBaseProtocol, b: PubSubBaseProtocol) {
   await pWaitFor(async () => {
-    const event = await pEvent<'pubsub:subscription-change', CustomEvent<SubscriptionChangeData>>(a, 'pubsub:subscription-change')
+    const event = await pEvent<'subscription-change', CustomEvent<SubscriptionChangeData>>(a, 'subscription-change')
 
     return event.detail.peerId.equals(b.components.getPeerId())
   })

--- a/packages/libp2p-interfaces/src/pubsub/index.ts
+++ b/packages/libp2p-interfaces/src/pubsub/index.ts
@@ -103,7 +103,7 @@ export interface SubscriptionChangeData {
 }
 
 export interface PubSubEvents {
-  'pubsub:subscription-change': CustomEvent<SubscriptionChangeData>
+  'subscription-change': CustomEvent<SubscriptionChangeData>
   'message': CustomEvent<Message>
 }
 

--- a/packages/libp2p-interfaces/src/pubsub/index.ts
+++ b/packages/libp2p-interfaces/src/pubsub/index.ts
@@ -1,6 +1,6 @@
 import type { PeerId } from '../peer-id/index.js'
 import type { Pushable } from 'it-pushable'
-import type { EventEmitter, EventHandler, Startable } from '../index.js'
+import type { EventEmitter, Startable } from '../index.js'
 import type { Stream } from '../connection/index.js'
 
 /**
@@ -104,9 +104,10 @@ export interface SubscriptionChangeData {
 
 export interface PubSubEvents {
   'pubsub:subscription-change': CustomEvent<SubscriptionChangeData>
+  'message': CustomEvent<Message>
 }
 
-export interface PubSub extends Startable {
+export interface PubSub extends EventEmitter<PubSubEvents>, Startable {
   globalSignaturePolicy: typeof StrictSign | typeof StrictNoSign
   multicodecs: string[]
 
@@ -115,11 +116,7 @@ export interface PubSub extends Startable {
   subscribe: (topic: string) => void
   unsubscribe: (topic: string) => void
   getSubscribers: (topic: string) => PeerId[]
-
-  dispatchEvent: (event: CustomEvent<Uint8Array | Message>) => boolean
-  addEventListener: ((type: string, callback: EventHandler<CustomEvent<Message>>, options?: AddEventListenerOptions | boolean) => void) & ((type: 'pubsub:subscription-change', callback: EventHandler<CustomEvent<SubscriptionChangeData>>, options?: AddEventListenerOptions | boolean) => void)
-  removeEventListener: ((type: string, callback?: EventHandler<CustomEvent<Message>> | undefined, options?: EventListenerOptions | boolean) => void) & ((type: 'pubsub:subscription-change', callback?: EventHandler<CustomEvent<Message>> | undefined, options?: EventListenerOptions | boolean) => void)
-  listenerCount: (type: string) => number
+  publish: (topic: string, data: Uint8Array) => void
 }
 
 export interface PeerStreamEvents {

--- a/packages/libp2p-pubsub/test/emit-self.spec.ts
+++ b/packages/libp2p-pubsub/test/emit-self.spec.ts
@@ -40,7 +40,15 @@ describe('emitSelf', () => {
     })
 
     it('should emit to self on publish', async () => {
-      const promise = new Promise((resolve) => pubsub.addEventListener(topic, resolve))
+      pubsub.subscribe(topic)
+
+      const promise = new Promise<void>((resolve) => {
+        pubsub.addEventListener('message', (evt) => {
+          if (evt.detail.topic === topic) {
+            resolve()
+          }
+        })
+      })
 
       pubsub.publish(topic, data)
 
@@ -48,7 +56,15 @@ describe('emitSelf', () => {
     })
 
     it('should publish a message without data', async () => {
-      const promise = new Promise((resolve) => pubsub.addEventListener(topic, resolve))
+      pubsub.subscribe(topic)
+
+      const promise = new Promise<void>((resolve) => {
+        pubsub.addEventListener('message', (evt) => {
+          if (evt.detail.topic === topic) {
+            resolve()
+          }
+        })
+      })
 
       pubsub.publish(topic)
 
@@ -80,9 +96,8 @@ describe('emitSelf', () => {
     })
 
     it('should not emit to self on publish', async () => {
-      pubsub.addEventListener(topic, () => shouldNotHappen, {
-        once: true
-      })
+      pubsub.subscribe(topic)
+      pubsub.addEventListener('message', shouldNotHappen)
 
       pubsub.publish(topic, data)
 

--- a/packages/libp2p-pubsub/test/emit-self.spec.ts
+++ b/packages/libp2p-pubsub/test/emit-self.spec.ts
@@ -6,7 +6,6 @@ import {
 } from './utils/index.js'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import delay from 'delay'
-import { CustomEvent } from '@libp2p/interfaces'
 import { Components } from '@libp2p/interfaces/components'
 
 const protocol = '/pubsub/1.0.0'
@@ -43,7 +42,7 @@ describe('emitSelf', () => {
     it('should emit to self on publish', async () => {
       const promise = new Promise((resolve) => pubsub.addEventListener(topic, resolve))
 
-      pubsub.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: data }))
+      pubsub.publish(topic, data)
 
       return await promise
     })
@@ -51,7 +50,7 @@ describe('emitSelf', () => {
     it('should publish a message without data', async () => {
       const promise = new Promise((resolve) => pubsub.addEventListener(topic, resolve))
 
-      pubsub.dispatchEvent(new CustomEvent<Uint8Array>(topic))
+      pubsub.publish(topic)
 
       return await promise
     })
@@ -85,7 +84,7 @@ describe('emitSelf', () => {
         once: true
       })
 
-      pubsub.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: data }))
+      pubsub.publish(topic, data)
 
       // Wait 1 second to guarantee that self is not noticed
       await delay(1000)

--- a/packages/libp2p-pubsub/test/pubsub.spec.ts
+++ b/packages/libp2p-pubsub/test/pubsub.spec.ts
@@ -12,7 +12,6 @@ import {
   mockIncomingStreamEvent
 } from './utils/index.js'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
-import { CustomEvent } from '@libp2p/interfaces'
 import { PeerSet } from '@libp2p/peer-collections'
 import { Components } from '@libp2p/interfaces/components'
 
@@ -41,7 +40,7 @@ describe('pubsub base implementation', () => {
       sinon.spy(pubsub, 'publishMessage')
 
       await pubsub.start()
-      pubsub.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: message }))
+      pubsub.publish(topic, message)
 
       // event dispatch is async
       await pWaitFor(() => {
@@ -58,7 +57,7 @@ describe('pubsub base implementation', () => {
 
       await pubsub.start()
 
-      pubsub.dispatchEvent(new CustomEvent<Uint8Array>(topic, { detail: message }))
+      pubsub.publish(topic, message)
 
       // event dispatch is async
       await pWaitFor(() => {


### PR DESCRIPTION
Instead of having arbitrary strings as event names, emit all incoming pubsub messages via the 'message' event.  Topic names can be discovered from the `type` property of the incoming `CustomEvent` and the `Message` object is accessible via the `detail` field.

This vastly simplifies typing the `PubSub` interface and means users don't have to worry about creating `CustomEvent` objects, they just call `.publish` with the topic name and the data they want to send.