### PR TITLE
feat!: add observed address methods

### DIFF
--- a/packages/interface-address-manager/src/index.ts
+++ b/packages/interface-address-manager/src/index.ts
@@ -38,7 +38,9 @@ export interface AddressManager extends EventEmitter<AddressManagerEvents> {
   removeObservedAddr: (addr: Multiaddr) => void
 
   /**
-   * Add peer observed addresses along with an optional confidence specifier
+   * Add peer observed addresses.  These will then appear in the output of getObservedAddrs
+   * but not getAddresses() until their dialability has been confirmed via a call to
+   * confirmObservedAddr.
    */
   addObservedAddr: (addr: Multiaddr) => void
 

--- a/packages/interface-address-manager/src/index.ts
+++ b/packages/interface-address-manager/src/index.ts
@@ -20,12 +20,25 @@ export interface AddressManager extends EventEmitter<AddressManagerEvents> {
   getAnnounceAddrs: () => Multiaddr[]
 
   /**
-   * Get observed multiaddrs
+   * Get observed multiaddrs - these addresses may not have been confirmed as
+   * publicly dialable yet
    */
   getObservedAddrs: () => Multiaddr[]
 
   /**
-   * Add peer observed addresses
+   * Signal that we have confidence an observed multiaddr is publicly dialable -
+   * this will make it appear in the output of getAddresses()
+   */
+  confirmObservedAddr: (addr: Multiaddr) => void
+
+  /**
+   * Signal that we do not have confidence an observed multiaddr is publicly dialable -
+   * this will remove it from the output of getObservedAddrs()
+   */
+  removeObservedAddr: (addr: Multiaddr) => void
+
+  /**
+   * Add peer observed addresses along with an optional confidence specifier
    */
   addObservedAddr: (addr: Multiaddr) => void
 


### PR DESCRIPTION
When we observe an address that might be externally dialable (via identify or uPNP NAT holepunching, etc), we need some way of signalling that we've either verified it's externally dialable and that we are safe to advertise it, or that it's not dialable and that we should forget about it.

These methods are necessary to implement autonat.