### PR TITLE
fix: pubsub and dht are always set

### DIFF
--- a/packages/libp2p-interface-compliance-tests/src/mocks/muxer.ts
+++ b/packages/libp2p-interface-compliance-tests/src/mocks/muxer.ts
@@ -260,7 +260,7 @@ class MockMuxer implements StreamMuxer {
         ndjson.parse,
         async (source) => {
           for await (const message of source) {
-            this.log('-> %s %s %s', message.type, message.direction, message.id)
+            this.log.trace('-> %s %s %s', message.type, message.direction, message.id)
             this.handleMessage(message)
           }
         }

--- a/packages/libp2p-interfaces/src/components.ts
+++ b/packages/libp2p-interfaces/src/components.ts
@@ -271,7 +271,11 @@ export class Components {
     return dht
   }
 
-  getDHT (): DualDHT | undefined {
+  getDHT (): DualDHT {
+    if (this.dht == null) {
+      throw errCode(new Error('dht not set'), 'ERR_SERVICE_MISSING')
+    }
+
     return this.dht
   }
 
@@ -281,7 +285,11 @@ export class Components {
     return pubsub
   }
 
-  getPubSub (): PubSub | undefined {
+  getPubSub (): PubSub {
+    if (this.pubsub == null) {
+      throw errCode(new Error('pubsub not set'), 'ERR_SERVICE_MISSING')
+    }
+
     return this.pubsub
   }
 }


### PR DESCRIPTION
Since https://github.com/libp2p/js-libp2p/pull/1193 there will be values for pubsub and dht so no need to return them as maybe-undefined.

Also make mock-muxer logs a little less chatty.