### PR TITLE
feat: define stream limits as input/output

### DIFF
--- a/packages/interface-mocks/package.json
+++ b/packages/interface-mocks/package.json
@@ -161,6 +161,7 @@
     "it-pipe": "^2.0.3",
     "it-pushable": "^3.0.0",
     "it-stream-types": "^1.0.4",
+    "merge-options": "^3.0.4",
     "uint8arraylist": "^1.5.1",
     "uint8arrays": "^3.0.0"
   },

--- a/packages/interface-mocks/src/registrar.ts
+++ b/packages/interface-mocks/src/registrar.ts
@@ -1,6 +1,7 @@
 import type { IncomingStreamData, Registrar, StreamHandler, Topology, StreamHandlerOptions, StreamHandlerRecord } from '@libp2p/interface-registrar'
 import type { Connection } from '@libp2p/interface-connection'
 import type { PeerId } from '@libp2p/interface-peer-id'
+import merge from 'merge-options'
 
 export class MockRegistrar implements Registrar {
   private readonly topologies: Map<string, Array<{ id: string, topology: Topology }>> = new Map()
@@ -10,7 +11,12 @@ export class MockRegistrar implements Registrar {
     return Array.from(this.handlers.keys()).sort()
   }
 
-  async handle (protocol: string, handler: StreamHandler, options: StreamHandlerOptions = { maxConcurrentStreams: 1 }): Promise<void> {
+  async handle (protocol: string, handler: StreamHandler, opts?: StreamHandlerOptions): Promise<void> {
+    const options = merge({
+      maxIncomingStreams: 1,
+      maxOutgoingStreams: 1
+    }, opts)
+
     if (this.handlers.has(protocol)) {
       throw new Error(`Handler already registered for protocol ${protocol}`)
     }

--- a/packages/interface-registrar/src/index.ts
+++ b/packages/interface-registrar/src/index.ts
@@ -13,9 +13,14 @@ export interface StreamHandler {
 
 export interface StreamHandlerOptions {
   /**
-   * How many streams can be open for this protocol at the same time on each connection (default: 1)
+   * How many incoming streams can be open for this protocol at the same time on each connection (default: 1)
    */
-  maxConcurrentStreams?: number
+  maxIncomingStreams?: number
+
+  /**
+   * How many outgoing streams can be open for this protocol at the same time on each connection (default: 1)
+   */
+  maxOutgoingStreams?: number
 }
 
 export interface StreamHandlerRecord {


### PR DESCRIPTION
Instead of one limit per connection, limit incoming and outgoing streams separately.