### PR TITLE
docs: add interface docs

### DIFF
--- a/packages/interface-connection-manager/src/index.ts
+++ b/packages/interface-connection-manager/src/index.ts
@@ -5,18 +5,58 @@ import type { PeerId } from '@libp2p/interface-peer-id'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
 export interface ConnectionManagerEvents {
+  /**
+   * This event will be triggered anytime a new Connection is established to another peer.
+   *
+   * @example
+   *
+   * ```js
+   * libp2p.connectionManager.addEventListener('peer:connect', (event) => {
+   *   const connection = event.detail
+   *   // ...
+   * })
+   * ```
+   */
   'peer:connect': CustomEvent<Connection>
+
+  /**
+   * This event will be triggered anytime we are disconnected from another peer, regardless of
+   * the circumstances of that disconnection. If we happen to have multiple connections to a
+   * peer, this event will **only** be triggered when the last connection is closed.
+   *
+   * @example
+   *
+   * ```js
+   * libp2p.connectionManager.addEventListener('peer:disconnect', (event) => {
+   *   const connection = event.detail
+   *   // ...
+   * })
+   * ```
+   */
   'peer:disconnect': CustomEvent<Connection>
 }
 
 export interface ConnectionManager extends EventEmitter<ConnectionManagerEvents> {
   /**
    * Return connections, optionally filtering by a PeerId
+   *
+   * @example
+   *
+   * ```js
+   * const connections = libp2p.connectionManager.get(peerId)
+   * // []
+   * ```
    */
   getConnections: (peerId?: PeerId) => Connection[]
 
   /**
    * Open a connection to a remote peer
+   *
+   * @example
+   *
+   * ```js
+   * const connection = await libp2p.connectionManager.openConnection(peerId)
+   * ```
    */
   openConnection: (peer: PeerId, options?: AbortOptions) => Promise<Connection>
 

--- a/packages/interface-connection/src/index.ts
+++ b/packages/interface-connection/src/index.ts
@@ -74,32 +74,54 @@ export interface StreamStat {
  */
 export interface Stream extends Duplex<Uint8ArrayList, Uint8ArrayList | Uint8Array> {
   /**
-   * Close a stream for reading and writing
+   * Closes the stream for **reading** *and* **writing**.
+   *
+   * Any buffered data in the source can still be consumed and the stream will end normally.
+   *
+   * This will cause a `CLOSE` message to be sent to the remote, *unless* the sink has already ended.
+   *
+   * The sink and the source will return normally.
    */
   close: () => void
 
   /**
-   * Close a stream for reading only
+   * Closes the stream for **reading**. If iterating over the source of this stream in a `for await of` loop, it will return (exit the loop) after any buffered data has been consumed.
+   *
+   * This function is called automatically by the muxer when it receives a `CLOSE` message from the remote.
+   *
+   * The source will return normally, the sink will continue to consume.
    */
   closeRead: () => void
 
   /**
-   * Close a stream for writing only
+   * Closes the stream for **writing**. If iterating over the source of this stream in a `for await of` loop, it will return (exit the loop) after any buffered data has been consumed.
+   *
+   * The source will return normally, the sink will continue to consume.
    */
   closeWrite: () => void
 
   /**
-   * Call when a local error occurs, should close the stream for reading and writing
+   * Closes the stream for **reading** *and* **writing**. This should be called when a *local error* has occurred.
+   *
+   * Note, if called without an error any buffered data in the source can still be consumed and the stream will end normally.
+   *
+   * This will cause a `RESET` message to be sent to the remote, *unless* the sink has already ended.
+   *
+   * The sink will return and the source will throw if an error is passed or return normally if not.
    */
   abort: (err: Error) => void
 
   /**
-   * Call when a remote error occurs, should close the stream for reading and writing
+   * Closes the stream *immediately* for **reading** *and* **writing**. This should be called when a *remote error* has occurred.
+   *
+   * This function is called automatically by the muxer when it receives a `RESET` message from the remote.
+   *
+   * The sink will return and the source will throw.
    */
   reset: () => void
 
   /**
-   * Unique identifier for a stream
+   * Unique identifier for a stream. Identifiers are not unique across muxers.
    */
   id: string
 

--- a/packages/interface-content-routing/src/index.ts
+++ b/packages/interface-content-routing/src/index.ts
@@ -3,8 +3,60 @@ import type { AbortOptions } from '@libp2p/interfaces'
 import type { PeerInfo } from '@libp2p/interface-peer-info'
 
 export interface ContentRouting {
+  /**
+   * Iterates over all content routers in parallel, in order to notify it is a provider of the given key.
+   *
+   * @example
+   *
+   * ```js
+   * // ...
+   * await contentRouting.provide(cid)
+   * ```
+   */
   provide: (cid: CID, options?: AbortOptions) => Promise<void>
+
+  /**
+   * Iterates over all content routers in series to find providers of the given key.
+   *
+   * Once a content router succeeds, the iteration will stop. If the DHT is enabled, it will be queried first.
+   *
+   * @example
+   *
+   * ```js
+   * // Iterate over the providers found for the given cid
+   * for await (const provider of contentRouting.findProviders(cid)) {
+   *  console.log(provider.id, provider.multiaddrs)
+   * }
+   * ```
+   */
   findProviders: (cid: CID, options?: AbortOptions) => AsyncIterable<PeerInfo>
+
+  /**
+   * Writes a value to a key in the DHT.
+   *
+   * @example
+   *
+   * ```js
+   * // ...
+   * const key = '/key'
+   * const value = uint8ArrayFromString('oh hello there')
+   *
+   * await contentRouting.put(key, value)
+   * ```
+   */
   put: (key: Uint8Array, value: Uint8Array, options?: AbortOptions) => Promise<void>
+
+  /**
+   * Queries the DHT for a value stored for a given key.
+   *
+   * @example
+   *
+   * ```js
+   * // ...
+   *
+   * const key = '/key'
+   * const value = await contentRouting.get(key)
+   * ```
+   */
   get: (key: Uint8Array, options?: AbortOptions) => Promise<Uint8Array>
 }

--- a/packages/interface-keychain/src/index.ts
+++ b/packages/interface-keychain/src/index.ts
@@ -15,14 +15,92 @@ export interface KeyInfo {
 export type KeyType = 'Ed25519' | 'RSA'
 
 export interface KeyChain {
+  /**
+   * Export an existing key as a PEM encrypted PKCS #8 string.
+   *
+   * ```js
+   * await libp2p.keychain.createKey('keyTest', 'rsa', 4096)
+   * const pemKey = await libp2p.keychain.exportKey('keyTest', 'password123')
+   * ```
+   */
   exportKey: (name: string, password: string) => Promise<Multibase<'m'>>
+
+  /**
+   * Import a new key from a PEM encoded PKCS #8 string.
+   *
+   * ```js
+   * await libp2p.keychain.createKey('keyTest', 'rsa', 4096)
+   * const pemKey = await libp2p.keychain.exportKey('keyTest', 'password123')
+   * const keyInfo = await libp2p.keychain.importKey('keyTestImport', pemKey, 'password123')
+   * ```
+   */
   importKey: (name: string, pem: string, password: string) => Promise<KeyInfo>
 
+  /**
+   * Create a key in the keychain.
+   *
+   * @example
+   *
+   * ```js
+   * const keyInfo = await libp2p.keychain.createKey('keyTest', 'rsa', 4096)
+   * ```
+   */
   createKey: (name: string, type: KeyType, size?: number) => Promise<KeyInfo>
+
+  /**
+   * List all the keys.
+   *
+   * @example
+   *
+   * ```js
+   * const keyInfos = await libp2p.keychain.listKeys()
+   * ```
+   */
   listKeys: () => Promise<KeyInfo[]>
+
+  /**
+   * Removes a key from the keychain.
+   *
+   * @example
+   *
+   * ```js
+   * await libp2p.keychain.createKey('keyTest', 'rsa', 4096)
+   * const keyInfo = await libp2p.keychain.removeKey('keyTest')
+   * ```
+   */
   removeKey: (name: string) => Promise<KeyInfo>
+
+  /**
+   * Rename a key in the keychain.
+   *
+   * @example
+   *
+   * ```js
+   * await libp2p.keychain.createKey('keyTest', 'rsa', 4096)
+   * const keyInfo = await libp2p.keychain.renameKey('keyTest', 'keyNewNtest')
+   * ```
+   */
   renameKey: (oldName: string, newName: string) => Promise<KeyInfo>
 
+  /**
+   * Find a key by it's id.
+   *
+   * ```js
+   * const keyInfo = await libp2p.keychain.createKey('keyTest', 'rsa', 4096)
+   * const keyInfo2 = await libp2p.keychain.findKeyById(keyInfo.id)
+   * ```
+   */
   findKeyById: (id: string) => Promise<KeyInfo>
+
+  /**
+   * Find a key by it's name.
+   *
+   * @example
+   *
+   * ```js
+   * const keyInfo = await libp2p.keychain.createKey('keyTest', 'rsa', 4096)
+   * const keyInfo2 = await libp2p.keychain.findKeyByName('keyTest')
+   * ```
+   */
   findKeyByName: (name: string) => Promise<KeyInfo>
 }

--- a/packages/interface-peer-routing/src/index.ts
+++ b/packages/interface-peer-routing/src/index.ts
@@ -3,6 +3,31 @@ import type { PeerInfo } from '@libp2p/interface-peer-info'
 import type { AbortOptions } from '@libp2p/interfaces'
 
 export interface PeerRouting {
+  /**
+   * Iterates over all peer routers in series to find the given peer. If the DHT is enabled, it will be tried first.
+   *
+   * @example
+   *
+   * ```js
+   * // ...
+   * const peer = await peerRouting.findPeer(peerId, options)
+   * ```
+   */
   findPeer: (peerId: PeerId, options?: AbortOptions) => Promise<PeerInfo>
+
+  /**
+   * Iterates over all peer routers in series to get the closest peers of the given key.
+   *
+   * Once a content router succeeds, the iteration will stop. If the DHT is enabled, it will be queried first.
+   *
+   * @example
+   *
+   * ```js
+   * // Iterate over the closest peers found for the given key
+   * for await (const peer of peerRouting.getClosestPeers(key)) {
+   *   console.log(peer.id, peer.multiaddrs)
+   * }
+   * ```
+   */
   getClosestPeers: (key: Uint8Array, options?: AbortOptions) => AsyncIterable<PeerInfo>
 }

--- a/packages/interface-pubsub/src/index.ts
+++ b/packages/interface-pubsub/src/index.ts
@@ -153,15 +153,112 @@ export interface TopicValidatorFn {
 }
 
 export interface PubSub<Events extends { [s: string]: any } = PubSubEvents> extends EventEmitter<Events> {
+  /**
+   * The global signature policy controls whether or not we sill send and receive
+   * signed or unsigned messages.
+   *
+   * Signed messages prevent spoofing message senders and should be preferred to
+   * using unsigned messages.
+   */
   globalSignaturePolicy: typeof StrictSign | typeof StrictNoSign
+
+  /**
+   * A list of multicodecs that contain the pubsub protocol name.
+   */
   multicodecs: string[]
+
+  /**
+   * Pubsub routers support message validators per topic, which will validate the message
+   * before its propagations. They are stored in a map where keys are the topic name and
+   * values are the validators.
+   *
+   * @example
+   *
+   * ```js
+   * const topic = 'topic'
+   * const validateMessage = (msgTopic, msg) => {
+   *   const input = uint8ArrayToString(msg.data)
+   *   const validInputs = ['a', 'b', 'c']
+   *
+   *   if (!validInputs.includes(input)) {
+   *     throw new Error('no valid input received')
+   *   }
+   * }
+   * libp2p.pubsub.topicValidators.set(topic, validateMessage)
+   * ```
+   */
   topicValidators: Map<string, TopicValidatorFn>
 
   getPeers: () => PeerId[]
+
+  /**
+   * Gets a list of topics the node is subscribed to.
+   *
+   * ```js
+   * const topics = libp2p.pubsub.getTopics()
+   * ```
+   */
   getTopics: () => string[]
+
+  /**
+   * Subscribes to a pubsub topic.
+   *
+   * @example
+   *
+   * ```js
+   * const topic = 'topic'
+   * const handler = (msg) => {
+   *   if (msg.topic === topic) {
+   *     // msg.data - pubsub data received
+   *   }
+   * }
+   *
+   * libp2p.pubsub.addEventListener('message', handler)
+   * libp2p.pubsub.subscribe(topic)
+   * ```
+   */
   subscribe: (topic: string) => void
+
+  /**
+   * Unsubscribes from a pubsub topic.
+   *
+   * @example
+   *
+   * ```js
+   * const topic = 'topic'
+   * const handler = (msg) => {
+   *   // msg.data - pubsub data received
+   * }
+   *
+   * libp2p.pubsub.removeEventListener(topic handler)
+   * libp2p.pubsub.unsubscribe(topic)
+   * ```
+   */
   unsubscribe: (topic: string) => void
+
+  /**
+   * Gets a list of the PeerIds that are subscribed to one topic.
+   *
+   * @example
+   *
+   * ```js
+   * const peerIds = libp2p.pubsub.getSubscribers(topic)
+   * ```
+   */
   getSubscribers: (topic: string) => PeerId[]
+
+  /**
+   * Publishes messages to the given topic.
+   *
+   * @example
+   *
+   * ```js
+   * const topic = 'topic'
+   * const data = uint8ArrayFromString('data')
+   *
+   * await libp2p.pubsub.publish(topic, data)
+   * ```
+   */
   publish: (topic: string, data: Uint8Array) => Promise<PublishResult>
 }
 

--- a/packages/interface-stream-muxer/src/index.ts
+++ b/packages/interface-stream-muxer/src/index.ts
@@ -3,7 +3,14 @@ import type { Direction, Stream } from '@libp2p/interface-connection'
 import type { AbortOptions } from '@libp2p/interfaces'
 
 export interface StreamMuxerFactory {
+  /**
+   * The protocol used to select this muxer during connection opening
+   */
   protocol: string
+
+  /**
+   * Creates a new stream muxer to be used with a new connection
+   */
   createStreamMuxer: (init?: StreamMuxerInit) => StreamMuxer
 }
 
@@ -11,8 +18,14 @@ export interface StreamMuxerFactory {
  * A libp2p stream muxer
  */
 export interface StreamMuxer extends Duplex<Uint8Array> {
+  /**
+   * The protocol used to select this muxer during connection opening
+   */
   protocol: string
 
+  /**
+   * A list of streams that are currently open. Closed streams will not be returned.
+   */
   readonly streams: Stream[]
   /**
    * Initiate a new stream with the given name. If no name is
@@ -27,7 +40,14 @@ export interface StreamMuxer extends Duplex<Uint8Array> {
 }
 
 export interface StreamMuxerInit extends AbortOptions {
+  /**
+   * A callback function invoked every time an incoming stream is opened
+   */
   onIncomingStream?: (stream: Stream) => void
+
+  /**
+   * A callback function invoke every time a stream ends
+   */
   onStreamEnd?: (stream: Stream) => void
 
   /**


### PR DESCRIPTION
Adds interface docs from main libp2p repo so we can build them on demand instead of having to keep both sources up to date.