### PR TITLE
fix!: add topicValidators to pubsub interface

### DIFF
--- a/packages/interface-pubsub-compliance-tests/src/api.ts
+++ b/packages/interface-pubsub-compliance-tests/src/api.ts
@@ -5,13 +5,12 @@ import pWaitFor from 'p-wait-for'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import delay from 'delay'
 import type { TestSetup } from '@libp2p/interface-compliance-tests'
-import { PubSub, TopicValidatorResult, Message } from '@libp2p/interface-pubsub'
+import type { PubSub } from '@libp2p/interface-pubsub'
 import type { PubSubArgs } from './index.js'
 import type { Components } from '@libp2p/components'
 import { createComponents } from './utils.js'
 import { isStartable, start, stop } from '@libp2p/interfaces/startable'
 import { mockNetwork } from '@libp2p/interface-mocks'
-import type { PeerId } from '@libp2p/interface-peer-id'
 
 const topic = 'foo'
 const data = uint8ArrayFromString('bar')
@@ -106,26 +105,6 @@ export default (common: TestSetup<PubSub, PubSubArgs>) => {
         expect(evt).to.have.nested.property('detail.topic', topic)
         expect(evt).to.have.deep.nested.property('detail.data', data)
         defer.resolve()
-      })
-      await pubsub.publish(topic, data)
-      await defer.promise
-
-      await stop(components)
-    })
-
-    it('validates topic messages', async () => {
-      const defer = pDefer()
-
-      await start(components)
-
-      pubsub.subscribe(topic)
-      pubsub.topicValidators.set(topic, (peer: PeerId, message: Message) => {
-        expect(peer).to.be.equal(components.getPeerId())
-        expect(message).to.exist()
-        expect(message).to.have.nested.property('data', data)
-        expect(message).to.have.nested.property('topic', topic)
-        defer.resolve()
-        return TopicValidatorResult.Accept
       })
       await pubsub.publish(topic, data)
       await defer.promise

--- a/packages/interface-pubsub-compliance-tests/src/api.ts
+++ b/packages/interface-pubsub-compliance-tests/src/api.ts
@@ -11,7 +11,7 @@ import type { Components } from '@libp2p/components'
 import { createComponents } from './utils.js'
 import { isStartable, start, stop } from '@libp2p/interfaces/startable'
 import { mockNetwork } from '@libp2p/interface-mocks'
-import { PeerId } from '@libp2p/interface-peer-id'
+import type { PeerId } from '@libp2p/interface-peer-id'
 
 const topic = 'foo'
 const data = uint8ArrayFromString('bar')
@@ -120,11 +120,11 @@ export default (common: TestSetup<PubSub, PubSubArgs>) => {
 
       pubsub.subscribe(topic)
       pubsub.topicValidators.set(topic, (peer: PeerId, message: Message) => {
-        expect(peer).to.be.equal(components.getPeerId());
+        expect(peer).to.be.equal(components.getPeerId())
         expect(message).to.exist()
         expect(message).to.have.nested.property('data', data)
         expect(message).to.have.nested.property('topic', topic)
-        defer.resolve();
+        defer.resolve()
         return TopicValidatorResult.Accept
       })
       await pubsub.publish(topic, data)

--- a/packages/interface-pubsub-compliance-tests/src/api.ts
+++ b/packages/interface-pubsub-compliance-tests/src/api.ts
@@ -5,12 +5,13 @@ import pWaitFor from 'p-wait-for'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import delay from 'delay'
 import type { TestSetup } from '@libp2p/interface-compliance-tests'
-import type { PubSub } from '@libp2p/interface-pubsub'
+import { PubSub, TopicValidatorResult, Message } from '@libp2p/interface-pubsub'
 import type { PubSubArgs } from './index.js'
 import type { Components } from '@libp2p/components'
 import { createComponents } from './utils.js'
 import { isStartable, start, stop } from '@libp2p/interfaces/startable'
 import { mockNetwork } from '@libp2p/interface-mocks'
+import { PeerId } from '@libp2p/interface-peer-id'
 
 const topic = 'foo'
 const data = uint8ArrayFromString('bar')
@@ -105,6 +106,26 @@ export default (common: TestSetup<PubSub, PubSubArgs>) => {
         expect(evt).to.have.nested.property('detail.topic', topic)
         expect(evt).to.have.deep.nested.property('detail.data', data)
         defer.resolve()
+      })
+      await pubsub.publish(topic, data)
+      await defer.promise
+
+      await stop(components)
+    })
+
+    it('validates topic messages', async () => {
+      const defer = pDefer()
+
+      await start(components)
+
+      pubsub.subscribe(topic)
+      pubsub.topicValidators.set(topic, (peer: PeerId, message: Message) => {
+        expect(peer).to.be.equal(components.getPeerId());
+        expect(message).to.exist()
+        expect(message).to.have.nested.property('data', data)
+        expect(message).to.have.nested.property('topic', topic)
+        defer.resolve();
+        return TopicValidatorResult.Accept
       })
       await pubsub.publish(topic, data)
       await defer.promise

--- a/packages/interface-pubsub/src/index.ts
+++ b/packages/interface-pubsub/src/index.ts
@@ -133,9 +133,22 @@ export interface PublishResult {
   recipients: PeerId[]
 }
 
+export enum TopicValidatorResult {
+  /// The message is considered valid, and it should be delivered and forwarded to the network.
+  Accept = 'accept',
+  /// The message is neither delivered nor forwarded to the network, but the router does not
+  /// trigger the P₄ penalty.
+  Ignore = 'ignore',
+  /// The message is considered invalid, and it should be rejected and trigger the P₄ penalty.
+  Reject = 'reject'
+}
+
+export type TopicValidatorFn = (peer: PeerId, message: Message) => TopicValidatorResult | Promise<TopicValidatorResult>
+
 export interface PubSub<Events extends { [s: string]: any } = PubSubEvents> extends EventEmitter<Events> {
   globalSignaturePolicy: typeof StrictSign | typeof StrictNoSign
   multicodecs: string[]
+  topicValidators: Map<string, TopicValidatorFn>
 
   getPeers: () => PeerId[]
   getTopics: () => string[]

--- a/packages/interface-pubsub/src/index.ts
+++ b/packages/interface-pubsub/src/index.ts
@@ -134,12 +134,17 @@ export interface PublishResult {
 }
 
 export enum TopicValidatorResult {
-  /// The message is considered valid, and it should be delivered and forwarded to the network.
+  /**
+   * The message is considered valid, and it should be delivered and forwarded to the network
+   */
   Accept = 'accept',
-  /// The message is neither delivered nor forwarded to the network, but the router does not
-  /// trigger the P₄ penalty.
+  /**
+   * The message is neither delivered nor forwarded to the network
+   */
   Ignore = 'ignore',
-  /// The message is considered invalid, and it should be rejected and trigger the P₄ penalty.
+  /**
+   * The message is considered invalid, and it should be rejected
+   */
   Reject = 'reject'
 }
 

--- a/packages/interface-pubsub/src/index.ts
+++ b/packages/interface-pubsub/src/index.ts
@@ -143,7 +143,9 @@ export enum TopicValidatorResult {
   Reject = 'reject'
 }
 
-export type TopicValidatorFn = (peer: PeerId, message: Message) => TopicValidatorResult | Promise<TopicValidatorResult>
+export interface TopicValidatorFn {
+  (peer: PeerId, message: Message): TopicValidatorResult | Promise<TopicValidatorResult>
+}
 
 export interface PubSub<Events extends { [s: string]: any } = PubSubEvents> extends EventEmitter<Events> {
   globalSignaturePolicy: typeof StrictSign | typeof StrictNoSign


### PR DESCRIPTION
resolves #297 

- topicValidation is indeed specified in https://github.com/libp2p/specs/blob/master/pubsub/README.md#topic-validation

Still need to:
- [x] test against https://github.com/libp2p/js-libp2p-floodsub to check new compliance test works 