### PR TITLE
feat!: add peer tagging

### DIFF
--- a/packages/interface-peer-store/src/index.ts
+++ b/packages/interface-peer-store/src/index.ts
@@ -223,6 +223,16 @@ export interface PeerStoreInit {
   addressFilter?: AddressFilter
 }
 
+export interface TagOptions {
+  value?: number
+  ttl?: number
+}
+
+export interface Tag {
+  name: string
+  value: number
+}
+
 export interface PeerStore extends EventEmitter<PeerStoreEvents> {
   addressBook: AddressBook
   keyBook: KeyBook
@@ -241,4 +251,8 @@ export interface PeerStore extends EventEmitter<PeerStoreEvents> {
   delete: (peerId: PeerId) => Promise<void>
   has: (peerId: PeerId) => Promise<boolean>
   get: (peerId: PeerId) => Promise<Peer>
+
+  tagPeer: (peerId: PeerId, tag: string, options?: TagOptions) => Promise<void>
+  unTagPeer: (peerId: PeerId, tag: string) => Promise<void>
+  getTags: (peerId: PeerId) => Promise<Tag[]>
 }


### PR DESCRIPTION
Allow tagging peers to better prioritise which connections to kill when hitting limits.  Also for keeping "priority" connections alive.

Refs: https://github.com/libp2p/js-libp2p/issues/369

BREAKING CHANGE: implementations will need to add the various tag methods