### PR TITLE
feat: add direction to StreamMuxerInit

### DIFF
--- a/packages/interface-connection/src/index.ts
+++ b/packages/interface-connection/src/index.ts
@@ -10,11 +10,16 @@ export interface ConnectionTimeline {
   close?: number
 }
 
+/**
+ * Outbound conections are opened by the local node, inbound streams are opened by the remote
+ */
+export type Direction = 'inbound' | 'outbound'
+
 export interface ConnectionStat {
   /**
    * Outbound conections are opened by the local node, inbound streams are opened by the remote
    */
-  direction: 'inbound' | 'outbound'
+  direction: Direction
 
   /**
    * Lifecycle times for the connection
@@ -46,7 +51,7 @@ export interface StreamStat {
   /**
    * Outbound streams are opened by the local node, inbound streams are opened by the remote
    */
-  direction: 'inbound' | 'outbound'
+  direction: Direction
 
   /**
    * Lifecycle times for the stream

--- a/packages/interface-mocks/src/connection.ts
+++ b/packages/interface-mocks/src/connection.ts
@@ -1,7 +1,7 @@
 import { peerIdFromString } from '@libp2p/peer-id'
 import { pipe } from 'it-pipe'
 import { duplexPair } from 'it-pair/duplex'
-import type { MultiaddrConnection, Connection, Stream, ConnectionStat } from '@libp2p/interface-connection'
+import type { MultiaddrConnection, Connection, Stream, ConnectionStat, Direction } from '@libp2p/interface-connection'
 import type { Duplex } from 'it-stream-types'
 import { mockMuxer } from './muxer.js'
 import type { PeerId } from '@libp2p/interface-peer-id'
@@ -20,14 +20,14 @@ import errCode from 'err-code'
 const log = logger('libp2p:mock-connection')
 
 export interface MockConnectionOptions {
-  direction?: 'inbound' | 'outbound'
+  direction?: Direction
   registrar?: Registrar
 }
 
 interface MockConnectionInit {
   remoteAddr: Multiaddr
   remotePeer: PeerId
-  direction: 'inbound' | 'outbound'
+  direction: Direction
   maConn: MultiaddrConnection
   muxer: StreamMuxer
 }
@@ -36,7 +36,7 @@ class MockConnection implements Connection {
   public id: string
   public remoteAddr: Multiaddr
   public remotePeer: PeerId
-  public direction: 'inbound' | 'outbound'
+  public direction: Direction
   public stat: ConnectionStat
   public streams: Stream[]
   public tags: string[]
@@ -128,6 +128,7 @@ export function mockConnection (maConn: MultiaddrConnection, opts: MockConnectio
   const muxerFactory = mockMuxer()
 
   const muxer = muxerFactory.createStreamMuxer({
+    direction: direction,
     onIncomingStream: (muxedStream) => {
       const mss = new Listener(muxedStream)
       try {

--- a/packages/interface-mocks/src/muxer.ts
+++ b/packages/interface-mocks/src/muxer.ts
@@ -278,7 +278,7 @@ class MockMuxer implements StreamMuxer {
     this.registryInitiatorStreams = new Map()
     this.registryRecipientStreams = new Map()
     this.log('create muxer')
-    this.options = init ?? {}
+    this.options = init ?? { direction: 'inbound' }
     // receives data from the muxer at the other end of the stream
     this.source = this.input = pushable({
       onEnd: (err) => {

--- a/packages/interface-stream-muxer-compliance-tests/src/base-test.ts
+++ b/packages/interface-stream-muxer-compliance-tests/src/base-test.ts
@@ -23,12 +23,13 @@ export default (common: TestSetup<StreamMuxerFactory>) => {
     it('Open a stream from the dialer', async () => {
       const p = duplexPair<Uint8Array>()
       const dialerFactory = await common.setup()
-      const dialer = dialerFactory.createStreamMuxer()
+      const dialer = dialerFactory.createStreamMuxer({ direction: 'outbound' })
       const onStreamPromise: DeferredPromise<Stream> = defer()
       const onStreamEndPromise: DeferredPromise<Stream> = defer()
 
       const listenerFactory = await common.setup()
       const listener = listenerFactory.createStreamMuxer({
+        direction: 'inbound',
         onIncomingStream: (stream) => {
           onStreamPromise.resolve(stream)
         },
@@ -77,13 +78,14 @@ export default (common: TestSetup<StreamMuxerFactory>) => {
       const onStreamPromise: DeferredPromise<Stream> = defer()
       const dialerFactory = await common.setup()
       const dialer = dialerFactory.createStreamMuxer({
+        direction: 'outbound',
         onIncomingStream: (stream: Stream) => {
           onStreamPromise.resolve(stream)
         }
       })
 
       const listenerFactory = await common.setup()
-      const listener = listenerFactory.createStreamMuxer()
+      const listener = listenerFactory.createStreamMuxer({ direction: 'inbound' })
 
       void pipe(p[0], dialer, p[0])
       void pipe(p[1], listener, p[1])
@@ -108,6 +110,7 @@ export default (common: TestSetup<StreamMuxerFactory>) => {
       const onListenerStreamPromise: DeferredPromise<Stream> = defer()
       const dialerFactory = await common.setup()
       const dialer = dialerFactory.createStreamMuxer({
+        direction: 'outbound',
         onIncomingStream: (stream) => {
           onDialerStreamPromise.resolve(stream)
         }
@@ -115,6 +118,7 @@ export default (common: TestSetup<StreamMuxerFactory>) => {
 
       const listenerFactory = await common.setup()
       const listener = listenerFactory.createStreamMuxer({
+        direction: 'inbound',
         onIncomingStream: (stream) => {
           onListenerStreamPromise.resolve(stream)
         }
@@ -146,12 +150,14 @@ export default (common: TestSetup<StreamMuxerFactory>) => {
       const onListenerStreamPromise: DeferredPromise<Stream> = defer()
       const dialerFactory = await common.setup()
       const dialer = dialerFactory.createStreamMuxer({
+        direction: 'outbound',
         onIncomingStream: (stream) => {
           onDialerStreamPromise.resolve(stream)
         }
       })
       const listenerFactory = await common.setup()
       const listener = listenerFactory.createStreamMuxer({
+        direction: 'inbound',
         onIncomingStream: (stream) => {
           onListenerStreamPromise.resolve(stream)
         }

--- a/packages/interface-stream-muxer-compliance-tests/src/close-test.ts
+++ b/packages/interface-stream-muxer-compliance-tests/src/close-test.ts
@@ -30,11 +30,12 @@ export default (common: TestSetup<StreamMuxerFactory>) => {
       let openedStreams = 0
       const expectedStreams = 5
       const dialerFactory = await common.setup()
-      const dialer = dialerFactory.createStreamMuxer()
+      const dialer = dialerFactory.createStreamMuxer({ direction: 'outbound' })
 
       // Listener is echo server :)
       const listenerFactory = await common.setup()
       const listener = listenerFactory.createStreamMuxer({
+        direction: 'inbound',
         onIncomingStream: (stream) => {
           openedStreams++
           void pipe(stream, stream)
@@ -70,11 +71,12 @@ export default (common: TestSetup<StreamMuxerFactory>) => {
     it('closing one of the muxed streams doesn\'t close others', async () => {
       const p = duplexPair<Uint8Array>()
       const dialerFactory = await common.setup()
-      const dialer = dialerFactory.createStreamMuxer()
+      const dialer = dialerFactory.createStreamMuxer({ direction: 'outbound' })
 
       // Listener is echo server :)
       const listenerFactory = await common.setup()
       const listener = listenerFactory.createStreamMuxer({
+        direction: 'inbound',
         onIncomingStream: (stream) => {
           void pipe(stream, stream)
         }
@@ -120,11 +122,12 @@ export default (common: TestSetup<StreamMuxerFactory>) => {
 
       const p = duplexPair<Uint8Array>()
       const dialerFactory = await common.setup()
-      const dialer = dialerFactory.createStreamMuxer()
+      const dialer = dialerFactory.createStreamMuxer({ direction: 'outbound' })
       const data = [randomBuffer(), randomBuffer()]
 
       const listenerFactory = await common.setup()
       const listener = listenerFactory.createStreamMuxer({
+        direction: 'inbound',
         onIncomingStream: (stream) => {
           void Promise.resolve().then(async () => {
             // Immediate close for write
@@ -165,11 +168,12 @@ export default (common: TestSetup<StreamMuxerFactory>) => {
 
       const p = duplexPair<Uint8Array>()
       const dialerFactory = await common.setup()
-      const dialer = dialerFactory.createStreamMuxer()
+      const dialer = dialerFactory.createStreamMuxer({ direction: 'outbound' })
       const data = [randomBuffer(), randomBuffer()]
 
       const listenerFactory = await common.setup()
       const listener = listenerFactory.createStreamMuxer({
+        direction: 'inbound',
         onIncomingStream: (stream) => {
           void all(stream.source).then(deferred.resolve, deferred.reject)
         }
@@ -198,6 +202,7 @@ export default (common: TestSetup<StreamMuxerFactory>) => {
       const onStreamEnd = () => deferred.resolve()
       const dialerFactory = await common.setup()
       const dialer = dialerFactory.createStreamMuxer({
+        direction: 'outbound',
         onStreamEnd
       })
 
@@ -213,6 +218,7 @@ export default (common: TestSetup<StreamMuxerFactory>) => {
       const onStreamEnd = () => deferred.resolve()
       const dialerFactory = await common.setup()
       const dialer = dialerFactory.createStreamMuxer({
+        direction: 'outbound',
         onStreamEnd
       })
 

--- a/packages/interface-stream-muxer-compliance-tests/src/spawner.ts
+++ b/packages/interface-stream-muxer-compliance-tests/src/spawner.ts
@@ -13,6 +13,7 @@ export default async (createMuxer: (init?: StreamMuxerInit) => Promise<StreamMux
   const msg = uint8ArrayFromString('simple msg')
 
   const listener = await createMuxer({
+    direction: 'inbound',
     onIncomingStream: (stream) => {
       void pipe(
         stream,
@@ -22,7 +23,7 @@ export default async (createMuxer: (init?: StreamMuxerInit) => Promise<StreamMux
       })
     }
   })
-  const dialer = await createMuxer()
+  const dialer = await createMuxer({ direction: 'outbound' })
 
   void pipe(listenerSocket, listener, listenerSocket)
   void pipe(dialerSocket, dialer, dialerSocket)

--- a/packages/interface-stream-muxer/src/index.ts
+++ b/packages/interface-stream-muxer/src/index.ts
@@ -1,5 +1,5 @@
 import type { Duplex } from 'it-stream-types'
-import type { Stream } from '@libp2p/interface-connection'
+import type { Direction, Stream } from '@libp2p/interface-connection'
 import type { AbortOptions } from '@libp2p/interfaces'
 
 export interface StreamMuxerFactory {
@@ -24,4 +24,9 @@ export interface StreamMuxer extends Duplex<Uint8Array> {
 export interface StreamMuxerInit extends AbortOptions {
   onIncomingStream?: (stream: Stream) => void
   onStreamEnd?: (stream: Stream) => void
+
+  /**
+   * Outbound stream muxers are opened by the local node, inbound stream muxers are opened by the remote
+   */
+  direction?: Direction
 }


### PR DESCRIPTION
- add `Direction` type alias in interface-connection
- add `direction?: Direction` to `StreamMuxerInit`

Resolves #252 
Resolves #250 