### PR TITLE
feat: allow passing muxer factory to mock upgrader

### DIFF
--- a/packages/interface-mocks/src/connection.ts
+++ b/packages/interface-mocks/src/connection.ts
@@ -12,7 +12,7 @@ import * as mss from '@libp2p/multistream-select'
 import { logger } from '@libp2p/logger'
 import * as STATUS from '@libp2p/interface-connection/status'
 import type { Multiaddr } from '@multiformats/multiaddr'
-import type { StreamMuxer } from '@libp2p/interface-stream-muxer'
+import type { StreamMuxer, StreamMuxerFactory } from '@libp2p/interface-stream-muxer'
 import type { AbortOptions } from '@libp2p/interfaces'
 import errCode from 'err-code'
 import type { Uint8ArrayList } from 'uint8arraylist'
@@ -21,7 +21,8 @@ const log = logger('libp2p:mock-connection')
 
 export interface MockConnectionOptions {
   direction?: Direction
-  registrar?: Registrar
+  registrar?: Registrar,
+  muxerFactory?: StreamMuxerFactory
 }
 
 interface MockConnectionInit {
@@ -124,7 +125,7 @@ export function mockConnection (maConn: MultiaddrConnection, opts: MockConnectio
   const remotePeer = peerIdFromString(remotePeerIdStr)
   const direction = opts.direction ?? 'inbound'
   const registrar = opts.registrar ?? mockRegistrar()
-  const muxerFactory = mockMuxer()
+  const muxerFactory = opts.muxerFactory ?? mockMuxer()
 
   const muxer = muxerFactory.createStreamMuxer({
     direction: direction,

--- a/packages/interface-mocks/src/connection.ts
+++ b/packages/interface-mocks/src/connection.ts
@@ -21,7 +21,7 @@ const log = logger('libp2p:mock-connection')
 
 export interface MockConnectionOptions {
   direction?: Direction
-  registrar?: Registrar,
+  registrar?: Registrar
   muxerFactory?: StreamMuxerFactory
 }
 

--- a/packages/interface-mocks/src/upgrader.ts
+++ b/packages/interface-mocks/src/upgrader.ts
@@ -1,5 +1,5 @@
 import { mockConnection } from './connection.js'
-import type { Upgrader, UpgraderEvents } from '@libp2p/interface-transport'
+import type { Upgrader, UpgraderEvents, UpgraderOptions } from '@libp2p/interface-transport'
 import type { MultiaddrConnection } from '@libp2p/interface-connection'
 import type { Registrar } from '@libp2p/interface-registrar'
 import { EventEmitter } from '@libp2p/interfaces/events'
@@ -17,17 +17,19 @@ class MockUpgrader extends EventEmitter<UpgraderEvents> implements Upgrader {
     this.registrar = init.registrar
   }
 
-  async upgradeOutbound (multiaddrConnection: MultiaddrConnection) {
+  async upgradeOutbound (multiaddrConnection: MultiaddrConnection, opts: UpgraderOptions = {}) {
     return mockConnection(multiaddrConnection, {
       direction: 'outbound',
-      registrar: this.registrar
+      registrar: this.registrar,
+      ...opts
     })
   }
 
-  async upgradeInbound (multiaddrConnection: MultiaddrConnection) {
+  async upgradeInbound (multiaddrConnection: MultiaddrConnection, opts: UpgraderOptions = {}) {
     return mockConnection(multiaddrConnection, {
       direction: 'inbound',
-      registrar: this.registrar
+      registrar: this.registrar,
+      ...opts
     })
   }
 }


### PR DESCRIPTION
In order to support compliance testing transports that supply their own muxers/encryption allow passing `UpgraderOptions` to the `MockUpgrader` to be passed on to the `MockConnection`.