### PR TITLE
fix: compare bytes in transport test

### DIFF
--- a/packages/interface-transport-compliance-tests/src/dial-test.ts
+++ b/packages/interface-transport-compliance-tests/src/dial-test.ts
@@ -70,7 +70,7 @@ export default (common: TestSetup<TransportTestFixtures>) => {
       expect(upgradeSpy.callCount).to.equal(1)
       await expect(upgradeSpy.getCall(0).returnValue).to.eventually.equal(conn)
       expect(result.length).to.equal(1)
-      expect(result[0]).to.equalBytes(uint8ArrayFromString('hey'))
+      expect(result[0].subarray()).to.equalBytes(uint8ArrayFromString('hey'))
       await conn.close()
     })
 


### PR DESCRIPTION
When testing the output of a stream, test byte value