### PR TITLE
fix!: remove @libp2p/components

### DIFF
--- a/packages/interface-connection-encrypter-compliance-tests/package.json
+++ b/packages/interface-connection-encrypter-compliance-tests/package.json
@@ -143,6 +143,6 @@
     "it-pair": "^2.0.2",
     "it-pipe": "^2.0.3",
     "it-stream-types": "^1.0.4",
-    "uint8arrays": "^4.0.1"
+    "uint8arrays": "^4.0.2"
   }
 }

--- a/packages/interface-connection-encrypter-compliance-tests/package.json
+++ b/packages/interface-connection-encrypter-compliance-tests/package.json
@@ -143,6 +143,6 @@
     "it-pair": "^2.0.2",
     "it-pipe": "^2.0.3",
     "it-stream-types": "^1.0.4",
-    "uint8arrays": "^3.0.0"
+    "uint8arrays": "^4.0.1"
   }
 }

--- a/packages/interface-content-routing/package.json
+++ b/packages/interface-content-routing/package.json
@@ -134,7 +134,7 @@
   "dependencies": {
     "@libp2p/interface-peer-info": "^1.0.0",
     "@libp2p/interfaces": "^3.0.0",
-    "multiformats": "^9.6.3"
+    "multiformats": "^10.0.0"
   },
   "devDependencies": {
     "aegir": "^37.4.0"

--- a/packages/interface-dht/package.json
+++ b/packages/interface-dht/package.json
@@ -136,7 +136,7 @@
     "@libp2p/interface-peer-id": "^1.0.0",
     "@libp2p/interface-peer-info": "^1.0.0",
     "@libp2p/interfaces": "^3.0.0",
-    "multiformats": "^9.6.3"
+    "multiformats": "^10.0.0"
   },
   "devDependencies": {
     "aegir": "^37.4.0"

--- a/packages/interface-keychain/package.json
+++ b/packages/interface-keychain/package.json
@@ -132,7 +132,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "multiformats": "^9.6.3"
+    "multiformats": "^10.0.0"
   },
   "devDependencies": {
     "aegir": "^37.4.0"

--- a/packages/interface-mocks/package.json
+++ b/packages/interface-mocks/package.json
@@ -166,7 +166,7 @@
     "it-stream-types": "^1.0.4",
     "merge-options": "^3.0.4",
     "uint8arraylist": "^2.0.0",
-    "uint8arrays": "^3.0.0"
+    "uint8arrays": "^4.0.1"
   },
   "devDependencies": {
     "@libp2p/interface-connection-compliance-tests": "^2.0.0",

--- a/packages/interface-mocks/package.json
+++ b/packages/interface-mocks/package.json
@@ -139,7 +139,6 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/components": "^3.0.0",
     "@libp2p/interface-connection": "^3.0.0",
     "@libp2p/interface-connection-encrypter": "^3.0.0",
     "@libp2p/interface-connection-manager": "^1.0.0",

--- a/packages/interface-mocks/package.json
+++ b/packages/interface-mocks/package.json
@@ -166,7 +166,7 @@
     "it-stream-types": "^1.0.4",
     "merge-options": "^3.0.4",
     "uint8arraylist": "^2.0.0",
-    "uint8arrays": "^4.0.1"
+    "uint8arrays": "^4.0.2"
   },
   "devDependencies": {
     "@libp2p/interface-connection-compliance-tests": "^2.0.0",

--- a/packages/interface-mocks/src/connection.ts
+++ b/packages/interface-mocks/src/connection.ts
@@ -13,7 +13,6 @@ import { logger } from '@libp2p/logger'
 import * as STATUS from '@libp2p/interface-connection/status'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { StreamMuxer } from '@libp2p/interface-stream-muxer'
-import type { Components } from '@libp2p/components'
 import type { AbortOptions } from '@libp2p/interfaces'
 import errCode from 'err-code'
 import type { Uint8ArrayList } from 'uint8arraylist'
@@ -193,18 +192,18 @@ export interface Peer {
   registrar: Registrar
 }
 
-export function connectionPair (a: Components, b: Components): [ Connection, Connection ] {
+export function connectionPair (a: { peerId: PeerId, registrar: Registrar }, b: { peerId: PeerId, registrar: Registrar }): [ Connection, Connection ] {
   const [peerBtoPeerA, peerAtoPeerB] = duplexPair<Uint8Array>()
 
   return [
     mockConnection(
-      mockMultiaddrConnection(peerAtoPeerB, b.getPeerId()), {
-        registrar: a.getRegistrar()
+      mockMultiaddrConnection(peerAtoPeerB, b.peerId), {
+        registrar: a.registrar
       }
     ),
     mockConnection(
-      mockMultiaddrConnection(peerBtoPeerA, a.getPeerId()), {
-        registrar: b.getRegistrar()
+      mockMultiaddrConnection(peerBtoPeerA, a.peerId), {
+        registrar: b.registrar
       }
     )
   ]

--- a/packages/interface-mocks/test/connection.spec.ts
+++ b/packages/interface-mocks/test/connection.spec.ts
@@ -4,24 +4,23 @@ import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { mockRegistrar } from '../src/registrar.js'
 import type { Connection } from '@libp2p/interface-connection'
 import { pipe } from 'it-pipe'
-import { Components } from '@libp2p/components'
 
 describe('mock connection compliance tests', () => {
   let connections: Connection[] = []
 
   tests({
     async setup () {
-      const componentsA = new Components({
+      const componentsA = {
         peerId: await createEd25519PeerId(),
         registrar: mockRegistrar()
-      })
-      const componentsB = new Components({
+      }
+      const componentsB = {
         peerId: await createEd25519PeerId(),
         registrar: mockRegistrar()
-      })
+      }
       connections = connectionPair(componentsA, componentsB)
 
-      await componentsB.getRegistrar().handle('/echo/0.0.1', (data) => {
+      await componentsB.registrar.handle('/echo/0.0.1', (data) => {
         void pipe(
           data.stream,
           data.stream

--- a/packages/interface-peer-discovery-compliance-tests/src/index.ts
+++ b/packages/interface-peer-discovery-compliance-tests/src/index.ts
@@ -5,11 +5,10 @@ import pDefer from 'p-defer'
 import { start, stop } from '@libp2p/interfaces/startable'
 import type { TestSetup } from '@libp2p/interface-compliance-tests'
 import type { PeerDiscovery } from '@libp2p/interface-peer-discovery'
-import type { Startable } from '@libp2p/interfaces/startable'
 
-export default (common: TestSetup<PeerDiscovery & Startable>) => {
+export default (common: TestSetup<PeerDiscovery>) => {
   describe('interface-peer-discovery compliance tests', () => {
-    let discovery: PeerDiscovery & Startable
+    let discovery: PeerDiscovery
 
     beforeEach(async () => {
       discovery = await common.setup()

--- a/packages/interface-peer-id/package.json
+++ b/packages/interface-peer-id/package.json
@@ -132,7 +132,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "multiformats": "^9.6.3"
+    "multiformats": "^10.0.0"
   },
   "devDependencies": {
     "aegir": "^37.4.0"

--- a/packages/interface-pubsub-compliance-tests/package.json
+++ b/packages/interface-pubsub-compliance-tests/package.json
@@ -144,6 +144,6 @@
     "p-event": "^5.0.1",
     "p-wait-for": "^5.0.0",
     "sinon": "^14.0.0",
-    "uint8arrays": "^3.0.0"
+    "uint8arrays": "^4.0.1"
   }
 }

--- a/packages/interface-pubsub-compliance-tests/package.json
+++ b/packages/interface-pubsub-compliance-tests/package.json
@@ -144,6 +144,6 @@
     "p-event": "^5.0.1",
     "p-wait-for": "^5.0.0",
     "sinon": "^14.0.0",
-    "uint8arrays": "^4.0.1"
+    "uint8arrays": "^4.0.2"
   }
 }

--- a/packages/interface-pubsub-compliance-tests/package.json
+++ b/packages/interface-pubsub-compliance-tests/package.json
@@ -132,7 +132,6 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/components": "^3.0.0",
     "@libp2p/interface-compliance-tests": "^3.0.0",
     "@libp2p/interface-mocks": "^6.0.0",
     "@libp2p/interface-peer-id": "^1.0.0",

--- a/packages/interface-pubsub-compliance-tests/src/emit-self.ts
+++ b/packages/interface-pubsub-compliance-tests/src/emit-self.ts
@@ -1,11 +1,9 @@
 import { expect } from 'aegir/chai'
 import sinon from 'sinon'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import { createEd25519PeerId } from '@libp2p/peer-id-factory'
-import { mockRegistrar, mockNetwork } from '@libp2p/interface-mocks'
+import { mockNetwork } from '@libp2p/interface-mocks'
 import type { TestSetup } from '@libp2p/interface-compliance-tests'
-import type { PubSubArgs } from './index.js'
-import { Components } from '@libp2p/components'
+import type { PubSubArgs, PubSubComponents } from './index.js'
 import { start, stop } from '@libp2p/interfaces/startable'
 import type { PubSub } from '@libp2p/interface-pubsub'
 import { createComponents } from './utils.js'
@@ -18,26 +16,26 @@ export default (common: TestSetup<PubSub, PubSubArgs>) => {
   describe('emit self', () => {
     describe('enabled', () => {
       let pubsub: PubSub
-      let components: Components
+      let components: PubSubComponents
 
       before(async () => {
         mockNetwork.reset()
         components = await createComponents()
 
-        pubsub = components.setPubSub(await common.setup({
+        pubsub = components.pubsub = await common.setup({
           components,
           init: {
             emitSelf: true
           }
-        }))
+        })
 
-        await start(components)
+        await start(...Object.values(components))
         pubsub.subscribe(topic)
       })
 
       after(async () => {
         sinon.restore()
-        await stop(components)
+        await stop(...Object.values(components))
         await common.teardown()
         mockNetwork.reset()
       })
@@ -63,28 +61,25 @@ export default (common: TestSetup<PubSub, PubSubArgs>) => {
 
     describe('disabled', () => {
       let pubsub: PubSub
-      let components: Components
+      let components: PubSubComponents
 
       before(async () => {
         mockNetwork.reset()
-        components = new Components({
-          peerId: await createEd25519PeerId(),
-          registrar: mockRegistrar()
-        })
-        pubsub = components.setPubSub(await common.setup({
+        components = await createComponents()
+        pubsub = components.pubsub = await common.setup({
           components,
           init: {
             emitSelf: false
           }
-        }))
+        })
 
-        await start(components)
+        await start(...Object.values(components))
         pubsub.subscribe(topic)
       })
 
       after(async () => {
         sinon.restore()
-        await stop(components)
+        await stop(...Object.values(components))
         await common.teardown()
         mockNetwork.reset()
       })

--- a/packages/interface-pubsub-compliance-tests/src/index.ts
+++ b/packages/interface-pubsub-compliance-tests/src/index.ts
@@ -6,10 +6,19 @@ import twoNodesTest from './two-nodes.js'
 import multipleNodesTest from './multiple-nodes.js'
 import type { TestSetup } from '@libp2p/interface-compliance-tests'
 import type { PubSub, PubSubInit } from '@libp2p/interface-pubsub'
-import type { Components } from '@libp2p/components'
+import type { PeerId } from '@libp2p/interface-peer-id'
+import type { Registrar } from '@libp2p/interface-registrar'
+import type { ConnectionManager } from '@libp2p/interface-connection-manager'
+
+export interface PubSubComponents {
+  peerId: PeerId
+  registrar: Registrar
+  connectionManager: ConnectionManager
+  pubsub?: PubSub
+}
 
 export interface PubSubArgs {
-  components: Components
+  components: PubSubComponents
   init: PubSubInit
 }
 

--- a/packages/interface-pubsub-compliance-tests/src/messages.ts
+++ b/packages/interface-pubsub-compliance-tests/src/messages.ts
@@ -3,8 +3,7 @@ import sinon from 'sinon'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import type { TestSetup } from '@libp2p/interface-compliance-tests'
 import type { Message, PubSub } from '@libp2p/interface-pubsub'
-import type { PubSubArgs } from './index.js'
-import type { Components } from '@libp2p/components'
+import type { PubSubArgs, PubSubComponents } from './index.js'
 import { start, stop } from '@libp2p/interfaces/startable'
 import { pEvent } from 'p-event'
 import { createComponents } from './utils.js'
@@ -16,25 +15,25 @@ const data = uint8ArrayFromString('bar')
 export default (common: TestSetup<PubSub, PubSubArgs>) => {
   describe('messages', () => {
     let pubsub: PubSub
-    let components: Components
+    let components: PubSubComponents
 
     // Create pubsub router
     beforeEach(async () => {
       mockNetwork.reset()
       components = await createComponents()
 
-      pubsub = components.setPubSub(await common.setup({
+      pubsub = components.pubsub = await common.setup({
         components,
         init: {
           emitSelf: true
         }
-      }))
-      await start(components)
+      })
+      await start(...Object.values(components))
     })
 
     afterEach(async () => {
       sinon.restore()
-      await stop(components)
+      await stop(...Object.values(components))
       await common.teardown()
       mockNetwork.reset()
     })
@@ -50,7 +49,7 @@ export default (common: TestSetup<PubSub, PubSubArgs>) => {
       const message = event.detail
 
       if (message.type === 'signed') {
-        expect(message.from.toString()).to.equal(components.getPeerId().toString())
+        expect(message.from.toString()).to.equal(components.peerId.toString())
         expect(message.sequenceNumber).to.not.eql(undefined)
         expect(message.key).to.not.eql(undefined)
         expect(message.signature).to.not.eql(undefined)

--- a/packages/interface-pubsub-compliance-tests/src/utils.ts
+++ b/packages/interface-pubsub-compliance-tests/src/utils.ts
@@ -1,10 +1,10 @@
 import { pEvent } from 'p-event'
 import pWaitFor from 'p-wait-for'
-import { Components } from '@libp2p/components'
 import type { PubSub, SubscriptionChangeData } from '@libp2p/interface-pubsub'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { mockConnectionManager, mockRegistrar, mockNetwork } from '@libp2p/interface-mocks'
+import type { NetworkComponents } from '@libp2p/interface-mocks/src/connection-manager'
 
 export async function waitForSubscriptionUpdate (a: PubSub, b: PeerId) {
   await pWaitFor(async () => {
@@ -14,12 +14,12 @@ export async function waitForSubscriptionUpdate (a: PubSub, b: PeerId) {
   })
 }
 
-export async function createComponents (): Promise<Components> {
-  const components = new Components({
+export async function createComponents (): Promise<NetworkComponents> {
+  const components: any = {
     peerId: await createEd25519PeerId(),
-    registrar: mockRegistrar(),
-    connectionManager: mockConnectionManager()
-  })
+    registrar: mockRegistrar()
+  }
+  components.connectionManager = mockConnectionManager(components)
 
   mockNetwork.addNode(components)
 

--- a/packages/interface-stream-muxer-compliance-tests/package.json
+++ b/packages/interface-stream-muxer-compliance-tests/package.json
@@ -147,6 +147,6 @@
     "p-defer": "^4.0.0",
     "p-limit": "^4.0.0",
     "uint8arraylist": "^2.1.2",
-    "uint8arrays": "^3.0.0"
+    "uint8arrays": "^4.0.1"
   }
 }

--- a/packages/interface-stream-muxer-compliance-tests/package.json
+++ b/packages/interface-stream-muxer-compliance-tests/package.json
@@ -147,6 +147,6 @@
     "p-defer": "^4.0.0",
     "p-limit": "^4.0.0",
     "uint8arraylist": "^2.1.2",
-    "uint8arrays": "^4.0.1"
+    "uint8arrays": "^4.0.2"
   }
 }

--- a/packages/interface-transport-compliance-tests/package.json
+++ b/packages/interface-transport-compliance-tests/package.json
@@ -146,6 +146,6 @@
     "p-defer": "^4.0.0",
     "p-wait-for": "^5.0.0",
     "sinon": "^14.0.0",
-    "uint8arrays": "^3.0.0"
+    "uint8arrays": "^4.0.1"
   }
 }

--- a/packages/interface-transport-compliance-tests/package.json
+++ b/packages/interface-transport-compliance-tests/package.json
@@ -146,6 +146,6 @@
     "p-defer": "^4.0.0",
     "p-wait-for": "^5.0.0",
     "sinon": "^14.0.0",
-    "uint8arrays": "^4.0.1"
+    "uint8arrays": "^4.0.2"
   }
 }


### PR DESCRIPTION
`@libp2p/components` is a choke-point for our dependency graph as it depends on every interface, meaning when one interface revs a major `@libp2p/components` major has to change too which means every module depending on it also needs a major.

Switch instead to constructor injection of simple objects that let modules declare their dependencies on interfaces directly instead of indirectly via `@libp2p/components`

Refs https://github.com/libp2p/js-libp2p-components/issues/6

BREAKING CHANGE: modules no longer implement `Initializable` instead switching to constructor injection