### PR TITLE
fix!: make record property and return types lists

### DIFF
--- a/packages/interface-record-compliance-tests/src/index.ts
+++ b/packages/interface-record-compliance-tests/src/index.ts
@@ -21,7 +21,7 @@ export default (test: TestSetup<Record>) => {
 
     it('is able to marshal', () => {
       const rawData = record.marshal()
-      expect(rawData).to.be.an.instanceof(Uint8Array)
+      expect(rawData).to.have.property('byteLength')
     })
 
     it('is able to compare two records', () => {

--- a/packages/interface-record/package.json
+++ b/packages/interface-record/package.json
@@ -132,7 +132,8 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/interface-peer-id": "^1.0.0"
+    "@libp2p/interface-peer-id": "^1.0.0",
+    "uint8arraylist": "^2.0.0"
   },
   "devDependencies": {
     "aegir": "^37.4.0"

--- a/packages/interface-record/src/index.ts
+++ b/packages/interface-record/src/index.ts
@@ -1,4 +1,5 @@
 import type { PeerId } from '@libp2p/interface-peer-id'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 /**
  * Record is the base implementation of a record that can be used as the payload of a libp2p envelope.
@@ -15,7 +16,7 @@ export interface Record {
   /**
    * Marshal a record to be used in an envelope.
    */
-  marshal: () => Uint8Array
+  marshal: () => Uint8ArrayList
   /**
    * Verifies if the other provided Record is identical to this one.
    */
@@ -24,11 +25,11 @@ export interface Record {
 
 export interface Envelope {
   peerId: PeerId
-  payloadType: Uint8Array
-  payload: Uint8Array
-  signature: Uint8Array
+  payloadType: Uint8Array | Uint8ArrayList
+  payload: Uint8Array | Uint8ArrayList
+  signature: Uint8Array | Uint8ArrayList
 
-  marshal: () => Uint8Array
+  marshal: () => Uint8ArrayList
   validate: (domain: string) => Promise<boolean>
   equals: (other: Envelope) => boolean
 }


### PR DESCRIPTION
In order to support no-copy operations, allow use of `Uint8ArrayList`s in libp2p records.

BREAKING CHANGE: return type of .marshal method and several properties have changed