### PR TITLE
fix: increase timeout for firefox

### DIFF
--- a/packages/interface-stream-muxer-compliance-tests/src/stress-test.ts
+++ b/packages/interface-stream-muxer-compliance-tests/src/stress-test.ts
@@ -21,7 +21,7 @@ export default (common: TestSetup<StreamMuxerFactory>) => {
     it('1000 streams with 1 msg', async () => await spawn(createMuxer, 1000, 1))
     it('1000 streams with 10 msg', async () => await spawn(createMuxer, 1000, 10))
     it('1000 streams with 100 msg', async function () {
-      this.timeout(120000)
+      this.timeout(800000)
       await spawn(createMuxer, 1000, 100)
     })
   })


### PR DESCRIPTION
The lastest playwright pulls a version of FireFox down that's very, very slow.