### PR TITLE
fix: add default extension type

### DIFF
--- a/packages/interface-connection-encrypter/src/index.ts
+++ b/packages/interface-connection-encrypter/src/index.ts
@@ -23,8 +23,8 @@ export interface ConnectionEncrypter<Extension = unknown> {
   secureInbound: (localPeer: PeerId, connection: Duplex<Uint8Array>, remotePeer?: PeerId) => Promise<SecuredConnection<Extension>>
 }
 
-export interface SecuredConnection<E> {
+export interface SecuredConnection<Extension = unknown> {
   conn: Duplex<Uint8Array>
-  remoteExtensions?: E
+  remoteExtensions?: Extension
   remotePeer: PeerId
 }


### PR DESCRIPTION
Similar to the `ConnectionEncrypter` interface, specify a default type for the `Extension` so consumers uninterested in the `remoteExtensions` field can operate as before.