### PR TITLE
fix!: use `Set` for improved performance when searching in `multicodecs`

### DIFF
--- a/packages/interface-pubsub/src/index.ts
+++ b/packages/interface-pubsub/src/index.ts
@@ -71,7 +71,7 @@ export interface PeerStreams extends EventEmitter<PeerStreamEvents> {
 export interface PubSubInit {
   enabled?: boolean
 
-  multicodecs?: string[]
+  multicodecs?: Set<string>
 
   /**
    * defines how signatures should be handled


### PR DESCRIPTION
The `multicodecs` values are the protocol codecs for the given pubsub
implementation. They are likely to be set once (at instantiation) but
accessed multiple time: everytime it needs to check whether a remote
peer supports the same pubsub protocol.

Hence, the usage of `Set` over `Array` is more adapted as it will
improve access performance by using `Set.prototype.has` O(1) instead
of `Array.prototype.includes` O(N).

Refs: https://github.com/ChainSafe/js-libp2p-gossipsub/pull/288