### PR TITLE
fix: only close muxed stream for reading

### DIFF
--- a/packages/libp2p-interface-compliance-tests/src/mocks/muxer.ts
+++ b/packages/libp2p-interface-compliance-tests/src/mocks/muxer.ts
@@ -350,7 +350,7 @@ class MockMuxer implements StreamMuxer {
       muxedStream.stream.reset()
     } else if (message.type === 'close') {
       this.log('-> closing stream %s %s', muxedStream.type, muxedStream.stream.id)
-      void muxedStream.stream.close()
+      void muxedStream.stream.closeRead()
     }
   }
 

--- a/packages/libp2p-interface-compliance-tests/src/stream-muxer/spawner.ts
+++ b/packages/libp2p-interface-compliance-tests/src/stream-muxer/spawner.ts
@@ -17,7 +17,9 @@ export default async (createMuxer: (init?: StreamMuxerInit) => Promise<StreamMux
       void pipe(
         stream,
         drain
-      )
+      ).then(() => {
+        stream.close()
+      })
     }
   })
   const dialer = await createMuxer()


### PR DESCRIPTION
When the remote closes us, only close for reading