### PR TITLE
fix: add separate type for multiplexed stream

### DIFF
--- a/packages/interface-connection/package.json
+++ b/packages/interface-connection/package.json
@@ -149,6 +149,7 @@
   },
   "dependencies": {
     "@libp2p/interface-peer-id": "^1.0.0",
+    "@libp2p/interface-stream-muxer": "^2.0.0",
     "@libp2p/interfaces": "^3.0.0",
     "@multiformats/multiaddr": "^10.2.0",
     "it-stream-types": "^1.0.4"

--- a/packages/interface-connection/tsconfig.json
+++ b/packages/interface-connection/tsconfig.json
@@ -11,6 +11,9 @@
       "path": "../interface-peer-id"
     },
     {
+      "path": "../interface-stream-muxer"
+    },
+    {
       "path": "../interfaces"
     }
   ]

--- a/packages/interface-mocks/src/connection.ts
+++ b/packages/interface-mocks/src/connection.ts
@@ -78,7 +78,7 @@ class MockConnection implements Connection {
     }
 
     const id = `${Math.random()}`
-    const stream: Stream = this.muxer.newStream(id)
+    const stream = this.muxer.newStream(id)
     const mss = new Dialer(stream)
     const result = await mss.select(protocols, options)
 
@@ -135,13 +135,19 @@ export function mockConnection (maConn: MultiaddrConnection, opts: MockConnectio
         mss.handle(registrar.getProtocols())
           .then(({ stream, protocol }) => {
             log('%s: incoming stream opened on %s', direction, protocol)
-            muxedStream = { ...muxedStream, ...stream }
-            muxedStream.stat.protocol = protocol
+            const streamWithProtocol = {
+              ...muxedStream,
+              ...stream,
+              stat: {
+                ...muxedStream.stat,
+                protocol
+              }
+            }
 
-            connection.addStream(muxedStream)
+            connection.addStream(streamWithProtocol)
             const { handler } = registrar.getHandler(protocol)
 
-            handler({ connection, stream: muxedStream })
+            handler({ connection, stream: streamWithProtocol })
           }).catch(err => {
             log.error(err)
           })

--- a/packages/interface-stream-muxer-compliance-tests/package.json
+++ b/packages/interface-stream-muxer-compliance-tests/package.json
@@ -129,7 +129,6 @@
   },
   "dependencies": {
     "@libp2p/interface-compliance-tests": "^3.0.0",
-    "@libp2p/interface-connection": "^2.0.0",
     "@libp2p/interface-stream-muxer": "^2.0.0",
     "abortable-iterator": "^4.0.2",
     "aegir": "^37.4.0",

--- a/packages/interface-stream-muxer-compliance-tests/src/base-test.ts
+++ b/packages/interface-stream-muxer-compliance-tests/src/base-test.ts
@@ -10,8 +10,7 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { isValidTick } from '@libp2p/interface-compliance-tests/is-valid-tick'
 import type { DeferredPromise } from 'p-defer'
 import type { TestSetup } from '@libp2p/interface-compliance-tests'
-import type { Stream } from '@libp2p/interface-connection'
-import type { StreamMuxerFactory } from '@libp2p/interface-stream-muxer'
+import type { MuxedStream, StreamMuxerFactory } from '@libp2p/interface-stream-muxer'
 import type { Source, Duplex } from 'it-stream-types'
 
 async function drainAndClose (stream: Duplex<Uint8Array>) {
@@ -24,8 +23,8 @@ export default (common: TestSetup<StreamMuxerFactory>) => {
       const p = duplexPair<Uint8Array>()
       const dialerFactory = await common.setup()
       const dialer = dialerFactory.createStreamMuxer({ direction: 'outbound' })
-      const onStreamPromise: DeferredPromise<Stream> = defer()
-      const onStreamEndPromise: DeferredPromise<Stream> = defer()
+      const onStreamPromise: DeferredPromise<MuxedStream> = defer()
+      const onStreamEndPromise: DeferredPromise<MuxedStream> = defer()
 
       const listenerFactory = await common.setup()
       const listener = listenerFactory.createStreamMuxer({
@@ -75,11 +74,11 @@ export default (common: TestSetup<StreamMuxerFactory>) => {
 
     it('Open a stream from the listener', async () => {
       const p = duplexPair<Uint8Array>()
-      const onStreamPromise: DeferredPromise<Stream> = defer()
+      const onStreamPromise: DeferredPromise<MuxedStream> = defer()
       const dialerFactory = await common.setup()
       const dialer = dialerFactory.createStreamMuxer({
         direction: 'outbound',
-        onIncomingStream: (stream: Stream) => {
+        onIncomingStream: (stream: MuxedStream) => {
           onStreamPromise.resolve(stream)
         }
       })
@@ -106,8 +105,8 @@ export default (common: TestSetup<StreamMuxerFactory>) => {
 
     it('Open a stream on both sides', async () => {
       const p = duplexPair<Uint8Array>()
-      const onDialerStreamPromise: DeferredPromise<Stream> = defer()
-      const onListenerStreamPromise: DeferredPromise<Stream> = defer()
+      const onDialerStreamPromise: DeferredPromise<MuxedStream> = defer()
+      const onListenerStreamPromise: DeferredPromise<MuxedStream> = defer()
       const dialerFactory = await common.setup()
       const dialer = dialerFactory.createStreamMuxer({
         direction: 'outbound',
@@ -146,8 +145,8 @@ export default (common: TestSetup<StreamMuxerFactory>) => {
     it('Open a stream on one side, write, open a stream on the other side', async () => {
       const toString = (source: Source<Uint8Array>) => map(source, (u) => uint8ArrayToString(u))
       const p = duplexPair<Uint8Array>()
-      const onDialerStreamPromise: DeferredPromise<Stream> = defer()
-      const onListenerStreamPromise: DeferredPromise<Stream> = defer()
+      const onDialerStreamPromise: DeferredPromise<MuxedStream> = defer()
+      const onListenerStreamPromise: DeferredPromise<MuxedStream> = defer()
       const dialerFactory = await common.setup()
       const dialer = dialerFactory.createStreamMuxer({
         direction: 'outbound',

--- a/packages/interface-stream-muxer-compliance-tests/tsconfig.json
+++ b/packages/interface-stream-muxer-compliance-tests/tsconfig.json
@@ -12,9 +12,6 @@
       "path": "../interface-compliance-tests"
     },
     {
-      "path": "../interface-connection"
-    },
-    {
       "path": "../interface-stream-muxer"
     }
   ]

--- a/packages/interface-stream-muxer/package.json
+++ b/packages/interface-stream-muxer/package.json
@@ -128,7 +128,6 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/interface-connection": "^2.0.0",
     "@libp2p/interfaces": "^3.0.0",
     "it-stream-types": "^1.0.4"
   },

--- a/packages/interface-stream-muxer/src/index.ts
+++ b/packages/interface-stream-muxer/src/index.ts
@@ -1,6 +1,10 @@
 import type { Duplex } from 'it-stream-types'
-import type { Direction, Stream } from '@libp2p/interface-connection'
 import type { AbortOptions } from '@libp2p/interfaces'
+
+/**
+ * Outbound streams are opened by the local node, inbound streams are opened by the remote
+ */
+export type Direction = 'inbound' | 'outbound'
 
 export interface StreamMuxerFactory {
   protocol: string
@@ -13,12 +17,13 @@ export interface StreamMuxerFactory {
 export interface StreamMuxer extends Duplex<Uint8Array> {
   protocol: string
 
-  readonly streams: Stream[]
+  readonly streams: MuxedStream[]
+
   /**
    * Initiate a new stream with the given name. If no name is
    * provided, the id of the stream will be used.
    */
-  newStream: (name?: string) => Stream
+  newStream: (name?: string) => MuxedStream
 
   /**
    * Close or abort all tracked streams and stop the muxer
@@ -27,11 +32,77 @@ export interface StreamMuxer extends Duplex<Uint8Array> {
 }
 
 export interface StreamMuxerInit extends AbortOptions {
-  onIncomingStream?: (stream: Stream) => void
-  onStreamEnd?: (stream: Stream) => void
+  onIncomingStream?: (stream: MuxedStream) => void
+  onStreamEnd?: (stream: MuxedStream) => void
 
   /**
    * Outbound stream muxers are opened by the local node, inbound stream muxers are opened by the remote
    */
   direction?: Direction
+}
+
+/**
+ * A Stream is a data channel between two peers that
+ * can be written to and read from at both ends.
+ *
+ * It may be encrypted and multiplexed depending on the
+ * configuration of the nodes.
+ */
+export interface MuxedStream extends Duplex<Uint8Array> {
+  /**
+   * Close a stream for reading and writing
+   */
+  close: () => void
+
+  /**
+   * Close a stream for reading only
+   */
+  closeRead: () => void
+
+  /**
+   * Close a stream for writing only
+   */
+  closeWrite: () => void
+
+  /**
+   * Call when a local error occurs, should close the stream for reading and writing
+   */
+  abort: (err: Error) => void
+
+  /**
+   * Call when a remote error occurs, should close the stream for reading and writing
+   */
+  reset: () => void
+
+  /**
+   * Unique identifier for a stream
+   */
+  id: string
+
+  /**
+   * Stats about this stream
+   */
+  stat: MuxedStreamStat
+
+  /**
+   * User defined stream metadata
+   */
+  metadata: Record<string, any>
+}
+
+export interface MuxedStreamStat {
+  /**
+   * Outbound streams are opened by the local node, inbound streams are opened by the remote
+   */
+  direction: Direction
+
+  /**
+   * Lifecycle times for the stream
+   */
+  timeline: MuxedStreamTimeline
+}
+
+export interface MuxedStreamTimeline {
+  open: number
+  close?: number
 }

--- a/packages/interface-stream-muxer/tsconfig.json
+++ b/packages/interface-stream-muxer/tsconfig.json
@@ -9,9 +9,6 @@
   ],
   "references": [
     {
-      "path": "../interface-connection"
-    },
-    {
       "path": "../interfaces"
     }
   ]


### PR DESCRIPTION
A stream only has a protocol once it's been negotiated, but that happens after the muxer has opened it, so make the protocol type required on the return type from `Connection.newStream` but not present on `StreamMuxerFactory.newStream`.

All the same types are exported so this should be non-breaking.