### PR TITLE
docs: update `peer-id` link to new implementation

### DIFF
--- a/packages/interface-peer-id/README.md
+++ b/packages/interface-peer-id/README.md
@@ -32,7 +32,7 @@ The API is presented with both Node.js and Go primitives, however, there is not 
 
 ## Modules that implement the interface
 
-- [JavaScript libp2p-peer-id](https://github.com/libp2p/js-peer-id)
+- [JavaScript libp2p-peer-id](https://github.com/libp2p/js-libp2p-peer-id)
 
 Send a PR to add a new one if you happen to find or write one.
 


### PR DESCRIPTION
The documentation currently points to the older version of `peer-id` and should be updated to point to the currently supported version.