### PR TITLE
fix: test PubSub interface and not PubSubBaseProtocol

### DIFF
--- a/packages/libp2p-interface-compliance-tests/src/pubsub/api.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/api.ts
@@ -10,13 +10,12 @@ import type { TestSetup } from '../index.js'
 import type { PubSub } from '@libp2p/interfaces/pubsub'
 import type { PubSubArgs } from './index.js'
 import type { Registrar } from '@libp2p/interfaces/registrar'
-import type { PubSubBaseProtocol } from '@libp2p/pubsub'
 import { Components } from '@libp2p/interfaces/components'
 
 const topic = 'foo'
 const data = uint8ArrayFromString('bar')
 
-export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
+export default (common: TestSetup<PubSub, PubSubArgs>) => {
   describe('pubsub api', () => {
     let pubsub: PubSub
     let registrar: Registrar

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/connection-handlers.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/connection-handlers.ts
@@ -7,18 +7,17 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { connectPeers, mockRegistrar } from '../mocks/registrar.js'
 import type { TestSetup } from '../index.js'
-import type { Message } from '@libp2p/interfaces/pubsub'
+import type { Message, PubSub } from '@libp2p/interfaces/pubsub'
 import type { PubSubArgs } from './index.js'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import type { Registrar } from '@libp2p/interfaces/registrar'
-import type { PubSubBaseProtocol } from '@libp2p/pubsub'
 import { Components } from '@libp2p/interfaces/components'
 import { start, stop } from '../index.js'
 
-export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
+export default (common: TestSetup<PubSub, PubSubArgs>) => {
   describe('pubsub connection handlers', () => {
-    let psA: PubSubBaseProtocol
-    let psB: PubSubBaseProtocol
+    let psA: PubSub
+    let psB: PubSub
     let peerA: PeerId
     let peerB: PeerId
     let registrarA: Registrar
@@ -103,8 +102,8 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
     })
 
     describe('pubsub started before connect', () => {
-      let psA: PubSubBaseProtocol
-      let psB: PubSubBaseProtocol
+      let psA: PubSub
+      let psB: PubSub
       let peerA: PeerId
       let peerB: PeerId
       let registrarA: Registrar
@@ -198,8 +197,8 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
     })
 
     describe('pubsub started after connect', () => {
-      let psA: PubSubBaseProtocol
-      let psB: PubSubBaseProtocol
+      let psA: PubSub
+      let psB: PubSub
       let peerA: PeerId
       let peerB: PeerId
       let registrarA: Registrar
@@ -302,8 +301,8 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
     })
 
     describe('pubsub with intermittent connections', () => {
-      let psA: PubSubBaseProtocol
-      let psB: PubSubBaseProtocol
+      let psA: PubSub
+      let psB: PubSub
       let peerA: PeerId
       let peerB: PeerId
       let registrarA: Registrar

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/emit-self.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/emit-self.ts
@@ -5,17 +5,17 @@ import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { mockRegistrar } from '../mocks/registrar.js'
 import type { TestSetup } from '../index.js'
 import type { PubSubArgs } from './index.js'
-import type { PubSubBaseProtocol } from '@libp2p/pubsub'
 import { Components } from '@libp2p/interfaces/components'
 import { start, stop } from '../index.js'
+import type { PubSub } from '@libp2p/interfaces/pubsub'
 
 const topic = 'foo'
 const data = uint8ArrayFromString('bar')
 const shouldNotHappen = () => expect.fail()
 
-export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
+export default (common: TestSetup<PubSub, PubSubArgs>) => {
   describe('emit self', () => {
-    let pubsub: PubSubBaseProtocol
+    let pubsub: PubSub
 
     describe('enabled', () => {
       before(async () => {

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/index.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/index.ts
@@ -5,8 +5,7 @@ import connectionHandlersTest from './connection-handlers.js'
 import twoNodesTest from './two-nodes.js'
 import multipleNodesTest from './multiple-nodes.js'
 import type { TestSetup } from '../index.js'
-import type { PubSubInit } from '@libp2p/interfaces/pubsub'
-import type { PubSubBaseProtocol } from '@libp2p/pubsub'
+import type { PubSub, PubSubInit } from '@libp2p/interfaces/pubsub'
 import type { Components } from '@libp2p/interfaces/components'
 
 export interface PubSubArgs {
@@ -14,7 +13,7 @@ export interface PubSubArgs {
   init: PubSubInit
 }
 
-export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
+export default (common: TestSetup<PubSub, PubSubArgs>) => {
   describe('interface-pubsub compliance tests', () => {
     apiTest(common)
     emitSelfTest(common)

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/messages.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/messages.ts
@@ -2,27 +2,22 @@ import { expect } from 'aegir/chai'
 import sinon from 'sinon'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import { noSignMsgId } from '@libp2p/pubsub/utils'
-import { PeerStreams } from '@libp2p/pubsub/peer-streams'
 import { mockRegistrar } from '../mocks/registrar.js'
-import pDefer from 'p-defer'
-import delay from 'delay'
-import pWaitFor from 'p-wait-for'
 import type { TestSetup } from '../index.js'
-import type { PubSubRPC } from '@libp2p/interfaces/pubsub'
+import type { Message, PubSub } from '@libp2p/interfaces/pubsub'
 import type { PubSubArgs } from './index.js'
-import type { PubSubBaseProtocol } from '@libp2p/pubsub'
 import { Components } from '@libp2p/interfaces/components'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import { start, stop } from '../index.js'
+import { pEvent } from 'p-event'
 
 const topic = 'foo'
 const data = uint8ArrayFromString('bar')
 
-export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
+export default (common: TestSetup<PubSub, PubSubArgs>) => {
   describe('messages', () => {
     let peerId: PeerId
-    let pubsub: PubSubBaseProtocol
+    let pubsub: PubSub
 
     // Create pubsub router
     beforeEach(async () => {
@@ -48,90 +43,15 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
 
     it('should emit normalized signed messages on publish', async () => {
       pubsub.globalSignaturePolicy = 'StrictSign'
+      pubsub.publish(topic, data)
 
-      const spy = sinon.spy(pubsub, 'publishMessage')
+      const event = await pEvent<'message', CustomEvent<Message>>(pubsub, 'message')
+      const message = event.detail
 
-      await pubsub.publish(topic, data)
-
-      await pWaitFor(async () => {
-        return spy.callCount === 1
-      })
-
-      expect(spy).to.have.property('callCount', 1)
-
-      const [from, messageToEmit] = spy.getCall(0).args
-
-      expect(from.toString()).to.equal(peerId.toString())
-      expect(messageToEmit.sequenceNumber).to.not.eql(undefined)
-      expect(messageToEmit.key).to.not.eql(undefined)
-      expect(messageToEmit.signature).to.not.eql(undefined)
-    })
-
-    it('should drop unsigned messages', async () => {
-      const publishSpy = sinon.spy(pubsub, 'publishMessage')
-      sinon.spy(pubsub, 'validate')
-
-      const peerStream = new PeerStreams({
-        id: await createEd25519PeerId(),
-        protocol: 'test'
-      })
-      const rpc: PubSubRPC = {
-        subscriptions: [],
-        messages: [{
-          from: peerStream.id.toBytes(),
-          data,
-          sequenceNumber: await noSignMsgId(data),
-          topic: topic
-        }]
-      }
-
-      pubsub.subscribe(topic)
-
-      await pubsub.processRpc(peerStream.id, peerStream, rpc)
-
-      // message should not be delivered
-      await delay(1000)
-
-      expect(publishSpy).to.have.property('called', false)
-    })
-
-    it('should not drop unsigned messages if strict signing is disabled', async () => {
-      pubsub.globalSignaturePolicy = 'StrictNoSign'
-
-      const publishSpy = sinon.spy(pubsub, 'publishMessage')
-      sinon.spy(pubsub, 'validate')
-
-      const peerStream = new PeerStreams({
-        id: await createEd25519PeerId(),
-        protocol: 'test'
-      })
-
-      const rpc: PubSubRPC = {
-        subscriptions: [],
-        messages: [{
-          from: peerStream.id.toBytes(),
-          data,
-          topic
-        }]
-      }
-
-      pubsub.subscribe(topic)
-
-      const deferred = pDefer()
-
-      pubsub.addEventListener('message', (evt) => {
-        if (evt.detail.topic === topic) {
-          deferred.resolve()
-        }
-      })
-
-      await pubsub.processRpc(peerStream.id, peerStream, rpc)
-
-      // await message delivery
-      await deferred.promise
-
-      expect(pubsub.validate).to.have.property('callCount', 1)
-      expect(publishSpy).to.have.property('callCount', 1)
+      expect(message.from.toString()).to.equal(peerId.toString())
+      expect(message.sequenceNumber).to.not.eql(undefined)
+      expect(message.key).to.not.eql(undefined)
+      expect(message.signature).to.not.eql(undefined)
     })
   })
 }

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/multiple-nodes.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/multiple-nodes.ts
@@ -9,24 +9,23 @@ import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { connectPeers, mockRegistrar } from '../mocks/registrar.js'
 import { waitForSubscriptionUpdate } from './utils.js'
 import type { TestSetup } from '../index.js'
-import type { Message } from '@libp2p/interfaces/pubsub'
+import type { Message, PubSub } from '@libp2p/interfaces/pubsub'
 import type { PubSubArgs } from './index.js'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import type { Registrar } from '@libp2p/interfaces/registrar'
-import type { PubSubBaseProtocol } from '@libp2p/pubsub'
 import { Components } from '@libp2p/interfaces/components'
 import { start, stop } from '../index.js'
 
-export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
+export default (common: TestSetup<PubSub, PubSubArgs>) => {
   describe('pubsub with multiple nodes', function () {
     describe('every peer subscribes to the topic', () => {
       describe('line', () => {
         // line
         // ◉────◉────◉
         // a    b    c
-        let psA: PubSubBaseProtocol
-        let psB: PubSubBaseProtocol
-        let psC: PubSubBaseProtocol
+        let psA: PubSub
+        let psB: PubSub
+        let psC: PubSub
         let peerIdA: PeerId
         let peerIdB: PeerId
         let peerIdC: PeerId
@@ -115,7 +114,7 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
           psA.subscribe(topic)
           expect(psA.getTopics()).to.deep.equal([topic])
 
-          await waitForSubscriptionUpdate(psB, psA)
+          await waitForSubscriptionUpdate(psB, peerIdA)
 
           expect(psB.getPeers().length).to.equal(2)
           expect(psB.getSubscribers(topic).map(p => p.toString())).to.deep.equal([peerIdA.toString()])
@@ -130,8 +129,8 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
           expect(psB.getTopics()).to.deep.equal([topic])
 
           await Promise.all([
-            waitForSubscriptionUpdate(psA, psB),
-            waitForSubscriptionUpdate(psC, psB)
+            waitForSubscriptionUpdate(psA, peerIdB),
+            waitForSubscriptionUpdate(psC, peerIdB)
           ])
 
           expect(psA.getPeers().length).to.equal(1)
@@ -188,9 +187,9 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
           })
 
           await Promise.all([
-            waitForSubscriptionUpdate(psA, psB),
-            waitForSubscriptionUpdate(psB, psA),
-            waitForSubscriptionUpdate(psC, psB)
+            waitForSubscriptionUpdate(psA, peerIdB),
+            waitForSubscriptionUpdate(psB, peerIdA),
+            waitForSubscriptionUpdate(psC, peerIdB)
           ])
 
           psA.publish(topic, uint8ArrayFromString('hey'))
@@ -260,9 +259,9 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
             psC.subscribe(topic)
 
             await Promise.all([
-              waitForSubscriptionUpdate(psA, psB),
-              waitForSubscriptionUpdate(psB, psA),
-              waitForSubscriptionUpdate(psC, psB)
+              waitForSubscriptionUpdate(psA, peerIdB),
+              waitForSubscriptionUpdate(psB, peerIdA),
+              waitForSubscriptionUpdate(psC, peerIdB)
             ])
 
             psB.publish(topic, uint8ArrayFromString('hey'))
@@ -307,11 +306,11 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
         //   │b     d│
         // ◉─┘       └─◉
         // a
-        let psA: PubSubBaseProtocol
-        let psB: PubSubBaseProtocol
-        let psC: PubSubBaseProtocol
-        let psD: PubSubBaseProtocol
-        let psE: PubSubBaseProtocol
+        let psA: PubSub
+        let psB: PubSub
+        let psC: PubSub
+        let psD: PubSub
+        let psE: PubSub
         let peerIdA: PeerId
         let peerIdB: PeerId
         let peerIdC: PeerId
@@ -483,11 +482,11 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
           })
 
           await Promise.all([
-            waitForSubscriptionUpdate(psA, psB),
-            waitForSubscriptionUpdate(psB, psA),
-            waitForSubscriptionUpdate(psC, psB),
-            waitForSubscriptionUpdate(psD, psC),
-            waitForSubscriptionUpdate(psE, psD)
+            waitForSubscriptionUpdate(psA, peerIdB),
+            waitForSubscriptionUpdate(psB, peerIdA),
+            waitForSubscriptionUpdate(psC, peerIdB),
+            waitForSubscriptionUpdate(psD, peerIdC),
+            waitForSubscriptionUpdate(psE, peerIdD)
           ])
 
           psC.publish('Z', uint8ArrayFromString('hey from c'))

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/two-nodes.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/two-nodes.ts
@@ -9,11 +9,10 @@ import { connectPeers, mockRegistrar } from '../mocks/registrar.js'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { waitForSubscriptionUpdate } from './utils.js'
 import type { TestSetup } from '../index.js'
-import type { Message } from '@libp2p/interfaces/pubsub'
+import type { Message, PubSub } from '@libp2p/interfaces/pubsub'
 import type { PubSubArgs } from './index.js'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import type { Registrar } from '@libp2p/interfaces/registrar'
-import type { PubSubBaseProtocol } from '@libp2p/pubsub'
 import { Components } from '@libp2p/interfaces/components'
 import { start, stop } from '../index.js'
 
@@ -23,10 +22,10 @@ function shouldNotHappen () {
   expect.fail()
 }
 
-export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
+export default (common: TestSetup<PubSub, PubSubArgs>) => {
   describe('pubsub with two nodes', () => {
-    let psA: PubSubBaseProtocol
-    let psB: PubSubBaseProtocol
+    let psA: PubSub
+    let psB: PubSub
     let peerIdA: PeerId
     let peerIdB: PeerId
     let registrarA: Registrar
@@ -124,8 +123,8 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
       psB.subscribe(topic)
 
       await Promise.all([
-        waitForSubscriptionUpdate(psA, psB),
-        waitForSubscriptionUpdate(psB, psA)
+        waitForSubscriptionUpdate(psA, peerIdB),
+        waitForSubscriptionUpdate(psB, peerIdA)
       ])
 
       psA.publish(topic, uint8ArrayFromString('hey'))
@@ -167,8 +166,8 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
       psB.subscribe(topic)
 
       await Promise.all([
-        waitForSubscriptionUpdate(psA, psB),
-        waitForSubscriptionUpdate(psB, psA)
+        waitForSubscriptionUpdate(psA, peerIdB),
+        waitForSubscriptionUpdate(psB, peerIdA)
       ])
 
       psB.publish(topic, uint8ArrayFromString('banana'))
@@ -202,8 +201,8 @@ export default (common: TestSetup<PubSubBaseProtocol, PubSubArgs>) => {
       psB.subscribe(topic)
 
       await Promise.all([
-        waitForSubscriptionUpdate(psA, psB),
-        waitForSubscriptionUpdate(psB, psA)
+        waitForSubscriptionUpdate(psA, peerIdB),
+        waitForSubscriptionUpdate(psB, peerIdA)
       ])
 
       Array.from({ length: 10 }, (_, i) => psB.publish(topic, uint8ArrayFromString('banana')))

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/utils.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/utils.ts
@@ -1,12 +1,12 @@
 import { pEvent } from 'p-event'
 import pWaitFor from 'p-wait-for'
-import type { SubscriptionChangeData } from '@libp2p/interfaces/pubsub'
-import type { PubSubBaseProtocol } from '@libp2p/pubsub'
+import type { PubSub, SubscriptionChangeData } from '@libp2p/interfaces/pubsub'
+import type { PeerId } from '@libp2p/interfaces/peer-id'
 
-export async function waitForSubscriptionUpdate (a: PubSubBaseProtocol, b: PubSubBaseProtocol) {
+export async function waitForSubscriptionUpdate (a: PubSub, b: PeerId) {
   await pWaitFor(async () => {
     const event = await pEvent<'subscription-change', CustomEvent<SubscriptionChangeData>>(a, 'subscription-change')
 
-    return event.detail.peerId.equals(b.components.getPeerId())
+    return event.detail.peerId.equals(b)
   })
 }

--- a/packages/libp2p-interfaces/src/pubsub/index.ts
+++ b/packages/libp2p-interfaces/src/pubsub/index.ts
@@ -107,7 +107,7 @@ export interface PubSubEvents {
   'message': CustomEvent<Message>
 }
 
-export interface PubSub extends EventEmitter<PubSubEvents>, Startable {
+export interface PubSub<Events = PubSubEvents> extends EventEmitter<Events>, Startable {
   globalSignaturePolicy: typeof StrictSign | typeof StrictNoSign
   multicodecs: string[]
 

--- a/packages/libp2p-pubsub/package.json
+++ b/packages/libp2p-pubsub/package.json
@@ -194,6 +194,7 @@
     "aegir": "^37.0.7",
     "delay": "^5.0.0",
     "it-pair": "^2.0.2",
+    "p-defer": "^4.0.0",
     "p-wait-for": "^4.1.0",
     "protons": "^3.0.2",
     "protons-runtime": "^1.0.2",

--- a/packages/libp2p-pubsub/src/index.ts
+++ b/packages/libp2p-pubsub/src/index.ts
@@ -26,7 +26,7 @@ export interface TopicValidator { (topic: string, message: Message): Promise<voi
  * PubSubBaseProtocol handles the peers and connections logic for pubsub routers
  * and specifies the API that pubsub routers should have.
  */
-export abstract class PubSubBaseProtocol extends EventEmitter<PubSubEvents> implements PubSub, Initializable {
+export abstract class PubSubBaseProtocol<Events = PubSubEvents> extends EventEmitter<Events> implements PubSub<Events>, Initializable {
   public started: boolean
   /**
    * Map of topics to which peers are subscribed to


### PR DESCRIPTION
Convert the PubSub interface compliance tests to only test the methods in the PubSub interface instead of the abstract subclass since it may not be used.