### PR TITLE
fix: update pubsub interface in line with gossipsub

### DIFF
--- a/packages/libp2p-interface-compliance-tests/src/mocks/connection-manager.ts
+++ b/packages/libp2p-interface-compliance-tests/src/mocks/connection-manager.ts
@@ -5,35 +5,19 @@ import type { ConnectionManager, ConnectionManagerEvents } from '@libp2p/interfa
 
 class MockConnectionManager extends EventEmitter<ConnectionManagerEvents> implements ConnectionManager {
   getConnectionMap (): Map<string, Connection[]> {
-    throw new Error('Method not implemented.')
+    return new Map<string, Connection[]>()
   }
 
   getConnectionList (): Connection[] {
-    throw new Error('Method not implemented.')
+    return []
   }
 
   getConnections (): Connection[] {
-    throw new Error('Method not implemented.')
+    return []
   }
 
   getConnection (peerId: PeerId): Connection | undefined {
-    throw new Error('Method not implemented.')
-  }
-
-  listenerCount (type: string): number {
-    throw new Error('Method not implemented.')
-  }
-
-  addEventListener<U extends keyof ConnectionManagerEvents>(type: U, callback: ((evt: ConnectionManagerEvents[U]) => void) | { handleEvent: (evt: ConnectionManagerEvents[U]) => void } | null, options?: boolean | AddEventListenerOptions): void {
-    throw new Error('Method not implemented.')
-  }
-
-  removeEventListener<U extends keyof ConnectionManagerEvents>(type: U, callback: (((evt: ConnectionManagerEvents[U]) => void) | { handleEvent: (evt: ConnectionManagerEvents[U]) => void } | null) | undefined, options?: boolean | EventListenerOptions): void {
-    throw new Error('Method not implemented.')
-  }
-
-  dispatchEvent (event: Event): boolean {
-    throw new Error('Method not implemented.')
+    return undefined
   }
 }
 

--- a/packages/libp2p-interface-compliance-tests/src/mocks/connection.ts
+++ b/packages/libp2p-interface-compliance-tests/src/mocks/connection.ts
@@ -184,18 +184,18 @@ export interface Peer {
   registrar: Registrar
 }
 
-export function connectionPair (a: Peer, b: Peer): [ Connection, Connection ] {
+export function connectionPair (a: Components, b: Components): [ Connection, Connection ] {
   const [peerBtoPeerA, peerAtoPeerB] = duplexPair<Uint8Array>()
 
   return [
     mockConnection(
-      mockMultiaddrConnection(peerAtoPeerB, b.peerId), {
-        registrar: a.registrar
+      mockMultiaddrConnection(peerAtoPeerB, b.getPeerId()), {
+        registrar: a.getRegistrar()
       }
     ),
     mockConnection(
-      mockMultiaddrConnection(peerBtoPeerA, a.peerId), {
-        registrar: b.registrar
+      mockMultiaddrConnection(peerBtoPeerA, a.getPeerId()), {
+        registrar: b.getRegistrar()
       }
     )
   ]

--- a/packages/libp2p-interface-compliance-tests/src/mocks/registrar.ts
+++ b/packages/libp2p-interface-compliance-tests/src/mocks/registrar.ts
@@ -3,6 +3,7 @@ import type { Connection } from '@libp2p/interfaces/connection'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import type { Topology } from '@libp2p/interfaces/topology'
 import { connectionPair } from './connection.js'
+import type { Components } from '@libp2p/interfaces/src/components'
 
 export class MockRegistrar implements Registrar {
   private readonly topologies: Map<string, { topology: Topology, protocols: string[] }> = new Map()
@@ -106,20 +107,15 @@ export async function mockIncomingStreamEvent (protocol: string, conn: Connectio
   }
 }
 
-export interface Peer {
-  peerId: PeerId
-  registrar: Registrar
-}
-
-export async function connectPeers (protocol: string, a: Peer, b: Peer) {
+export async function connectPeers (protocol: string, a: Components, b: Components) {
   // Notify peers of connection
   const [aToB, bToA] = connectionPair(a, b)
 
-  for (const topology of a.registrar.getTopologies(protocol)) {
-    await topology.onConnect(b.peerId, aToB)
+  for (const topology of a.getRegistrar().getTopologies(protocol)) {
+    await topology.onConnect(b.getPeerId(), aToB)
   }
 
-  for (const topology of b.registrar.getTopologies(protocol)) {
-    await topology.onConnect(a.peerId, bToA)
+  for (const topology of b.getRegistrar().getTopologies(protocol)) {
+    await topology.onConnect(a.getPeerId(), bToA)
   }
 }

--- a/packages/libp2p-interface-compliance-tests/src/pubsub/utils.ts
+++ b/packages/libp2p-interface-compliance-tests/src/pubsub/utils.ts
@@ -1,12 +1,23 @@
 import { pEvent } from 'p-event'
 import pWaitFor from 'p-wait-for'
+import { Components } from '@libp2p/interfaces/components'
 import type { PubSub, SubscriptionChangeData } from '@libp2p/interfaces/pubsub'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
+import { createEd25519PeerId } from '@libp2p/peer-id-factory'
+import { mockConnectionManager, mockRegistrar } from '../mocks/index.js'
 
 export async function waitForSubscriptionUpdate (a: PubSub, b: PeerId) {
   await pWaitFor(async () => {
     const event = await pEvent<'subscription-change', CustomEvent<SubscriptionChangeData>>(a, 'subscription-change')
 
     return event.detail.peerId.equals(b)
+  })
+}
+
+export async function createComponents (): Promise<Components> {
+  return new Components({
+    peerId: await createEd25519PeerId(),
+    registrar: mockRegistrar(),
+    connectionManager: mockConnectionManager()
   })
 }

--- a/packages/libp2p-interfaces/src/pubsub/index.ts
+++ b/packages/libp2p-interfaces/src/pubsub/index.ts
@@ -25,6 +25,8 @@ export const StrictSign = 'StrictSign'
  */
 export const StrictNoSign = 'StrictNoSign'
 
+export type SignaturePolicy = typeof StrictSign | typeof StrictNoSign
+
 export interface Message {
   from: PeerId
   topic: string
@@ -74,7 +76,7 @@ export interface PubSubInit {
   /**
    * defines how signatures should be handled
    */
-  globalSignaturePolicy?: typeof StrictSign | typeof StrictNoSign
+  globalSignaturePolicy?: SignaturePolicy
 
   /**
    * if can relay messages not subscribed
@@ -107,6 +109,10 @@ export interface PubSubEvents {
   'message': CustomEvent<Message>
 }
 
+export interface PublishResult {
+  recipients: PeerId[]
+}
+
 export interface PubSub<Events = PubSubEvents> extends EventEmitter<Events>, Startable {
   globalSignaturePolicy: typeof StrictSign | typeof StrictNoSign
   multicodecs: string[]
@@ -116,7 +122,7 @@ export interface PubSub<Events = PubSubEvents> extends EventEmitter<Events>, Sta
   subscribe: (topic: string) => void
   unsubscribe: (topic: string) => void
   getSubscribers: (topic: string) => PeerId[]
-  publish: (topic: string, data: Uint8Array) => void
+  publish: (topic: string, data: Uint8Array) => Promise<PublishResult>
 }
 
 export interface PeerStreamEvents {

--- a/packages/libp2p-pubsub/test/emit-self.spec.ts
+++ b/packages/libp2p-pubsub/test/emit-self.spec.ts
@@ -50,7 +50,7 @@ describe('emitSelf', () => {
         })
       })
 
-      pubsub.publish(topic, data)
+      await pubsub.publish(topic, data)
 
       return await promise
     })
@@ -66,7 +66,7 @@ describe('emitSelf', () => {
         })
       })
 
-      pubsub.publish(topic)
+      await pubsub.publish(topic)
 
       return await promise
     })
@@ -99,7 +99,7 @@ describe('emitSelf', () => {
       pubsub.subscribe(topic)
       pubsub.addEventListener('message', shouldNotHappen)
 
-      pubsub.publish(topic, data)
+      await pubsub.publish(topic, data)
 
       // Wait 1 second to guarantee that self is not noticed
       await delay(1000)

--- a/packages/libp2p-pubsub/test/instance.spec.ts
+++ b/packages/libp2p-pubsub/test/instance.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'aegir/chai'
 import { PubSubBaseProtocol } from '../src/index.js'
-import type { PubSubRPC, PubSubRPCMessage } from '@libp2p/interfaces/pubsub'
+import type { PublishResult, PubSubRPC, PubSubRPCMessage } from '@libp2p/interfaces/pubsub'
 
 class PubsubProtocol extends PubSubBaseProtocol {
   decodeRpc (bytes: Uint8Array): PubSubRPC {
@@ -19,7 +19,7 @@ class PubsubProtocol extends PubSubBaseProtocol {
     throw new Error('Method not implemented.')
   }
 
-  async publishMessage (): Promise<void> {
+  async publishMessage (): Promise<PublishResult> {
     throw new Error('Method not implemented.')
   }
 }

--- a/packages/libp2p-pubsub/test/lifecycle.spec.ts
+++ b/packages/libp2p-pubsub/test/lifecycle.spec.ts
@@ -10,7 +10,7 @@ import {
 } from './utils/index.js'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import type { Registrar } from '@libp2p/interfaces/registrar'
-import type { PubSubRPC, PubSubRPCMessage } from '@libp2p/interfaces/pubsub'
+import type { PublishResult, PubSubRPC, PubSubRPCMessage } from '@libp2p/interfaces/pubsub'
 import { Components } from '@libp2p/interfaces/components'
 
 class PubsubProtocol extends PubSubBaseProtocol {
@@ -30,7 +30,7 @@ class PubsubProtocol extends PubSubBaseProtocol {
     throw new Error('Method not implemented.')
   }
 
-  async publishMessage (): Promise<void> {
+  async publishMessage (): Promise<PublishResult> {
     throw new Error('Method not implemented.')
   }
 }

--- a/packages/libp2p-pubsub/test/pubsub.spec.ts
+++ b/packages/libp2p-pubsub/test/pubsub.spec.ts
@@ -45,7 +45,7 @@ describe('pubsub base implementation', () => {
       sinon.spy(pubsub, 'publishMessage')
 
       await pubsub.start()
-      pubsub.publish(topic, message)
+      await pubsub.publish(topic, message)
 
       // event dispatch is async
       await pWaitFor(() => {
@@ -61,8 +61,7 @@ describe('pubsub base implementation', () => {
       sinon.spy(pubsub, 'publishMessage')
 
       await pubsub.start()
-
-      pubsub.publish(topic, message)
+      await pubsub.publish(topic, message)
 
       // event dispatch is async
       await pWaitFor(() => {

--- a/packages/libp2p-pubsub/test/utils/index.ts
+++ b/packages/libp2p-pubsub/test/utils/index.ts
@@ -16,7 +16,9 @@ export const createPeerId = async (): Promise<PeerId> => {
 
 export class PubsubImplementation extends PubSubBaseProtocol {
   async publishMessage () {
-    // ...
+    return {
+      recipients: []
+    }
   }
 
   decodeRpc (bytes: Uint8Array): PubSubRPC {


### PR DESCRIPTION
Makes the publish method async as it needs to be to sign outgoing messages.

Also returns the peer IDs that a given message was sent to.