### PR TITLE
feat: add libp2p interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - [Structure](#structure)
 - [API Docs](#api-docs)
 - [License](#license)
-- [Contribute](#contribute)
+- [Contribution](#contribution)
 
 ## Structure
 
@@ -27,6 +27,7 @@
 - [`/packages/interface-dht`](./packages/interface-dht) DHT interface for libp2p
 - [`/packages/interface-keychain`](./packages/interface-keychain) Keychain interface for libp2p
 - [`/packages/interface-keys`](./packages/interface-keys) Keys interface for libp2p
+- [`/packages/interface-libp2p`](./packages/interface-libp2p) The interface implemented by a libp2p node
 - [`/packages/interface-metrics`](./packages/interface-metrics) Metrics interface for libp2p
 - [`/packages/interface-mocks`](./packages/interface-mocks) Mock implementations of several libp2p interfaces
 - [`/packages/interface-peer-discovery`](./packages/interface-peer-discovery) Peer Discovery interface for libp2p
@@ -57,6 +58,6 @@ Licensed under either of
 - Apache 2.0, ([LICENSE-APACHE](LICENSE-APACHE) / <http://www.apache.org/licenses/LICENSE-2.0>)
 - MIT ([LICENSE-MIT](LICENSE-MIT) / <http://opensource.org/licenses/MIT>)
 
-## Contribute
+## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/packages/interface-libp2p/CHANGELOG.md
+++ b/packages/interface-libp2p/CHANGELOG.md
@@ -1,0 +1,97 @@
+## [@libp2p/interface-metrics-v4.0.4](https://github.com/libp2p/js-libp2p-interfaces/compare/@libp2p/interface-metrics-v4.0.3...@libp2p/interface-metrics-v4.0.4) (2022-12-16)
+
+
+### Documentation
+
+* update project config ([#323](https://github.com/libp2p/js-libp2p-interfaces/issues/323)) ([0fc6a08](https://github.com/libp2p/js-libp2p-interfaces/commit/0fc6a08e9cdcefe361fe325281a3a2a03759ff59))
+
+## [@libp2p/interface-metrics-v4.0.3](https://github.com/libp2p/js-libp2p-interfaces/compare/@libp2p/interface-metrics-v4.0.2...@libp2p/interface-metrics-v4.0.3) (2022-12-14)
+
+
+### Bug Fixes
+
+* generate docs for all packages ([#321](https://github.com/libp2p/js-libp2p-interfaces/issues/321)) ([b6f8b32](https://github.com/libp2p/js-libp2p-interfaces/commit/b6f8b32a920c15a28fe021e6050e31aaae89d518))
+
+## [@libp2p/interface-metrics-v4.0.2](https://github.com/libp2p/js-libp2p-interfaces/compare/@libp2p/interface-metrics-v4.0.1...@libp2p/interface-metrics-v4.0.2) (2022-11-05)
+
+
+### Bug Fixes
+
+* metrics only need numbers ([#312](https://github.com/libp2p/js-libp2p-interfaces/issues/312)) ([0076c1f](https://github.com/libp2p/js-libp2p-interfaces/commit/0076c1f354ebc1106b6ac42d48688c0209866084))
+
+## [@libp2p/interface-metrics-v4.0.1](https://github.com/libp2p/js-libp2p-interfaces/compare/@libp2p/interface-metrics-v4.0.0...@libp2p/interface-metrics-v4.0.1) (2022-11-05)
+
+
+### Bug Fixes
+
+* update project config ([#311](https://github.com/libp2p/js-libp2p-interfaces/issues/311)) ([27dd0ce](https://github.com/libp2p/js-libp2p-interfaces/commit/27dd0ce3c249892ac69cbb24ddaf0b9f32385e37))
+
+## [@libp2p/interface-metrics-v4.0.0](https://github.com/libp2p/js-libp2p-interfaces/compare/@libp2p/interface-metrics-v3.0.0...@libp2p/interface-metrics-v4.0.0) (2022-11-05)
+
+
+### ⚠ BREAKING CHANGES
+
+* the global/per-peer moving average tracking has been removed from the interface as it's expensive and requires lots of timers - this functionality can be replicated by implementations if it's desirable.  It's better to have simple counters instead and let an external system like Prometheus or Graphana calculate the values over time
+
+### Features
+
+* return metrics objects from register instead of updating with an options object ([#310](https://github.com/libp2p/js-libp2p-interfaces/issues/310)) ([3b106ce](https://github.com/libp2p/js-libp2p-interfaces/commit/3b106ce799b5d84a82a66238995e09970ed8116c))
+
+## [@libp2p/interface-metrics-v3.0.0](https://github.com/libp2p/js-libp2p-interfaces/compare/@libp2p/interface-metrics-v2.0.0...@libp2p/interface-metrics-v3.0.0) (2022-08-07)
+
+
+### ⚠ BREAKING CHANGES
+
+* change stream muxer interface (#279)
+
+### Features
+
+* change stream muxer interface ([#279](https://github.com/libp2p/js-libp2p-interfaces/issues/279)) ([1ebe269](https://github.com/libp2p/js-libp2p-interfaces/commit/1ebe26988b6a286f36a4fc5177f502cfb60368a1))
+
+
+### Trivial Changes
+
+* update project config ([#271](https://github.com/libp2p/js-libp2p-interfaces/issues/271)) ([59c0bf5](https://github.com/libp2p/js-libp2p-interfaces/commit/59c0bf5e0b05496fca2e4902632b61bb41fad9e9))
+
+## [@libp2p/interface-metrics-v2.0.0](https://github.com/libp2p/js-libp2p-interfaces/compare/@libp2p/interface-metrics-v1.0.3...@libp2p/interface-metrics-v2.0.0) (2022-07-01)
+
+
+### ⚠ BREAKING CHANGES
+
+* the return type of `metrics.getComponentMetrics` has been changed to include optional labels/help text and also is now a function that returns a single or group value
+
+### Features
+
+* add metrics groups ([#267](https://github.com/libp2p/js-libp2p-interfaces/issues/267)) ([b9d898a](https://github.com/libp2p/js-libp2p-interfaces/commit/b9d898abdb551ebe2e0e961ec325d5e6abcf4fab)), closes [#257](https://github.com/libp2p/js-libp2p-interfaces/issues/257) [#258](https://github.com/libp2p/js-libp2p-interfaces/issues/258)
+
+## [@libp2p/interface-metrics-v1.0.3](https://github.com/libp2p/js-libp2p-interfaces/compare/@libp2p/interface-metrics-v1.0.2...@libp2p/interface-metrics-v1.0.3) (2022-06-27)
+
+
+### Trivial Changes
+
+* update deps ([#262](https://github.com/libp2p/js-libp2p-interfaces/issues/262)) ([51edf7d](https://github.com/libp2p/js-libp2p-interfaces/commit/51edf7d9b3765a6f75c915b1483ea345d0133a41))
+
+## [@libp2p/interface-metrics-v1.0.2](https://github.com/libp2p/js-libp2p-interfaces/compare/@libp2p/interface-metrics-v1.0.1...@libp2p/interface-metrics-v1.0.2) (2022-06-14)
+
+
+### Trivial Changes
+
+* update aegir ([#234](https://github.com/libp2p/js-libp2p-interfaces/issues/234)) ([3e03895](https://github.com/libp2p/js-libp2p-interfaces/commit/3e038959ecab6cfa3585df9ee179c0af7a61eda5))
+
+## [@libp2p/interface-metrics-v1.0.1](https://github.com/libp2p/js-libp2p-interfaces/compare/@libp2p/interface-metrics-v1.0.0...@libp2p/interface-metrics-v1.0.1) (2022-06-14)
+
+
+### Trivial Changes
+
+* update readmes ([#233](https://github.com/libp2p/js-libp2p-interfaces/issues/233)) ([ee7da38](https://github.com/libp2p/js-libp2p-interfaces/commit/ee7da38dccc08160d26c8436df8739ce7e0b340e))
+
+## @libp2p/interface-metrics-v1.0.0 (2022-06-14)
+
+
+### ⚠ BREAKING CHANGES
+
+* most modules have been split out of the `@libp2p/interfaces` and `@libp2p/interface-compliance-tests` packages
+
+### Trivial Changes
+
+* break modules apart ([#232](https://github.com/libp2p/js-libp2p-interfaces/issues/232)) ([385614e](https://github.com/libp2p/js-libp2p-interfaces/commit/385614e772329052ab17415c8bd421f65b01a61b)), closes [#226](https://github.com/libp2p/js-libp2p-interfaces/issues/226)

--- a/packages/interface-libp2p/LICENSE
+++ b/packages/interface-libp2p/LICENSE
@@ -1,0 +1,4 @@
+This project is dual licensed under MIT and Apache-2.0.
+
+MIT: https://www.opensource.org/licenses/mit
+Apache-2.0: https://www.apache.org/licenses/license-2.0

--- a/packages/interface-libp2p/LICENSE-APACHE
+++ b/packages/interface-libp2p/LICENSE-APACHE
@@ -1,0 +1,5 @@
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/packages/interface-libp2p/LICENSE-MIT
+++ b/packages/interface-libp2p/LICENSE-MIT
@@ -1,0 +1,19 @@
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/interface-libp2p/README.md
+++ b/packages/interface-libp2p/README.md
@@ -1,0 +1,36 @@
+# @libp2p/interface-libp2p <!-- omit in toc -->
+
+[![libp2p.io](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
+[![Discuss](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg?style=flat-square)](https://discuss.libp2p.io)
+[![codecov](https://img.shields.io/codecov/c/github/libp2p/js-libp2p-interfaces.svg?style=flat-square)](https://codecov.io/gh/libp2p/js-libp2p-interfaces)
+[![CI](https://img.shields.io/github/actions/workflow/status/libp2p/js-libp2p-interfaces/js-test-and-release.yml?branch=master\&style=flat-square)](https://github.com/libp2p/js-libp2p-interfaces/actions/workflows/js-test-and-release.yml?query=branch%3Amaster)
+
+> The interface implemented by a libp2p node
+
+## Table of contents <!-- omit in toc -->
+
+- [Install](#install)
+- [API Docs](#api-docs)
+- [License](#license)
+- [Contribution](#contribution)
+
+## Install
+
+```console
+$ npm i @libp2p/interface-libp2p
+```
+
+## API Docs
+
+- <https://libp2p.github.io/js-libp2p-interfaces/modules/_libp2p_interface_libp2p.html>
+
+## License
+
+Licensed under either of
+
+- Apache 2.0, ([LICENSE-APACHE](LICENSE-APACHE) / <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT ([LICENSE-MIT](LICENSE-MIT) / <http://opensource.org/licenses/MIT>)
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/packages/interface-libp2p/package.json
+++ b/packages/interface-libp2p/package.json
@@ -133,7 +133,6 @@
   },
   "dependencies": {
     "@libp2p/interface-connection": "^3.0.0",
-    "@libp2p/interface-connection-manager": "^1.0.0",
     "@libp2p/interface-content-routing": "^1.0.0",
     "@libp2p/interface-dht": "^1.0.0",
     "@libp2p/interface-keychain": "^1.0.0",

--- a/packages/interface-libp2p/package.json
+++ b/packages/interface-libp2p/package.json
@@ -1,0 +1,156 @@
+{
+  "name": "@libp2p/interface-libp2p",
+  "version": "0.0.0",
+  "description": "The interface implemented by a libp2p node",
+  "license": "Apache-2.0 OR MIT",
+  "homepage": "https://github.com/libp2p/js-libp2p-interfaces/tree/master/packages/interface-libp2p#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/libp2p/js-libp2p-interfaces.git"
+  },
+  "bugs": {
+    "url": "https://github.com/libp2p/js-libp2p-interfaces/issues"
+  },
+  "keywords": [
+    "interface",
+    "libp2p"
+  ],
+  "engines": {
+    "node": ">=16.0.0",
+    "npm": ">=7.0.0"
+  },
+  "type": "module",
+  "types": "./dist/src/index.d.ts",
+  "files": [
+    "src",
+    "dist",
+    "!dist/test",
+    "!**/*.tsbuildinfo"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js"
+    }
+  },
+  "eslintConfig": {
+    "extends": "ipfs",
+    "parserOptions": {
+      "sourceType": "module"
+    }
+  },
+  "release": {
+    "branches": [
+      "master"
+    ],
+    "plugins": [
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "preset": "conventionalcommits",
+          "releaseRules": [
+            {
+              "breaking": true,
+              "release": "major"
+            },
+            {
+              "revert": true,
+              "release": "patch"
+            },
+            {
+              "type": "feat",
+              "release": "minor"
+            },
+            {
+              "type": "fix",
+              "release": "patch"
+            },
+            {
+              "type": "docs",
+              "release": "patch"
+            },
+            {
+              "type": "test",
+              "release": "patch"
+            },
+            {
+              "type": "deps",
+              "release": "patch"
+            },
+            {
+              "scope": "no-release",
+              "release": false
+            }
+          ]
+        }
+      ],
+      [
+        "@semantic-release/release-notes-generator",
+        {
+          "preset": "conventionalcommits",
+          "presetConfig": {
+            "types": [
+              {
+                "type": "feat",
+                "section": "Features"
+              },
+              {
+                "type": "fix",
+                "section": "Bug Fixes"
+              },
+              {
+                "type": "chore",
+                "section": "Trivial Changes"
+              },
+              {
+                "type": "docs",
+                "section": "Documentation"
+              },
+              {
+                "type": "deps",
+                "section": "Dependencies"
+              },
+              {
+                "type": "test",
+                "section": "Tests"
+              }
+            ]
+          }
+        }
+      ],
+      "@semantic-release/changelog",
+      "@semantic-release/npm",
+      "@semantic-release/github",
+      "@semantic-release/git"
+    ]
+  },
+  "scripts": {
+    "clean": "aegir clean",
+    "lint": "aegir lint",
+    "dep-check": "aegir dep-check",
+    "build": "aegir build",
+    "release": "aegir release"
+  },
+  "dependencies": {
+    "@libp2p/interface-connection": "^3.0.0",
+    "@libp2p/interface-connection-manager": "^1.0.0",
+    "@libp2p/interface-content-routing": "^1.0.0",
+    "@libp2p/interface-dht": "^1.0.0",
+    "@libp2p/interface-keychain": "^1.0.0",
+    "@libp2p/interface-metrics": "^4.0.0",
+    "@libp2p/interface-peer-id": "^1.0.0",
+    "@libp2p/interface-peer-info": "^1.0.0",
+    "@libp2p/interface-peer-routing": "^1.0.0",
+    "@libp2p/interface-peer-store": "^1.0.0",
+    "@libp2p/interface-pubsub": "^3.0.0",
+    "@libp2p/interface-registrar": "^2.0.0",
+    "@libp2p/interfaces": "^3.0.0",
+    "@multiformats/multiaddr": "^11.0.0"
+  },
+  "devDependencies": {
+    "aegir": "^37.7.3"
+  },
+  "typedoc": {
+    "entryPoint": "./src/index.ts"
+  }
+}

--- a/packages/interface-libp2p/src/index.ts
+++ b/packages/interface-libp2p/src/index.ts
@@ -179,7 +179,6 @@ export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
    *
    * @example
    *
-   *
    * ```js
    * for await (const event of libp2p.dht.findPeer(peerId)) {
    *   // ...
@@ -190,13 +189,7 @@ export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
 
   /**
    * The fetch service allows registering and unregistering functions that supply
-   * values for fetch queries - {@see https://github.com/libp2p/specs/tree/master/fetch }
-   *
-   * @example
-   *
-   * ```js
-   * libp2p.fetchService.registerLookupFunction('/prefix', (key) => { ... })
-   * ```
+   * values for fetch queries - see the [fetch spec](https://github.com/libp2p/specs/tree/master/fetch).
    */
   fetchService: {
     /**

--- a/packages/interface-libp2p/src/index.ts
+++ b/packages/interface-libp2p/src/index.ts
@@ -1,0 +1,229 @@
+/**
+ * @packageDocumentation
+ *
+ * Use the `createLibp2p` function to create a libp2p node.
+ *
+ * @example
+ *
+ * ```typescript
+ * import { createLibp2p } from 'libp2p'
+ *
+ * const node = await createLibp2p({
+ *   // ...other options
+ * })
+ * ```
+ */
+
+import type { AbortOptions } from '@libp2p/interfaces'
+import type { EventEmitter } from '@libp2p/interfaces/events'
+import type { Startable } from '@libp2p/interfaces/startable'
+import type { Multiaddr } from '@multiformats/multiaddr'
+import type { DualDHT } from '@libp2p/interface-dht'
+import type { PeerStore } from '@libp2p/interface-peer-store'
+import type { PeerId } from '@libp2p/interface-peer-id'
+import type { Connection, Stream } from '@libp2p/interface-connection'
+import type { PeerRouting } from '@libp2p/interface-peer-routing'
+import type { ContentRouting } from '@libp2p/interface-content-routing'
+import type { PubSub } from '@libp2p/interface-pubsub'
+import type { Registrar, StreamHandler, StreamHandlerOptions } from '@libp2p/interface-registrar'
+import type { ConnectionManager } from '@libp2p/interface-connection-manager'
+import type { Metrics } from '@libp2p/interface-metrics'
+import type { PeerInfo } from '@libp2p/interface-peer-info'
+import type { KeyChain } from '@libp2p/interface-keychain'
+
+/**
+ * Once you have a libp2p instance, you can listen to several events it emits, so that you can be notified of relevant network events.
+ */
+export interface Libp2pEvents {
+  /**
+   * @example
+   *
+   * ```js
+   * libp2p.addEventListener('peer:discovery', (event) => {
+   *    const peerInfo = event.detail
+   *    // ...
+   * })
+   * ```
+   */
+  'peer:discovery': CustomEvent<PeerInfo>
+}
+
+/**
+ * Fetch service lookup function
+ */
+export interface LookupFunction {
+  (key: string): Promise<Uint8Array | null>
+}
+
+export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
+  peerId: PeerId
+  peerStore: PeerStore
+  peerRouting: PeerRouting
+  contentRouting: ContentRouting
+  keychain: KeyChain
+  connectionManager: ConnectionManager
+  registrar: Registrar
+  metrics?: Metrics
+  pubsub: PubSub
+  dht: DualDHT
+  fetchService: {
+    registerLookupFunction: (prefix: string, lookup: LookupFunction) => void
+    unregisterLookupFunction: (prefix: string, lookup?: LookupFunction) => void
+  }
+
+  /**
+   * Get a deduplicated list of peer advertising multiaddrs by concatenating
+   * the listen addresses used by transports with any configured
+   * announce addresses as well as observed addresses reported by peers.
+   *
+   * If Announce addrs are specified, configured listen addresses will be
+   * ignored though observed addresses will still be included.
+   *
+   * @example
+   *
+   * ```js
+   * // ...
+   * const listenMa = libp2p.getMultiaddrs()
+   * // [ <Multiaddr 047f00000106f9ba - /ip4/127.0.0.1/tcp/63930> ]
+   * ```
+   */
+  getMultiaddrs: () => Multiaddr[]
+
+  /**
+   * Return a list of all connections this node has open, optionally filtering
+   * by a PeerId
+   *
+   * @example
+   *
+   * ```js
+   * for (const connection of libp2p.getConnections()) {
+   *   console.log(peerId, connection.remoteAddr.toString())
+   *   // Logs the PeerId string and the observed remote multiaddr of each Connection
+   * }
+   * ```
+   */
+  getConnections: (peerId?: PeerId) => Connection[]
+
+  /**
+   * Return a list of all peers we currently have a connection open to
+   */
+  getPeers: () => PeerId[]
+
+  /**
+   * Dials to the provided peer. If successful, the known metadata of the
+   * peer will be added to the nodes `peerStore`.
+   *
+   * If a PeerId is passed as the first argument, the peer will need to have known multiaddrs for it in the PeerStore.
+   *
+   * @example
+   *
+   * ```js
+   * // ...
+   * const conn = await libp2p.dial(remotePeerId)
+   *
+   * // create a new stream within the connection
+   * const { stream, protocol } = await conn.newStream(['/echo/1.1.0', '/echo/1.0.0'])
+   *
+   * // protocol negotiated: 'echo/1.0.0' means that the other party only supports the older version
+   *
+   * // ...
+   * await conn.close()
+   * ```
+   */
+  dial: (peer: PeerId | Multiaddr, options?: AbortOptions) => Promise<Connection>
+
+  /**
+   * Dials to the provided peer and tries to handshake with the given protocols in order.
+   * If successful, the known metadata of the peer will be added to the nodes `peerStore`,
+   * and the `MuxedStream` will be returned together with the successful negotiated protocol.
+   *
+   * @example
+   *
+   * ```js
+   * // ...
+   * import { pipe } from 'it-pipe'
+   *
+   * const { stream, protocol } = await libp2p.dialProtocol(remotePeerId, protocols)
+   *
+   * // Use this new stream like any other duplex stream
+   * pipe([1, 2, 3], stream, consume)
+   * ```
+   */
+  dialProtocol: (peer: PeerId | Multiaddr, protocols: string | string[], options?: AbortOptions) => Promise<Stream>
+
+  /**
+   * Attempts to gracefully close an open connection to the given peer. If the connection is not closed in the grace period, it will be forcefully closed.
+   *
+   * @example
+   *
+   * ```js
+   * // ...
+   * await libp2p.hangUp(remotePeerId)
+   * ```
+   */
+  hangUp: (peer: PeerId | Multiaddr) => Promise<void>
+
+  /**
+   * Sets up [multistream-select routing](https://github.com/multiformats/multistream-select) of protocols to their application handlers. Whenever a stream is opened on one of the provided protocols, the handler will be called. `handle` must be called in order to register a handler and support for a given protocol. This also informs other peers of the protocols you support.
+   *
+   * `libp2p.handle(protocols, handler, options)`
+   *
+   * In the event of a new handler for the same protocol being added, the first one is discarded.
+   *
+   * @example
+   *
+   * ```js
+   * // ...
+   * const handler = ({ connection, stream, protocol }) => {
+   *   // use stream or connection according to the needs
+   * }
+   *
+   * libp2p.handle('/echo/1.0.0', handler, {
+   *   maxInboundStreams: 5,
+   *   maxOutboundStreams: 5
+   * })
+   * ```
+   */
+  handle: (protocol: string | string[], handler: StreamHandler, options?: StreamHandlerOptions) => Promise<void>
+
+  /**
+   * Removes the handler for each protocol. The protocol
+   * will no longer be supported on streams.
+   *
+   * @example
+   *
+   * ```js
+   * // ...
+   * libp2p.unhandle(['/echo/1.0.0'])
+   * ```
+   */
+  unhandle: (protocols: string[] | string) => Promise<void>
+
+  /**
+   * Pings the given peer in order to obtain the operation latency
+   *
+   * @example
+   *
+   * ```js
+   * // ...
+   * const latency = await libp2p.ping(otherPeerId)
+   * ```
+   */
+  ping: (peer: PeerId | Multiaddr, options?: AbortOptions) => Promise<number>
+
+  /**
+   * Sends a request to fetch the value associated with the given key from the given peer.
+   *
+   * ```js
+   * // ...
+   * const value = await libp2p.fetch(otherPeerId, '/some/key')
+   * ```
+   */
+  fetch: (peer: PeerId | Multiaddr, key: string, options?: AbortOptions) => Promise<Uint8Array | null>
+
+  /**
+   * Returns the public key for the passed PeerId. If the PeerId is of the 'RSA' type
+   * this may mean searching the DHT if the key is not present in the KeyStore.
+   */
+  getPublicKey: (peer: PeerId, options?: AbortOptions) => Promise<Uint8Array>
+}

--- a/packages/interface-libp2p/src/index.ts
+++ b/packages/interface-libp2p/src/index.ts
@@ -1,16 +1,16 @@
 /**
  * @packageDocumentation
  *
- * Use the `createLibp2p` function to create a libp2p node.
+ * Exports a `Libp2p` type for modules to use as a type argument.
  *
  * @example
  *
  * ```typescript
- * import { createLibp2p } from 'libp2p'
+ * import type { Libp2p } from '@libp2p/interface-libp2p'
  *
- * const node = await createLibp2p({
- *   // ...other options
- * })
+ * function doSomethingWithLibp2p (node: Libp2p) {
+ *   // ...
+ * }
  * ```
  */
 
@@ -25,8 +25,7 @@ import type { Connection, Stream } from '@libp2p/interface-connection'
 import type { PeerRouting } from '@libp2p/interface-peer-routing'
 import type { ContentRouting } from '@libp2p/interface-content-routing'
 import type { PubSub } from '@libp2p/interface-pubsub'
-import type { Registrar, StreamHandler, StreamHandlerOptions } from '@libp2p/interface-registrar'
-import type { ConnectionManager } from '@libp2p/interface-connection-manager'
+import type { StreamHandler, StreamHandlerOptions } from '@libp2p/interface-registrar'
 import type { Metrics } from '@libp2p/interface-metrics'
 import type { PeerInfo } from '@libp2p/interface-peer-info'
 import type { KeyChain } from '@libp2p/interface-keychain'
@@ -55,19 +54,175 @@ export interface LookupFunction {
   (key: string): Promise<Uint8Array | null>
 }
 
+/**
+ * Libp2p nodes implement this interface.
+ */
 export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
+  /**
+   * The PeerId is a unique identifier for a node on the network.
+   *
+   * It is the hash of an RSA public key or, for Ed25519 or secp256k1 keys,
+   * the key itself.
+   *
+   * @example
+   *
+   * ```js
+   * console.info(libp2p.peerId)
+   * // PeerId(12D3Foo...)
+   * ````
+   */
   peerId: PeerId
+
+  /**
+   * The peer store holds information we know about other peers on the network.
+   * - multiaddrs, supported protocols, etc.
+   *
+   * @example
+   *
+   * ```js
+   * const peer = await libp2p.peerStore.get(peerId)
+   * console.info(peer)
+   * // { id: PeerId(12D3Foo...), addresses: [] ... }
+   * ```
+   */
   peerStore: PeerStore
+
+  /**
+   * The peer routing subsystem allows the user to find peers on the network
+   * or to find peers close to binary keys.
+   *
+   * @example
+   *
+   * ```js
+   * const peerInfo = await libp2p.peerRouting.findPeer(peerId)
+   * console.info(peerInfo)
+   * // { id: PeerId(12D3Foo...), multiaddrs: [] ... }
+   * ```
+   *
+   * @example
+   *
+   * ```js
+   * for await (const peerInfo of libp2p.peerRouting.getClosestPeers(key)) {
+   *   console.info(peerInfo)
+   *   // { id: PeerId(12D3Foo...), multiaddrs: [] ... }
+   * }
+   * ```
+   */
   peerRouting: PeerRouting
+
+  /**
+   * The content routing subsystem allows the user to find providers for content,
+   * let the network know they are providers for content, and get/put values to
+   * the DHT.
+   *
+   * @example
+   *
+   * ```js
+   * for await (const peerInfo of libp2p.contentRouting.findProviders(cid)) {
+   *   console.info(peerInfo)
+   *   // { id: PeerId(12D3Foo...), multiaddrs: [] ... }
+   * }
+   * ```
+   */
   contentRouting: ContentRouting
+
+  /**
+   * The keychain contains the keys used by the current node, and can create new
+   * keys, export them, import them, etc.
+   *
+   * @example
+   *
+   * ```js
+   * const keyInfo = await libp2p.keychain.createKey('new key')
+   * console.info(keyInfo)
+   * // { id: '...', name: 'new key' }
+   * ```
+   */
   keychain: KeyChain
-  connectionManager: ConnectionManager
-  registrar: Registrar
+
+  /**
+   * The metrics subsystem allows recording values to assess the health/performance
+   * of the running node.
+   *
+   * @example
+   *
+   * ```js
+   * const metric = libp2p.registerMetric({
+   *   'my-metric'
+   * })
+   *
+   * // later
+   * metric.update(5)
+   * ```
+   */
   metrics?: Metrics
+
+  /**
+   * The pubsub component implements a distributed [Publish-subscribe](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern)
+   * network made up of libp2p nodes listening on various topics.
+   *
+   * @example
+   *
+   * ```js
+   * libp2p.pubsub.addEventListener('message', (event) => {
+   *   // ...
+   * })
+   * libp2p.pubsub.subscribe('my-topic')
+   * ```
+   */
   pubsub: PubSub
+
+  /**
+   * The [DHT](https://en.wikipedia.org/wiki/Distributed_hash_table) is used by
+   * libp2p to store and find values such as provider records and also to discover
+   * information about peers.
+   *
+   * @example
+   *
+   *
+   * ```js
+   * for await (const event of libp2p.dht.findPeer(peerId)) {
+   *   // ...
+   * }
+   * ```
+   */
   dht: DualDHT
+
+  /**
+   * The fetch service allows registering and unregistering functions that supply
+   * values for fetch queries - {@see https://github.com/libp2p/specs/tree/master/fetch }
+   *
+   * @example
+   *
+   * ```js
+   * libp2p.fetchService.registerLookupFunction('/prefix', (key) => { ... })
+   * ```
+   */
   fetchService: {
+    /**
+     * Registers a new lookup callback that can map keys to values, for a given set of keys that
+     * share the same prefix
+     *
+     * @example
+     *
+     * ```js
+     * // ...
+     * libp2p.fetchService.registerLookupFunction('/prefix', (key) => { ... })
+     * ```
+     */
     registerLookupFunction: (prefix: string, lookup: LookupFunction) => void
+
+    /**
+     * Registers a new lookup callback that can map keys to values, for a given set of keys that
+     * share the same prefix.
+     *
+     * @example
+     *
+     * ```js
+     * // ...
+     * libp2p.fetchService.unregisterLookupFunction('/prefix')
+     * ```
+     */
     unregisterLookupFunction: (prefix: string, lookup?: LookupFunction) => void
   }
 

--- a/packages/interface-libp2p/src/index.ts
+++ b/packages/interface-libp2p/src/index.ts
@@ -206,7 +206,6 @@ export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
      * @example
      *
      * ```js
-     * // ...
      * libp2p.fetchService.registerLookupFunction('/prefix', (key) => { ... })
      * ```
      */
@@ -219,7 +218,6 @@ export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
      * @example
      *
      * ```js
-     * // ...
      * libp2p.fetchService.unregisterLookupFunction('/prefix')
      * ```
      */
@@ -237,7 +235,6 @@ export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
    * @example
    *
    * ```js
-   * // ...
    * const listenMa = libp2p.getMultiaddrs()
    * // [ <Multiaddr 047f00000106f9ba - /ip4/127.0.0.1/tcp/63930> ]
    * ```
@@ -273,7 +270,6 @@ export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
    * @example
    *
    * ```js
-   * // ...
    * const conn = await libp2p.dial(remotePeerId)
    *
    * // create a new stream within the connection
@@ -295,7 +291,6 @@ export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
    * @example
    *
    * ```js
-   * // ...
    * import { pipe } from 'it-pipe'
    *
    * const { stream, protocol } = await libp2p.dialProtocol(remotePeerId, protocols)
@@ -312,7 +307,6 @@ export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
    * @example
    *
    * ```js
-   * // ...
    * await libp2p.hangUp(remotePeerId)
    * ```
    */
@@ -328,7 +322,6 @@ export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
    * @example
    *
    * ```js
-   * // ...
    * const handler = ({ connection, stream, protocol }) => {
    *   // use stream or connection according to the needs
    * }
@@ -348,7 +341,6 @@ export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
    * @example
    *
    * ```js
-   * // ...
    * libp2p.unhandle(['/echo/1.0.0'])
    * ```
    */
@@ -360,7 +352,6 @@ export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
    * @example
    *
    * ```js
-   * // ...
    * const latency = await libp2p.ping(otherPeerId)
    * ```
    */
@@ -369,8 +360,9 @@ export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
   /**
    * Sends a request to fetch the value associated with the given key from the given peer.
    *
+   * @example
+   *
    * ```js
-   * // ...
    * const value = await libp2p.fetch(otherPeerId, '/some/key')
    * ```
    */

--- a/packages/interface-libp2p/tsconfig.json
+++ b/packages/interface-libp2p/tsconfig.json
@@ -1,0 +1,50 @@
+{
+  "extends": "aegir/src/config/tsconfig.aegir.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../interface-connection"
+    },
+    {
+      "path": "../interface-connection-manager"
+    },
+    {
+      "path": "../interface-content-routing"
+    },
+    {
+      "path": "../interface-dht"
+    },
+    {
+      "path": "../interface-keychain"
+    },
+    {
+      "path": "../interface-metrics"
+    },
+    {
+      "path": "../interface-peer-id"
+    },
+    {
+      "path": "../interface-peer-info"
+    },
+    {
+      "path": "../interface-peer-routing"
+    },
+    {
+      "path": "../interface-peer-store"
+    },
+    {
+      "path": "../interface-pubsub"
+    },
+    {
+      "path": "../interface-registrar"
+    },
+    {
+      "path": "../interfaces"
+    }
+  ]
+}

--- a/packages/interfaces/src/errors.ts
+++ b/packages/interfaces/src/errors.ts
@@ -1,4 +1,9 @@
 
+/**
+ * When this error is thrown it means an operation was aborted,
+ * usually in response to the `abort` event being emitted by an
+ * AbortSignal.
+ */
 export class AbortError extends Error {
   public readonly code: string
   public readonly type: string

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -1,9 +1,30 @@
 
+/**
+ * An object that contains an AbortSignal as
+ * the optional `signal` property.
+ *
+ * @example
+ *
+ * ```js
+ * const controller = new AbortController()
+ *
+ * aLongRunningOperation({
+ *   signal: controller.signal
+ * })
+ *
+ * // later
+ *
+ * controller.abort()
+ */
 export interface AbortOptions {
   signal?: AbortSignal
 }
 
-// Borrowed from the tsdef module
+/**
+ * Returns a new type with all fields marked optional.
+ *
+ * Borrowed from the tsdef module.
+ */
 export type RecursivePartial<T> = {
   [P in keyof T]?: T[P] extends Array<infer I> ? Array<RecursivePartial<I>> : T[P] extends (...args: any[]) => any ? T[P] : RecursivePartial<T[P]>
 }


### PR DESCRIPTION
Adds the interface that libp2p node instance implement so other modules can show what version of libp2p they support without having to depend on libp2p directly.