### PR TITLE
feat: allow passing stream handler options to the registrar

### DIFF
--- a/packages/libp2p-interface-compliance-tests/src/mocks/connection.ts
+++ b/packages/libp2p-interface-compliance-tests/src/mocks/connection.ts
@@ -137,7 +137,7 @@ export function mockConnection (maConn: MultiaddrConnection, opts: MockConnectio
             muxedStream = { ...muxedStream, ...stream }
 
             connection.addStream(muxedStream, { protocol, metadata: {} })
-            const handler = registrar.getHandler(protocol)
+            const { handler } = registrar.getHandler(protocol)
 
             handler({ connection, stream: muxedStream, protocol })
           }).catch(err => {

--- a/packages/libp2p-interface-compliance-tests/src/mocks/registrar.ts
+++ b/packages/libp2p-interface-compliance-tests/src/mocks/registrar.ts
@@ -1,17 +1,17 @@
-import type { IncomingStreamData, Registrar, StreamHandler } from '@libp2p/interfaces/registrar'
+import type { IncomingStreamData, Registrar, StreamHandler, StreamHandlerOptions, StreamHandlerRecord } from '@libp2p/interfaces/registrar'
 import type { Connection } from '@libp2p/interfaces/connection'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
 import type { Topology } from '@libp2p/interfaces/topology'
 
 export class MockRegistrar implements Registrar {
   private readonly topologies: Map<string, { topology: Topology, protocols: string[] }> = new Map()
-  private readonly handlers: Map<string, StreamHandler> = new Map()
+  private readonly handlers: Map<string, StreamHandlerRecord> = new Map()
 
   getProtocols () {
     return Array.from(this.handlers.keys()).sort()
   }
 
-  async handle (protocols: string | string[], handler: StreamHandler): Promise<void> {
+  async handle (protocols: string | string[], handler: StreamHandler, options: StreamHandlerOptions = {}): Promise<void> {
     const protocolList = Array.isArray(protocols) ? protocols : [protocols]
 
     for (const protocol of protocolList) {
@@ -19,7 +19,10 @@ export class MockRegistrar implements Registrar {
         throw new Error(`Handler already registered for protocol ${protocol}`)
       }
 
-      this.handlers.set(protocol, handler)
+      this.handlers.set(protocol, {
+        handler,
+        options
+      })
     }
   }
 

--- a/packages/libp2p-interfaces/src/registrar/index.ts
+++ b/packages/libp2p-interfaces/src/registrar/index.ts
@@ -11,11 +11,21 @@ export interface StreamHandler {
   (data: IncomingStreamData): void
 }
 
+export interface StreamHandlerOptions {
+  connectionStreamLimit?: number
+  hostStreamLimit?: number
+}
+
+export interface StreamHandlerRecord {
+  handler: StreamHandler
+  options: StreamHandlerOptions
+}
+
 export interface Registrar {
   getProtocols: () => string[]
-  handle: (protocol: string | string[], handler: StreamHandler) => Promise<void>
+  handle: (protocol: string | string[], handler: StreamHandler, options?: StreamHandlerOptions) => Promise<void>
   unhandle: (protocol: string | string[]) => Promise<void>
-  getHandler: (protocol: string) => StreamHandler
+  getHandler: (protocol: string) => StreamHandlerRecord
 
   register: (protocols: string | string[], topology: Topology) => Promise<string>
   unregister: (id: string) => void

--- a/packages/libp2p-pubsub/test/lifecycle.spec.ts
+++ b/packages/libp2p-pubsub/test/lifecycle.spec.ts
@@ -148,7 +148,7 @@ describe('pubsub base lifecycle', () => {
 
     it('should handle onConnect as expected', async () => {
       const topologyA = registrarA.getTopologies(protocol)[0]
-      const handlerB = registrarB.getHandler(protocol)
+      const { handler: handlerB } = registrarB.getHandler(protocol)
 
       if (topologyA == null || handlerB == null) {
         throw new Error(`No handler registered for ${protocol}`)
@@ -166,7 +166,7 @@ describe('pubsub base lifecycle', () => {
 
     it('should use the latest connection if onConnect is called more than once', async () => {
       const topologyA = registrarA.getTopologies(protocol)[0]
-      const handlerB = registrarB.getHandler(protocol)
+      const { handler: handlerB } = registrarB.getHandler(protocol)
 
       if (topologyA == null || handlerB == null) {
         throw new Error(`No handler registered for ${protocol}`)
@@ -207,7 +207,7 @@ describe('pubsub base lifecycle', () => {
 
     it('should handle newStream errors in onConnect', async () => {
       const topologyA = registrarA.getTopologies(protocol)[0]
-      const handlerB = registrarB.getHandler(protocol)
+      const { handler: handlerB } = registrarB.getHandler(protocol)
 
       if (topologyA == null || handlerB == null) {
         throw new Error(`No handler registered for ${protocol}`)
@@ -227,7 +227,7 @@ describe('pubsub base lifecycle', () => {
     it('should handle onDisconnect as expected', async () => {
       const topologyA = registrarA.getTopologies(protocol)[0]
       const topologyB = registrarB.getTopologies(protocol)[0]
-      const handlerB = registrarB.getHandler(protocol)
+      const { handler: handlerB } = registrarB.getHandler(protocol)
 
       if (topologyA == null || handlerB == null) {
         throw new Error(`No handler registered for ${protocol}`)

--- a/packages/libp2p-pubsub/test/pubsub.spec.ts
+++ b/packages/libp2p-pubsub/test/pubsub.spec.ts
@@ -139,7 +139,7 @@ describe('pubsub base implementation', () => {
           pubsubB.start()
         ])
         const topologyA = registrarA.getTopologies(protocol)[0]
-        const handlerB = registrarB.getHandler(protocol)
+        const { handler: handlerB } = registrarB.getHandler(protocol)
 
         if (topologyA == null || handlerB == null) {
           throw new Error(`No handler registered for ${protocol}`)
@@ -249,7 +249,7 @@ describe('pubsub base implementation', () => {
         ])
 
         const topologyA = registrarA.getTopologies(protocol)[0]
-        const handlerB = registrarB.getHandler(protocol)
+        const { handler: handlerB } = registrarB.getHandler(protocol)
 
         if (topologyA == null || handlerB == null) {
           throw new Error(`No handler registered for ${protocol}`)

--- a/packages/libp2p-pubsub/test/utils/index.ts
+++ b/packages/libp2p-pubsub/test/utils/index.ts
@@ -2,7 +2,7 @@ import { duplexPair } from 'it-pair/duplex'
 import * as PeerIdFactory from '@libp2p/peer-id-factory'
 import { PubSubBaseProtocol } from '../../src/index.js'
 import { RPC } from '../message/rpc.js'
-import type { IncomingStreamData, Registrar, StreamHandler } from '@libp2p/interfaces/registrar'
+import type { IncomingStreamData, Registrar, StreamHandler, StreamHandlerOptions, StreamHandlerRecord } from '@libp2p/interfaces/registrar'
 import type { Topology } from '@libp2p/interfaces/topology'
 import type { Connection } from '@libp2p/interfaces/connection'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
@@ -40,7 +40,7 @@ export class PubsubImplementation extends PubSubBaseProtocol {
 
 export class MockRegistrar implements Registrar {
   private readonly topologies: Map<string, { topology: Topology, protocols: string[] }> = new Map()
-  private readonly handlers: Map<string, StreamHandler> = new Map()
+  private readonly handlers: Map<string, StreamHandlerRecord> = new Map()
 
   getProtocols () {
     const protocols = new Set<string>()
@@ -56,7 +56,7 @@ export class MockRegistrar implements Registrar {
     return Array.from(protocols).sort()
   }
 
-  async handle (protocols: string | string[], handler: StreamHandler): Promise<void> {
+  async handle (protocols: string | string[], handler: StreamHandler, options: StreamHandlerOptions = {}): Promise<void> {
     const protocolList = Array.isArray(protocols) ? protocols : [protocols]
 
     for (const protocol of protocolList) {
@@ -64,7 +64,10 @@ export class MockRegistrar implements Registrar {
         throw new Error(`Handler already registered for protocol ${protocol}`)
       }
 
-      this.handlers.set(protocol, handler)
+      this.handlers.set(protocol, {
+        handler,
+        options
+      })
     }
   }
 


### PR DESCRIPTION
In order to let protocols inform libp2p of their stream constraints, accept an options object to `Registrar.handle` and return the handler plus options from `Registrar.getHandler`.

BREAKING CHANGE: the return type of `Registrar.getHandler` now includes the handler and it's options