### PR TITLE
feat: export common tags

### DIFF
--- a/packages/interface-peer-store/README.md
+++ b/packages/interface-peer-store/README.md
@@ -11,6 +11,8 @@
 ## Table of contents <!-- omit in toc -->
 
 - [Install](#install)
+- [Usage](#usage)
+  - [Tags](#tags)
 - [License](#license)
 - [Contribution](#contribution)
 
@@ -18,6 +20,18 @@
 
 ```console
 $ npm i @libp2p/interface-peer-store
+```
+
+## Usage
+
+### Tags
+
+Common tags can be imported from the `@libp2p/interface-peer-store/tag` module:
+
+```js
+import { KEEP_ALIVE } from '@libp2p/interface-peer-store/tags'
+
+await peerStore.tagPeer(peerId, KEEP_ALIVE)
 ```
 
 ## License

--- a/packages/interface-peer-store/package.json
+++ b/packages/interface-peer-store/package.json
@@ -21,6 +21,22 @@
   },
   "type": "module",
   "types": "./dist/src/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "*",
+        "dist/*",
+        "dist/src/*",
+        "dist/src/*/index"
+      ],
+      "src/*": [
+        "*",
+        "dist/*",
+        "dist/src/*",
+        "dist/src/*/index"
+      ]
+    }
+  },
   "files": [
     "src",
     "dist/src",

--- a/packages/interface-peer-store/package.json
+++ b/packages/interface-peer-store/package.json
@@ -31,6 +31,10 @@
     ".": {
       "types": "./dist/src/index.d.ts",
       "import": "./dist/src/index.js"
+    },
+    "./tags": {
+      "types": "./dist/src/tags.d.ts",
+      "import": "./dist/src/tags.js"
     }
   },
   "eslintConfig": {

--- a/packages/interface-peer-store/src/tags.ts
+++ b/packages/interface-peer-store/src/tags.ts
@@ -1,0 +1,2 @@
+
+export const KEEP_ALIVE = 'keep-alive'


### PR DESCRIPTION
Exports a `KEEP_ALIVE` tag for reuse.