### PR TITLE
fix: close streams when connection is closed

### DIFF
--- a/packages/libp2p-connection/package.json
+++ b/packages/libp2p-connection/package.json
@@ -156,6 +156,7 @@
   },
   "dependencies": {
     "@libp2p/interfaces": "^1.3.0",
+    "@libp2p/logger": "^1.1.0",
     "@multiformats/multiaddr": "^10.1.5",
     "err-code": "^3.0.1"
   },

--- a/packages/libp2p-connection/test/compliance.spec.ts
+++ b/packages/libp2p-connection/test/compliance.spec.ts
@@ -35,12 +35,13 @@ describe('compliance tests', () => {
           const id = `${streamId++}`
           const stream: Stream = {
             ...pair(),
-            close: () => {
-              void stream.sink(async function * () {}())
-                .then(() => {
-                  connection.removeStream(stream.id)
-                })
-                .catch()
+            close: async () => {
+              await stream.sink(async function * () {}())
+              connection.removeStream(stream.id)
+            },
+            closeRead: async () => {},
+            closeWrite: async () => {
+              await stream.sink(async function * () {}())
             },
             id,
             abort: () => {},

--- a/packages/libp2p-connection/test/index.spec.ts
+++ b/packages/libp2p-connection/test/index.spec.ts
@@ -54,8 +54,12 @@ describe('connection tests', () => {
         const id = `${streamId++}`
         const stream: Stream = {
           ...pair<Uint8Array>(),
-          close: () => {
-            void stream.sink(async function * () {}()).catch()
+          close: async () => {
+            await stream.sink(async function * () {}()).catch()
+          },
+          closeRead: async () => {},
+          closeWrite: async () => {
+            await stream.sink(async function * () {}())
           },
           id,
           abort: () => {},

--- a/packages/libp2p-interface-compliance-tests/src/mocks/connection.ts
+++ b/packages/libp2p-interface-compliance-tests/src/mocks/connection.ts
@@ -169,7 +169,9 @@ export function mockConnection (maConn: MultiaddrConnection, opts: MockConnectio
 export function mockStream (stream: Duplex<Uint8Array>): Stream {
   return {
     ...stream,
-    close: () => {},
+    close: async () => {},
+    closeRead: async () => {},
+    closeWrite: async () => {},
     abort: () => {},
     reset: () => {},
     timeline: {

--- a/packages/libp2p-interface-compliance-tests/src/mocks/muxer.ts
+++ b/packages/libp2p-interface-compliance-tests/src/mocks/muxer.ts
@@ -250,7 +250,11 @@ class MockMuxer implements StreamMuxer {
       onEnd: (err) => {
         this.log('closing muxed streams')
         for (const stream of this.streams) {
-          stream.abort(err)
+          if (err == null) {
+            void stream.close().catch()
+          } else {
+            stream.abort(err)
+          }
         }
       }
     })

--- a/packages/libp2p-interface-compliance-tests/src/mocks/muxer.ts
+++ b/packages/libp2p-interface-compliance-tests/src/mocks/muxer.ts
@@ -191,7 +191,15 @@ class MuxedStream {
       source: this.input,
 
       // Close for reading
-      close: () => {
+      close: async () => {
+        this.input.end()
+      },
+
+      closeRead: async () => {
+        this.input.end()
+      },
+
+      closeWrite: async () => {
         this.input.end()
       },
 
@@ -307,7 +315,7 @@ class MockMuxer implements StreamMuxer {
       muxedStream.stream.reset()
     } else if (message.type === 'close') {
       this.log('-> closing stream %s %s', muxedStream.type, muxedStream.stream.id)
-      muxedStream.stream.close()
+      void muxedStream.stream.close()
     }
   }
 

--- a/packages/libp2p-interfaces/src/connection/index.ts
+++ b/packages/libp2p-interfaces/src/connection/index.ts
@@ -31,7 +31,9 @@ export interface Metadata {
  * configuration of the nodes.
  */
 export interface Stream extends Duplex<Uint8Array> {
-  close: () => void
+  close: () => Promise<void>
+  closeRead: () => Promise<void>
+  closeWrite: () => Promise<void>
   abort: (err?: Error) => void
   reset: () => void
   timeline: Timeline

--- a/packages/libp2p-interfaces/src/connection/index.ts
+++ b/packages/libp2p-interfaces/src/connection/index.ts
@@ -34,7 +34,7 @@ export interface Stream extends Duplex<Uint8Array> {
   close: () => Promise<void>
   closeRead: () => Promise<void>
   closeWrite: () => Promise<void>
-  abort: (err?: Error) => void
+  abort: (err: Error) => void
   reset: () => void
   timeline: Timeline
   id: string

--- a/packages/libp2p-interfaces/src/connection/index.ts
+++ b/packages/libp2p-interfaces/src/connection/index.ts
@@ -31,12 +31,39 @@ export interface Metadata {
  * configuration of the nodes.
  */
 export interface Stream extends Duplex<Uint8Array> {
+  /**
+   * Close a stream for reading and writing
+   */
   close: () => Promise<void>
+
+  /**
+   * Close a stream for reading only
+   */
   closeRead: () => Promise<void>
+
+  /**
+   * Close a stream for writing only
+   */
   closeWrite: () => Promise<void>
+
+  /**
+   * Call when a local error occurs, should close the stream for reading and writing
+   */
   abort: (err: Error) => void
+
+  /**
+   * Call when a remote error occurs, should close the stream for reading and writing
+   */
   reset: () => void
+
+  /**
+   * Records stream lifecycle event timings
+   */
   timeline: Timeline
+
+  /**
+   * Unique identifier for a stream
+   */
   id: string
 }
 


### PR DESCRIPTION
This adds tests for closeRead and closeWrite on the muxer streams.

Also:

- Removed libp2p-tcp in favor of it-pair to avoid circular deps
- Connection.close() will now close its internal streams to avoid lingering streams.

Supersedes #90

BREAKING CHANGE: This adds closeWrite and closeRead checks in the tests, which will cause test failures for muxers that don't implement those