### PR TITLE
fix: refactor peer discovery compliance test

### DIFF
--- a/packages/interface-peer-discovery-compliance-tests/src/index.ts
+++ b/packages/interface-peer-discovery-compliance-tests/src/index.ts
@@ -1,88 +1,90 @@
-import { expect } from 'aegir/chai'
-import { isMultiaddr } from '@multiformats/multiaddr'
-import delay from 'delay'
-import pDefer from 'p-defer'
-import { start, stop } from '@libp2p/interfaces/startable'
-import type { TestSetup } from '@libp2p/interface-compliance-tests'
-import type { PeerDiscovery } from '@libp2p/interface-peer-discovery'
+import { expect } from "aegir/chai";
+import { isMultiaddr } from "@multiformats/multiaddr";
+import delay from "delay";
+import pDefer from "p-defer";
+import { start, stop } from "@libp2p/interfaces/startable";
+import type { TestSetup } from "@libp2p/interface-compliance-tests";
+import type { PeerDiscovery } from "@libp2p/interface-peer-discovery";
 
 export default (common: TestSetup<PeerDiscovery>) => {
-  describe('interface-peer-discovery compliance tests', () => {
-    let discovery: PeerDiscovery
+  describe("interface-peer-discovery compliance tests", () => {
+    let discovery: PeerDiscovery;
 
     beforeEach(async () => {
-      discovery = await common.setup()
-    })
+      discovery = await common.setup();
+    });
 
-    afterEach('ensure discovery was stopped', async () => {
-      await stop(discovery)
+    afterEach("ensure discovery was stopped", async () => {
+      await stop(discovery);
 
-      await common.teardown()
-    })
+      await common.teardown();
+    });
 
-    it('can start the service', async () => {
-      await start(discovery)
-    })
+    it("can start the service", async () => {
+      await start(discovery);
+    });
 
-    it('can start and stop the service', async () => {
-      await start(discovery)
-      await stop(discovery)
-    })
+    it("can start and stop the service", async () => {
+      await start(discovery);
+      await stop(discovery);
+    });
 
-    it('should not fail to stop the service if it was not started', async () => {
-      await stop(discovery)
-    })
+    it("should not fail to stop the service if it was not started", async () => {
+      await stop(discovery);
+    });
 
-    it('should not fail to start the service if it is already started', async () => {
-      await start(discovery)
-      await start(discovery)
-    })
+    it("should not fail to start the service if it is already started", async () => {
+      await start(discovery);
+      await start(discovery);
+    });
 
-    it('should emit a peer event after start', async () => {
-      const defer = pDefer()
+    it("should emit a peer event after start", async () => {
+      const defer = pDefer();
 
-      await start(discovery)
+      discovery.addEventListener("peer", (evt) => {
+        const { id, multiaddrs } = evt.detail;
+        expect(id).to.exist();
+        expect(id)
+          .to.have.property("type")
+          .that.is.oneOf(["RSA", "Ed25519", "secp256k1"]);
+        expect(multiaddrs).to.exist();
 
-      discovery.addEventListener('peer', (evt) => {
-        const { id, multiaddrs } = evt.detail
-        expect(id).to.exist()
-        expect(id).to.have.property('type').that.is.oneOf(['RSA', 'Ed25519', 'secp256k1'])
-        expect(multiaddrs).to.exist()
+        multiaddrs.forEach((m) => expect(isMultiaddr(m)).to.eql(true));
 
-        multiaddrs.forEach((m) => expect(isMultiaddr(m)).to.eql(true))
+        defer.resolve();
+      });
 
-        defer.resolve()
-      })
+      await start(discovery);
 
-      await defer.promise
-    })
+      await defer.promise;
+    });
 
-    it('should not receive a peer event before start', async () => {
-      discovery.addEventListener('peer', () => {
-        throw new Error('should not receive a peer event before start')
-      })
+    it("should not receive a peer event before start", async () => {
+      discovery.addEventListener("peer", () => {
+        throw new Error("should not receive a peer event before start");
+      });
 
-      await delay(2000)
-    })
+      await delay(2000);
+    });
 
-    it('should not receive a peer event after stop', async () => {
-      const deferStart = pDefer()
+    it("should not receive a peer event after stop", async () => {
+      const deferStart = pDefer();
 
-      await start(discovery)
+      discovery.addEventListener("peer", () => {
+        deferStart.resolve();
+      });
 
-      discovery.addEventListener('peer', () => {
-        deferStart.resolve()
-      })
+      await start(discovery);
 
-      await deferStart.promise
+      await deferStart.promise;
 
-      await stop(discovery)
+      await stop(discovery);
 
-      discovery.addEventListener('peer', () => {
-        throw new Error('should not receive a peer event after stop')
-      })
+      discovery.addEventListener("peer", () => {
+        throw new Error("should not receive a peer event after stop");
+      });
 
-      await delay(2000)
-    })
-  })
-}
+      await delay(2000);
+    });
+  });
+};

--- a/packages/interface-peer-discovery-compliance-tests/src/index.ts
+++ b/packages/interface-peer-discovery-compliance-tests/src/index.ts
@@ -1,90 +1,90 @@
-import { expect } from "aegir/chai";
-import { isMultiaddr } from "@multiformats/multiaddr";
-import delay from "delay";
-import pDefer from "p-defer";
-import { start, stop } from "@libp2p/interfaces/startable";
-import type { TestSetup } from "@libp2p/interface-compliance-tests";
-import type { PeerDiscovery } from "@libp2p/interface-peer-discovery";
+import { expect } from 'aegir/chai'
+import { isMultiaddr } from '@multiformats/multiaddr'
+import delay from 'delay'
+import pDefer from 'p-defer'
+import { start, stop } from '@libp2p/interfaces/startable'
+import type { TestSetup } from '@libp2p/interface-compliance-tests'
+import type { PeerDiscovery } from '@libp2p/interface-peer-discovery'
 
 export default (common: TestSetup<PeerDiscovery>) => {
-  describe("interface-peer-discovery compliance tests", () => {
-    let discovery: PeerDiscovery;
+  describe('interface-peer-discovery compliance tests', () => {
+    let discovery: PeerDiscovery
 
     beforeEach(async () => {
-      discovery = await common.setup();
-    });
+      discovery = await common.setup()
+    })
 
-    afterEach("ensure discovery was stopped", async () => {
-      await stop(discovery);
+    afterEach('ensure discovery was stopped', async () => {
+      await stop(discovery)
 
-      await common.teardown();
-    });
+      await common.teardown()
+    })
 
-    it("can start the service", async () => {
-      await start(discovery);
-    });
+    it('can start the service', async () => {
+      await start(discovery)
+    })
 
-    it("can start and stop the service", async () => {
-      await start(discovery);
-      await stop(discovery);
-    });
+    it('can start and stop the service', async () => {
+      await start(discovery)
+      await stop(discovery)
+    })
 
-    it("should not fail to stop the service if it was not started", async () => {
-      await stop(discovery);
-    });
+    it('should not fail to stop the service if it was not started', async () => {
+      await stop(discovery)
+    })
 
-    it("should not fail to start the service if it is already started", async () => {
-      await start(discovery);
-      await start(discovery);
-    });
+    it('should not fail to start the service if it is already started', async () => {
+      await start(discovery)
+      await start(discovery)
+    })
 
-    it("should emit a peer event after start", async () => {
-      const defer = pDefer();
+    it('should emit a peer event after start', async () => {
+      const defer = pDefer()
 
-      discovery.addEventListener("peer", (evt) => {
-        const { id, multiaddrs } = evt.detail;
-        expect(id).to.exist();
+      discovery.addEventListener('peer', (evt) => {
+        const { id, multiaddrs } = evt.detail
+        expect(id).to.exist()
         expect(id)
-          .to.have.property("type")
-          .that.is.oneOf(["RSA", "Ed25519", "secp256k1"]);
-        expect(multiaddrs).to.exist();
+          .to.have.property('type')
+          .that.is.oneOf(['RSA', 'Ed25519', 'secp256k1'])
+        expect(multiaddrs).to.exist()
 
-        multiaddrs.forEach((m) => expect(isMultiaddr(m)).to.eql(true));
+        multiaddrs.forEach((m) => expect(isMultiaddr(m)).to.eql(true))
 
-        defer.resolve();
-      });
+        defer.resolve()
+      })
 
-      await start(discovery);
+      await start(discovery)
 
-      await defer.promise;
-    });
+      await defer.promise
+    })
 
-    it("should not receive a peer event before start", async () => {
-      discovery.addEventListener("peer", () => {
-        throw new Error("should not receive a peer event before start");
-      });
+    it('should not receive a peer event before start', async () => {
+      discovery.addEventListener('peer', () => {
+        throw new Error('should not receive a peer event before start')
+      })
 
-      await delay(2000);
-    });
+      await delay(2000)
+    })
 
-    it("should not receive a peer event after stop", async () => {
-      const deferStart = pDefer();
+    it('should not receive a peer event after stop', async () => {
+      const deferStart = pDefer()
 
-      discovery.addEventListener("peer", () => {
-        deferStart.resolve();
-      });
+      discovery.addEventListener('peer', () => {
+        deferStart.resolve()
+      })
 
-      await start(discovery);
+      await start(discovery)
 
-      await deferStart.promise;
+      await deferStart.promise
 
-      await stop(discovery);
+      await stop(discovery)
 
-      discovery.addEventListener("peer", () => {
-        throw new Error("should not receive a peer event after stop");
-      });
+      discovery.addEventListener('peer', () => {
+        throw new Error('should not receive a peer event after stop')
+      })
 
-      await delay(2000);
-    });
-  });
-};
+      await delay(2000)
+    })
+  })
+}


### PR DESCRIPTION
The event listener listening to new peers should be attached before waiting for the execution of `discovery.start()` to finish