### PR TITLE
fix: mock connection manager close reciprocal connection

### DIFF
--- a/packages/interface-mocks/src/connection-manager.ts
+++ b/packages/interface-mocks/src/connection-manager.ts
@@ -132,7 +132,7 @@ class MockConnectionManager extends EventEmitter<ConnectionManagerEvents> implem
 
     this.connections = this.connections.filter(c => !c.remotePeer.equals(peerId))
 
-    await componentsB.getConnectionManager().closeConnections(peerId)
+    await componentsB.getConnectionManager().closeConnections(this.components.getPeerId())
   }
 }
 


### PR DESCRIPTION
`closeConnections` should close a connection with a peer reciprocally.

Fix bug where the reciprocal connection was not being closed.