### PR TITLE
fix: dead badge

### DIFF
--- a/packages/libp2p-interfaces/src/content-routing/README.md
+++ b/packages/libp2p-interfaces/src/content-routing/README.md
@@ -18,7 +18,7 @@ Publishing a test suite as a module lets multiple modules all ensure compatibili
 
 Include this badge in your readme if you make a module that is compatible with the interface-content-routing API. You can validate this by running the tests.
 
-![](https://raw.githubusercontent.com/libp2p/interface-content-routing/master/img/badge.png)
+![](img/badge.png)
 
 # How to use the battery of tests
 

--- a/packages/libp2p-interfaces/src/peer-discovery/README.md
+++ b/packages/libp2p-interfaces/src/peer-discovery/README.md
@@ -24,7 +24,7 @@ Send a PR to add a new one if you happen to find or write one.
 
 Include this badge in your readme if you make a new module that uses interface-peer-discovery API.
 
-![](/img/badge.png)
+![](img/badge.png)
 
 ## Usage
 

--- a/packages/libp2p-interfaces/src/peer-routing/README.md
+++ b/packages/libp2p-interfaces/src/peer-routing/README.md
@@ -18,7 +18,7 @@ Publishing a test suite as a module lets multiple modules all ensure compatibili
 
 Include this badge in your readme if you make a module that is compatible with the interface-record-store API. You can validate this by running the tests.
 
-![](https://raw.githubusercontent.com/libp2p/interface-peer-routing/master/img/badge.png)
+![](img/badge.png)
 
 # How to use the battery of tests
 

--- a/packages/libp2p-interfaces/src/stream-muxer/README.md
+++ b/packages/libp2p-interfaces/src/stream-muxer/README.md
@@ -19,7 +19,7 @@ Send a PR to add a new one if you happen to find or write one.
 
 Include this badge in your readme if you make a new module that uses interface-stream-muxer API.
 
-![](/img/badge.png)
+![](img/badge.png)
 
 ## Usage
 

--- a/packages/libp2p-interfaces/src/transport/README.md
+++ b/packages/libp2p-interfaces/src/transport/README.md
@@ -23,7 +23,7 @@ The purpose of this interface is not to reinvent any wheels when it comes to dia
 
 Include this badge in your readme if you make a module that is compatible with the interface-transport API. You can validate this by running the tests.
 
-![](https://raw.githubusercontent.com/diasdavid/interface-transport/master/img/badge.png)
+![](img/badge.png)
 
 # How to use the battery of tests
 


### PR DESCRIPTION
Fixes a typo that caused the [peer-discovery](https://github.com/libp2p/js-libp2p-interfaces/tree/master/packages/libp2p-interfaces/src/peer-discovery) badge not to appear in Github previews. 

Please note that other readmes in the libp2p-interfaces folder point to their old, deprecated and read-only repos (example: [peer-routing](https://github.com/libp2p/js-libp2p-interfaces/tree/master/packages/libp2p-interfaces/src/peer-routing)), whereas this one was set to point to the local images folder. Perhaps something should be done for consistency?