### PR TITLE
feat!: Add remoteExtensions to connection-encrypter

### DIFF
--- a/packages/interface-connection-encrypter/src/index.ts
+++ b/packages/interface-connection-encrypter/src/index.ts
@@ -5,7 +5,7 @@ import type { Duplex } from 'it-stream-types'
  * A libp2p connection encrypter module must be compliant to this interface
  * to ensure all exchanged data between two peers is encrypted.
  */
-export interface ConnectionEncrypter {
+export interface ConnectionEncrypter<Extension = any> {
   protocol: string
 
   /**
@@ -13,18 +13,19 @@ export interface ConnectionEncrypter {
    * pass it for extra verification, otherwise it will be determined during
    * the handshake.
    */
-  secureOutbound: (localPeer: PeerId, connection: Duplex<Uint8Array>, remotePeer?: PeerId) => Promise<SecuredConnection>
+  secureOutbound: (localPeer: PeerId, connection: Duplex<Uint8Array>, remotePeer?: PeerId) => Promise<SecuredConnection<Extension>>
 
   /**
    * Decrypt incoming data. If the remote PeerId is known,
    * pass it for extra verification, otherwise it will be determined during
    * the handshake
    */
-  secureInbound: (localPeer: PeerId, connection: Duplex<Uint8Array>, remotePeer?: PeerId) => Promise<SecuredConnection>
+  secureInbound: (localPeer: PeerId, connection: Duplex<Uint8Array>, remotePeer?: PeerId) => Promise<SecuredConnection<Extension>>
 }
 
-export interface SecuredConnection {
+export interface SecuredConnection<E> {
   conn: Duplex<Uint8Array>
   remoteEarlyData: Uint8Array
+  remoteExtensions: E
   remotePeer: PeerId
 }

--- a/packages/interface-connection-encrypter/src/index.ts
+++ b/packages/interface-connection-encrypter/src/index.ts
@@ -5,7 +5,7 @@ import type { Duplex } from 'it-stream-types'
  * A libp2p connection encrypter module must be compliant to this interface
  * to ensure all exchanged data between two peers is encrypted.
  */
-export interface ConnectionEncrypter<Extension = any> {
+export interface ConnectionEncrypter<Extension = unknown> {
   protocol: string
 
   /**
@@ -25,7 +25,6 @@ export interface ConnectionEncrypter<Extension = any> {
 
 export interface SecuredConnection<E> {
   conn: Duplex<Uint8Array>
-  remoteEarlyData: Uint8Array
   remoteExtensions: E
   remotePeer: PeerId
 }

--- a/packages/interface-connection-encrypter/src/index.ts
+++ b/packages/interface-connection-encrypter/src/index.ts
@@ -25,6 +25,6 @@ export interface ConnectionEncrypter<Extension = unknown> {
 
 export interface SecuredConnection<E> {
   conn: Duplex<Uint8Array>
-  remoteExtensions: E
+  remoteExtensions?: E
   remotePeer: PeerId
 }

--- a/packages/interface-mocks/src/connection-encrypter.ts
+++ b/packages/interface-mocks/src/connection-encrypter.ts
@@ -63,7 +63,6 @@ export function mockConnectionEncrypter () {
           conn: true
         },
         remotePeer,
-        remoteEarlyData: new Uint8Array(0),
         remoteExtensions: {}
       }
     },
@@ -105,7 +104,6 @@ export function mockConnectionEncrypter () {
           conn: true
         },
         remotePeer: peerIdFromBytes(remoteId.slice()),
-        remoteEarlyData: new Uint8Array(0),
         remoteExtensions: {}
       }
     }

--- a/packages/interface-mocks/src/connection-encrypter.ts
+++ b/packages/interface-mocks/src/connection-encrypter.ts
@@ -54,7 +54,7 @@ export function mockConnectionEncrypter () {
       return {
         conn: {
           ...wrapper[1],
-          close: async () => {},
+          close: async () => { },
           localAddr: multiaddr('/ip4/127.0.0.1/tcp/4001'),
           remoteAddr: multiaddr('/ip4/127.0.0.1/tcp/4002'),
           timeline: {
@@ -95,7 +95,7 @@ export function mockConnectionEncrypter () {
       return {
         conn: {
           ...wrapper[1],
-          close: async () => {},
+          close: async () => { },
           localAddr: multiaddr('/ip4/127.0.0.1/tcp/4001'),
           remoteAddr: multiaddr('/ip4/127.0.0.1/tcp/4002'),
           timeline: {

--- a/packages/interface-mocks/src/connection-encrypter.ts
+++ b/packages/interface-mocks/src/connection-encrypter.ts
@@ -63,7 +63,8 @@ export function mockConnectionEncrypter () {
           conn: true
         },
         remotePeer,
-        remoteEarlyData: new Uint8Array(0)
+        remoteEarlyData: new Uint8Array(0),
+        remoteExtensions: {}
       }
     },
     secureOutbound: async (localPeer, duplex, remotePeer) => {
@@ -104,7 +105,8 @@ export function mockConnectionEncrypter () {
           conn: true
         },
         remotePeer: peerIdFromBytes(remoteId.slice()),
-        remoteEarlyData: new Uint8Array(0)
+        remoteEarlyData: new Uint8Array(0),
+        remoteExtensions: {}
       }
     }
   }


### PR DESCRIPTION
fixes https://github.com/libp2p/js-libp2p-interfaces/issues/291

earlyData in Noise has been deprecated in favor of a structured protobuf labeled Noise Extensions: https://github.com/libp2p/specs/pull/453.

remoteExtensions and earlyData are both Noise specific. I'm not sure what the value is by having this interface defined here. Probably what we want is a minimum interface that callers expect, but the concrete implementation can return anything as long as it meets the minimum interface. This is a bigger change than I want to take, but probably the better solution that we should do when we have other encryption modules.

BREAKING CHANGE: remoteEarlyData is replaced by generic remoteExtensions