### PR TITLE
fix: add importPeer method to keychain interface

### DIFF
--- a/packages/interface-keychain/package.json
+++ b/packages/interface-keychain/package.json
@@ -132,6 +132,7 @@
     "release": "aegir release"
   },
   "dependencies": {
+    "@libp2p/interface-peer-id": "^2.0.0",
     "multiformats": "^11.0.0"
   },
   "devDependencies": {

--- a/packages/interface-keychain/src/index.ts
+++ b/packages/interface-keychain/src/index.ts
@@ -1,4 +1,5 @@
 import type { Multibase } from 'multiformats/bases/interface'
+import type { PeerId } from '@libp2p/interface-peer-id'
 
 export interface KeyInfo {
   /**
@@ -35,6 +36,15 @@ export interface KeyChain {
    * ```
    */
   importKey: (name: string, pem: string, password: string) => Promise<KeyInfo>
+
+  /**
+   * Import a new key from a PeerId with a private key component
+   *
+   * ```js
+   * const keyInfo = await libp2p.keychain.importPeer('keyTestImport', peerIdFromString('12D3Foo...'))
+   * ```
+   */
+  importPeer: (name: string, peerId: PeerId) => Promise<KeyInfo>
 
   /**
    * Create a key in the keychain.


### PR DESCRIPTION
This was missed in an earlier iteration.