### PR TITLE
feat!: pubsub Message types for signature policies

### DIFF
--- a/packages/interface-pubsub-compliance-tests/src/messages.ts
+++ b/packages/interface-pubsub-compliance-tests/src/messages.ts
@@ -49,10 +49,12 @@ export default (common: TestSetup<PubSub, PubSubArgs>) => {
       const event = await eventPromise
       const message = event.detail
 
-      expect(message.from.toString()).to.equal(components.getPeerId().toString())
-      expect(message.sequenceNumber).to.not.eql(undefined)
-      expect(message.key).to.not.eql(undefined)
-      expect(message.signature).to.not.eql(undefined)
+      if (message.type === 'signed') {
+        expect(message.from.toString()).to.equal(components.getPeerId().toString())
+        expect(message.sequenceNumber).to.not.eql(undefined)
+        expect(message.key).to.not.eql(undefined)
+        expect(message.signature).to.not.eql(undefined)
+      }
     })
   })
 }

--- a/packages/interface-pubsub-compliance-tests/src/two-nodes.ts
+++ b/packages/interface-pubsub-compliance-tests/src/two-nodes.ts
@@ -165,10 +165,15 @@ export default (common: TestSetup<PubSub, PubSubArgs>) => {
 
       function receivedMsg (evt: CustomEvent<Message>) {
         const msg = evt.detail
-        expect(uint8ArrayToString(msg.data)).to.equal('banana')
-        expect(msg.from.toString()).to.equal(componentsB.getPeerId().toString())
-        expect(msg.sequenceNumber).to.be.a('BigInt')
-        expect(msg.topic).to.be.equal(topic)
+        if (msg.type === 'unsigned') {
+          expect(uint8ArrayToString(msg.data)).to.equal('banana')
+          expect(msg.topic).to.be.equal(topic)
+        } else {
+          expect(uint8ArrayToString(msg.data)).to.equal('banana')
+          expect(msg.from.toString()).to.equal(componentsB.getPeerId().toString())
+          expect(msg.sequenceNumber).to.be.a('BigInt')
+          expect(msg.topic).to.be.equal(topic)
+        }
 
         if (++counter === 10) {
           psA.removeEventListener('message', receivedMsg)

--- a/packages/interface-pubsub/src/index.ts
+++ b/packages/interface-pubsub/src/index.ts
@@ -27,14 +27,23 @@ export const StrictNoSign = 'StrictNoSign'
 
 export type SignaturePolicy = typeof StrictSign | typeof StrictNoSign
 
-export interface Message {
+export interface SignedMessage {
+  type: 'signed'
   from: PeerId
   topic: string
   data: Uint8Array
-  sequenceNumber?: bigint
-  signature?: Uint8Array
-  key?: Uint8Array
+  sequenceNumber: bigint
+  signature: Uint8Array
+  key: Uint8Array
 }
+
+export interface UnsignedMessage {
+  type: 'unsigned'
+  topic: string
+  data: Uint8Array
+}
+
+export type Message = SignedMessage | UnsignedMessage
 
 export interface PubSubRPCMessage {
   from?: Uint8Array


### PR DESCRIPTION
BREAKING CHANGE: The `Message` type is now either a `StrictSignMessage`
or a `StrictNoSignMessage`