### PR TITLE
feat: add CodeError

### DIFF
--- a/packages/interfaces/src/errors.ts
+++ b/packages/interfaces/src/errors.ts
@@ -17,3 +17,18 @@ export class AbortError extends Error {
     return 'aborted'
   }
 }
+
+export class CodeError<T extends Record<string, any> = Record<string, never>> extends Error {
+  public readonly props: T
+
+  constructor (
+    message: string,
+    public readonly code: string,
+    props?: T
+  ) {
+    super(message)
+
+    this.name = 'CodeError'
+    this.props = props ?? {} as T // eslint-disable-line @typescript-eslint/consistent-type-assertions
+  }
+}

--- a/packages/interfaces/src/errors.ts
+++ b/packages/interfaces/src/errors.ts
@@ -28,7 +28,7 @@ export class CodeError<T extends Record<string, any> = Record<string, never>> ex
   ) {
     super(message)
 
-    this.name = 'CodeError'
+    this.name = props?.name ?? 'CodeError'
     this.props = props ?? {} as T // eslint-disable-line @typescript-eslint/consistent-type-assertions
   }
 }


### PR DESCRIPTION
Adds [CodeError](https://github.com/libp2p/js-libp2p/issues/1269) to errors.ts

Related: https://github.com/libp2p/js-libp2p-crypto/pull/284#issuecomment-1324005434

Added public to props and code to match AbortCode style.

Also recently added the custom [Error.name](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/name) property to [code-err](https://github.com/tabcat/code-err) implementation. Can remove it from this PR if not wanted.

@wemeetagain 