### PR TITLE
fix: replace err-code with CodeError

### DIFF
--- a/packages/interface-mocks/package.json
+++ b/packages/interface-mocks/package.json
@@ -158,7 +158,6 @@
     "@multiformats/multiaddr": "^11.0.0",
     "abortable-iterator": "^4.0.2",
     "any-signal": "^3.0.1",
-    "err-code": "^3.0.1",
     "it-handshake": "^4.0.0",
     "it-map": "^2.0.0",
     "it-ndjson": "^1.0.0",

--- a/packages/interface-mocks/src/connection-manager.ts
+++ b/packages/interface-mocks/src/connection-manager.ts
@@ -4,7 +4,7 @@ import type { Connection } from '@libp2p/interface-connection'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import type { ConnectionManager, ConnectionManagerEvents } from '@libp2p/interface-connection-manager'
 import { connectionPair } from './connection.js'
-import errCode from 'err-code'
+import { CodeError } from '@libp2p/interfaces/errors'
 import type { Registrar } from '@libp2p/interface-registrar'
 import type { PubSub } from '@libp2p/interface-pubsub'
 import { isMultiaddr, Multiaddr } from '@multiformats/multiaddr'
@@ -30,7 +30,7 @@ class MockNetwork {
       }
     }
 
-    throw errCode(new Error('Peer not found'), 'ERR_PEER_NOT_FOUND')
+    throw new CodeError('Peer not found', 'ERR_PEER_NOT_FOUND')
   }
 
   reset (): void {
@@ -78,11 +78,11 @@ class MockConnectionManager extends EventEmitter<ConnectionManagerEvents> implem
 
   async openConnection (peerId: PeerId | Multiaddr): Promise<Connection> {
     if (this.components == null) {
-      throw errCode(new Error('Not initialized'), 'ERR_NOT_INITIALIZED')
+      throw new CodeError('Not initialized', 'ERR_NOT_INITIALIZED')
     }
 
     if (isMultiaddr(peerId)) {
-      throw errCode(new Error('Dialing multiaddrs not supported'), 'ERR_NOT_SUPPORTED')
+      throw new CodeError('Dialing multiaddrs not supported', 'ERR_NOT_SUPPORTED')
     }
 
     const existingConnections = this.getConnections(peerId)
@@ -124,7 +124,7 @@ class MockConnectionManager extends EventEmitter<ConnectionManagerEvents> implem
 
   async closeConnections (peerId: PeerId): Promise<void> {
     if (this.components == null) {
-      throw errCode(new Error('Not initialized'), 'ERR_NOT_INITIALIZED')
+      throw new CodeError('Not initialized', 'ERR_NOT_INITIALIZED')
     }
 
     const connections = this.getConnections(peerId)

--- a/packages/interface-mocks/src/connection.ts
+++ b/packages/interface-mocks/src/connection.ts
@@ -14,7 +14,7 @@ import * as STATUS from '@libp2p/interface-connection/status'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { StreamMuxer, StreamMuxerFactory } from '@libp2p/interface-stream-muxer'
 import type { AbortOptions } from '@libp2p/interfaces'
-import errCode from 'err-code'
+import { CodeError } from '@libp2p/interfaces/errors'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 const log = logger('libp2p:mock-connection')
@@ -75,7 +75,7 @@ class MockConnection implements Connection {
     }
 
     if (this.stat.status !== STATUS.OPEN) {
-      throw errCode(new Error('connection must be open to create streams'), 'ERR_CONNECTION_CLOSED')
+      throw new CodeError('connection must be open to create streams', 'ERR_CONNECTION_CLOSED')
     }
 
     const id = `${Math.random()}`

--- a/packages/interface-mocks/src/muxer.ts
+++ b/packages/interface-mocks/src/muxer.ts
@@ -3,7 +3,7 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { abortableSource } from 'abortable-iterator'
 import { anySignal } from 'any-signal'
-import errCode from 'err-code'
+import { CodeError } from '@libp2p/interfaces/errors'
 import { Logger, logger } from '@libp2p/logger'
 import * as ndjson from 'it-ndjson'
 import type { Stream } from '@libp2p/interface-connection'
@@ -125,7 +125,7 @@ class MuxedStream {
       id,
       sink: async (source) => {
         if (this.sinkEnded) {
-          throw errCode(new Error('stream closed for writing'), 'ERR_SINK_ENDED')
+          throw new CodeError('stream closed for writing', 'ERR_SINK_ENDED')
         }
 
         source = abortableSource(source, anySignal([
@@ -243,7 +243,7 @@ class MuxedStream {
 
       // Close immediately for reading and writing (remote error)
       reset: () => {
-        const err = errCode(new Error('stream reset'), 'ERR_STREAM_RESET')
+        const err = new CodeError('stream reset', 'ERR_STREAM_RESET')
         this.resetController.abort()
         this.input.end(err)
         onSinkEnd(err)


### PR DESCRIPTION
Replaces [err-code](https://github.com/IndigoUnited/js-err-code/blob/master/index.js) with [CodeError](https://github.com/libp2p/js-libp2p-interfaces/pull/314)

Related: [js-libp2p#1269](https://github.com/libp2p/js-libp2p/issues/1269)

**Was not sure how to update dependencies**

Changes (affect interface-mocks package only)

- uses CodeError in place of err-code

Blockers

- [ ] ~~remove err-code from dependencies~~
- [ ] ~~add @libp2p/interfaces@3.2.0 to dependencies~~