### PR TITLE
feat: expose supported peer id types

### DIFF
--- a/packages/interface-peer-id/src/index.ts
+++ b/packages/interface-peer-id/src/index.ts
@@ -1,8 +1,10 @@
 import type { CID } from 'multiformats/cid'
 import type { MultihashDigest } from 'multiformats/hashes/interface'
 
+export type PeerIdType = 'RSA' | 'Ed25519' | 'secp256k1'
+
 interface BasePeerId {
-  readonly type: 'RSA' | 'Ed25519' | 'secp256k1'
+  readonly type: PeerIdType
   readonly multihash: MultihashDigest
   readonly privateKey?: Uint8Array
   readonly publicKey?: Uint8Array


### PR DESCRIPTION
To reduce duplication elsewhere, expose supported PeerId types