### PR TITLE
fix: only send handled protocols

### DIFF
--- a/packages/libp2p-interface-compliance-tests/src/mocks/muxer.ts
+++ b/packages/libp2p-interface-compliance-tests/src/mocks/muxer.ts
@@ -295,7 +295,13 @@ class MockMuxer implements StreamMuxer {
     muxedStream = registry.get(message.id)
 
     if (muxedStream == null) {
-      throw new Error(`No stream found for ${message.id}`)
+      this.log.error(`No stream found for ${message.id}`)
+
+      // send a reset, don't know if we were initiator or recipient so send both
+      this.streamInput.push({ id: message.id, type: 'reset', direction: 'initiator' })
+      this.streamInput.push({ id: message.id, type: 'reset', direction: 'recipient' })
+
+      return
     }
 
     if (message.type === 'data') {

--- a/packages/libp2p-interface-compliance-tests/src/mocks/registrar.ts
+++ b/packages/libp2p-interface-compliance-tests/src/mocks/registrar.ts
@@ -8,17 +8,7 @@ export class MockRegistrar implements Registrar {
   private readonly handlers: Map<string, StreamHandler> = new Map()
 
   getProtocols () {
-    const protocols = new Set<string>()
-
-    for (const topology of this.topologies.values()) {
-      topology.protocols.forEach(protocol => protocols.add(protocol))
-    }
-
-    for (const protocol of this.handlers.keys()) {
-      protocols.add(protocol)
-    }
-
-    return Array.from(protocols).sort()
+    return Array.from(this.handlers.keys()).sort()
   }
 
   async handle (protocols: string | string[], handler: StreamHandler): Promise<void> {

--- a/packages/libp2p-interfaces/src/connection-manager/index.ts
+++ b/packages/libp2p-interfaces/src/connection-manager/index.ts
@@ -74,7 +74,7 @@ export interface ConnectionManager extends EventEmitter<ConnectionManagerEvents>
   openConnection: (peer: PeerId, options?: AbortOptions) => Promise<Connection>
 
   /**
-   * Close our connection to a peer
+   * Close our connections to a peer
    */
   closeConnections: (peer: PeerId) => Promise<void>
 }


### PR DESCRIPTION
Do not return topology protocols, only ones that are handled.

Also do not throw error when a stream is missing, just send a reset.