### PR TITLE
feat: add afterUpgradeInbound method

### DIFF
--- a/packages/interface-connection-manager/src/index.ts
+++ b/packages/interface-connection-manager/src/index.ts
@@ -32,6 +32,11 @@ export interface ConnectionManager extends EventEmitter<ConnectionManagerEvents>
    * otherwise it will return false.
    */
   acceptIncomingConnection: (maConn: MultiaddrConnection) => Promise<boolean>
+
+  /**
+   * Invoked after upgrading a multiaddr connection has finished
+   */
+  afterUpgradeInbound: () => void
 }
 
 export interface Dialer {

--- a/packages/interface-mocks/src/connection-manager.ts
+++ b/packages/interface-mocks/src/connection-manager.ts
@@ -138,6 +138,10 @@ class MockConnectionManager extends EventEmitter<ConnectionManagerEvents> implem
   async acceptIncomingConnection (): Promise<boolean> {
     return true
   }
+
+  afterUpgradeInbound (): void {
+
+  }
 }
 
 export function mockConnectionManager () {


### PR DESCRIPTION
This is so we can count the number of pending upgrades in the connection manager and disallow new connections if we cross a configurable threshold.