### PR TITLE
feat: add acceptIncomingConnection to ConnectionManager

### DIFF
--- a/packages/interface-connection-manager/src/index.ts
+++ b/packages/interface-connection-manager/src/index.ts
@@ -28,10 +28,10 @@ export interface ConnectionManager extends EventEmitter<ConnectionManagerEvents>
   /**
    * Invoked after an incoming connection is opened but before PeerIds are
    * exchanged, this lets the ConnectionManager check we have sufficient
-   * resources to accept the connection, otherwise it will be closed and an
-   * error thrown
+   * resources to accept the connection in which case it will return true,
+   * otherwise it will return false.
    */
-  acceptIncomingConnection: (maConn: MultiaddrConnection) => Promise<void>
+  acceptIncomingConnection: (maConn: MultiaddrConnection) => Promise<boolean>
 }
 
 export interface Dialer {

--- a/packages/interface-connection-manager/src/index.ts
+++ b/packages/interface-connection-manager/src/index.ts
@@ -1,6 +1,6 @@
 import type { AbortOptions } from '@libp2p/interfaces'
 import type { EventEmitter } from '@libp2p/interfaces/events'
-import type { Connection } from '@libp2p/interface-connection'
+import type { Connection, MultiaddrConnection } from '@libp2p/interface-connection'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
@@ -24,6 +24,14 @@ export interface ConnectionManager extends EventEmitter<ConnectionManagerEvents>
    * Close our connections to a peer
    */
   closeConnections: (peer: PeerId) => Promise<void>
+
+  /**
+   * Invoked after an incoming connection is opened but before PeerIds are
+   * exchanged, this lets the ConnectionManager check we have sufficient
+   * resources to accept the connection, otherwise it will be closed and an
+   * error thrown
+   */
+  acceptIncomingConnection: (maConn: MultiaddrConnection) => Promise<void>
 }
 
 export interface Dialer {

--- a/packages/interface-mocks/src/connection-manager.ts
+++ b/packages/interface-mocks/src/connection-manager.ts
@@ -135,8 +135,8 @@ class MockConnectionManager extends EventEmitter<ConnectionManagerEvents> implem
     await componentsB.getConnectionManager().closeConnections(this.components.getPeerId())
   }
 
-  async acceptIncomingConnection () {
-
+  async acceptIncomingConnection (): Promise<boolean> {
+    return true
   }
 }
 

--- a/packages/interface-mocks/src/connection-manager.ts
+++ b/packages/interface-mocks/src/connection-manager.ts
@@ -134,6 +134,10 @@ class MockConnectionManager extends EventEmitter<ConnectionManagerEvents> implem
 
     await componentsB.getConnectionManager().closeConnections(this.components.getPeerId())
   }
+
+  async acceptIncomingConnection () {
+
+  }
 }
 
 export function mockConnectionManager () {


### PR DESCRIPTION
In order to check we can accept an incoming connection before exchanging PeerIds, add a method to the ConnectionManager interface that can be called by the upgrader.