### PR TITLE
fix: add tag to peer discovery interface

### DIFF
--- a/packages/libp2p-interface-compliance-tests/src/mocks/muxer.ts
+++ b/packages/libp2p-interface-compliance-tests/src/mocks/muxer.ts
@@ -297,10 +297,6 @@ class MockMuxer implements StreamMuxer {
     if (muxedStream == null) {
       this.log.error(`No stream found for ${message.id}`)
 
-      // send a reset, don't know if we were initiator or recipient so send both
-      this.streamInput.push({ id: message.id, type: 'reset', direction: 'initiator' })
-      this.streamInput.push({ id: message.id, type: 'reset', direction: 'recipient' })
-
       return
     }
 

--- a/packages/libp2p-interface-compliance-tests/test/peer-discovery/mock-discovery.ts
+++ b/packages/libp2p-interface-compliance-tests/test/peer-discovery/mock-discovery.ts
@@ -3,6 +3,7 @@ import * as PeerIdFactory from '@libp2p/peer-id-factory'
 import { EventEmitter, CustomEvent } from '@libp2p/interfaces/events'
 import type { PeerDiscovery, PeerDiscoveryEvents } from '@libp2p/interfaces/peer-discovery'
 import type { PeerInfo } from '@libp2p/interfaces/peer-info'
+import { symbol } from '@libp2p/interfaces/peer-discovery'
 
 interface MockDiscoveryInit {
   discoveryDelay?: number
@@ -21,6 +22,14 @@ export class MockDiscovery extends EventEmitter<PeerDiscoveryEvents> implements 
 
     this.options = init
     this._isRunning = false
+  }
+
+  get [symbol] (): true {
+    return true
+  }
+
+  get [Symbol.toStringTag] () {
+    return 'MockDiscovery'
   }
 
   start () {

--- a/packages/libp2p-interfaces/src/peer-discovery/index.ts
+++ b/packages/libp2p-interfaces/src/peer-discovery/index.ts
@@ -11,12 +11,12 @@ export interface PeerDiscovery extends EventEmitter<PeerDiscoveryEvents> {
   /**
    * Used to identify the peer discovery mechanism
    */
-   [Symbol.toStringTag]: string
+  [Symbol.toStringTag]: string
 
-   /**
-    * Used by the isPeerDiscovery function
-    */
-   [symbol]: true
+  /**
+   * Used by the isPeerDiscovery function
+   */
+  [symbol]: true
 }
 
 export function isPeerDiscovery (other: any): other is PeerDiscovery {

--- a/packages/libp2p-interfaces/src/peer-discovery/index.ts
+++ b/packages/libp2p-interfaces/src/peer-discovery/index.ts
@@ -1,10 +1,24 @@
 import type { PeerInfo } from '../peer-info/index.js'
 import type { EventEmitter } from '../events.js'
 
+export const symbol = Symbol.for('@libp2p/peer-discovery')
+
 export interface PeerDiscoveryEvents {
   'peer': CustomEvent<PeerInfo>
 }
 
 export interface PeerDiscovery extends EventEmitter<PeerDiscoveryEvents> {
+  /**
+   * Used to identify the peer discovery mechanism
+   */
+   [Symbol.toStringTag]: string
 
+   /**
+    * Used by the isPeerDiscovery function
+    */
+   [symbol]: true
+}
+
+export function isPeerDiscovery (other: any): other is PeerDiscovery {
+  return other != null && Boolean(other[symbol])
 }


### PR DESCRIPTION
So we can identify them from instances