### PR TITLE
fix: update interfaces

### DIFF
--- a/packages/libp2p-connection/package.json
+++ b/packages/libp2p-connection/package.json
@@ -155,7 +155,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/interfaces": "^1.3.0",
+    "@libp2p/interfaces": "^2.0.0",
     "@libp2p/logger": "^1.1.0",
     "@multiformats/multiaddr": "^10.1.5",
     "err-code": "^3.0.1"

--- a/packages/libp2p-connection/tsconfig.json
+++ b/packages/libp2p-connection/tsconfig.json
@@ -15,6 +15,9 @@
       "path": "../libp2p-interfaces"
     },
     {
+      "path": "../libp2p-logger"
+    },
+    {
       "path": "../libp2p-peer-id-factory"
     }
   ]

--- a/packages/libp2p-interface-compliance-tests/package.json
+++ b/packages/libp2p-interface-compliance-tests/package.json
@@ -200,7 +200,7 @@
   },
   "dependencies": {
     "@libp2p/crypto": "^0.22.8",
-    "@libp2p/interfaces": "^1.3.0",
+    "@libp2p/interfaces": "^2.0.0",
     "@libp2p/logger": "^1.1.0",
     "@libp2p/multistream-select": "^1.0.0",
     "@libp2p/peer-id": "^1.1.0",

--- a/packages/libp2p-logger/package.json
+++ b/packages/libp2p-logger/package.json
@@ -133,7 +133,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/interfaces": "^1.3.0",
+    "@libp2p/interfaces": "^2.0.0",
     "debug": "^4.3.3",
     "interface-datastore": "^6.1.0",
     "multiformats": "^9.6.3"

--- a/packages/libp2p-multistream-select/package.json
+++ b/packages/libp2p-multistream-select/package.json
@@ -137,7 +137,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/interfaces": "^1.3.0",
+    "@libp2p/interfaces": "^2.0.0",
     "@libp2p/logger": "^1.1.0",
     "abortable-iterator": "^4.0.2",
     "err-code": "^3.0.1",

--- a/packages/libp2p-peer-collections/package.json
+++ b/packages/libp2p-peer-collections/package.json
@@ -133,7 +133,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/interfaces": "^1.3.0",
+    "@libp2p/interfaces": "^2.0.0",
     "@libp2p/peer-id": "^1.1.0"
   },
   "devDependencies": {

--- a/packages/libp2p-peer-id-factory/package.json
+++ b/packages/libp2p-peer-id-factory/package.json
@@ -139,7 +139,7 @@
   },
   "dependencies": {
     "@libp2p/crypto": "^0.22.8",
-    "@libp2p/interfaces": "^1.3.0",
+    "@libp2p/interfaces": "^2.0.0",
     "@libp2p/peer-id": "^1.1.0",
     "multiformats": "^9.6.3",
     "protons-runtime": "^1.0.4",

--- a/packages/libp2p-peer-id/package.json
+++ b/packages/libp2p-peer-id/package.json
@@ -133,7 +133,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/interfaces": "^1.3.0",
+    "@libp2p/interfaces": "^2.0.0",
     "err-code": "^3.0.1",
     "multiformats": "^9.6.3",
     "uint8arrays": "^3.0.0"

--- a/packages/libp2p-peer-record/package.json
+++ b/packages/libp2p-peer-record/package.json
@@ -141,7 +141,7 @@
   },
   "dependencies": {
     "@libp2p/crypto": "^0.22.8",
-    "@libp2p/interfaces": "^1.3.0",
+    "@libp2p/interfaces": "^2.0.0",
     "@libp2p/logger": "^1.1.0",
     "@libp2p/peer-id": "^1.1.0",
     "@libp2p/utils": "^1.0.9",

--- a/packages/libp2p-peer-store/package.json
+++ b/packages/libp2p-peer-store/package.json
@@ -138,7 +138,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/interfaces": "^1.3.0",
+    "@libp2p/interfaces": "^2.0.0",
     "@libp2p/logger": "^1.1.0",
     "@libp2p/peer-id": "^1.1.0",
     "@libp2p/peer-record": "^1.0.0",

--- a/packages/libp2p-pubsub/package.json
+++ b/packages/libp2p-pubsub/package.json
@@ -173,7 +173,7 @@
   },
   "dependencies": {
     "@libp2p/crypto": "^0.22.8",
-    "@libp2p/interfaces": "^1.3.0",
+    "@libp2p/interfaces": "^2.0.0",
     "@libp2p/logger": "^1.1.0",
     "@libp2p/peer-collections": "^1.0.0",
     "@libp2p/peer-id": "^1.1.0",

--- a/packages/libp2p-topology/package.json
+++ b/packages/libp2p-topology/package.json
@@ -148,7 +148,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/interfaces": "^1.3.0",
+    "@libp2p/interfaces": "^2.0.0",
     "@libp2p/logger": "^1.1.0",
     "@multiformats/multiaddr": "^10.1.5",
     "err-code": "^3.0.1",

--- a/packages/libp2p-tracked-map/package.json
+++ b/packages/libp2p-tracked-map/package.json
@@ -133,7 +133,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/interfaces": "^1.3.0"
+    "@libp2p/interfaces": "^2.0.0"
   },
   "devDependencies": {
     "aegir": "^37.0.7",


### PR DESCRIPTION
The build failed during release, looks like sibling deps don't get updated by semantic-release-monorepo properly.