### PR TITLE
fix: accept multiaddr param when opening connections

### DIFF
--- a/packages/interface-connection-manager/src/index.ts
+++ b/packages/interface-connection-manager/src/index.ts
@@ -58,7 +58,7 @@ export interface ConnectionManager extends EventEmitter<ConnectionManagerEvents>
    * const connection = await libp2p.connectionManager.openConnection(peerId)
    * ```
    */
-  openConnection: (peer: PeerId, options?: AbortOptions) => Promise<Connection>
+  openConnection: (peer: PeerId | Multiaddr, options?: AbortOptions) => Promise<Connection>
 
   /**
    * Close our connections to a peer

--- a/packages/interface-mocks/src/connection-manager.ts
+++ b/packages/interface-mocks/src/connection-manager.ts
@@ -7,6 +7,7 @@ import { connectionPair } from './connection.js'
 import errCode from 'err-code'
 import type { Registrar } from '@libp2p/interface-registrar'
 import type { PubSub } from '@libp2p/interface-pubsub'
+import { isMultiaddr, Multiaddr } from '@multiformats/multiaddr'
 
 export interface MockNetworkComponents {
   peerId: PeerId
@@ -75,9 +76,13 @@ class MockConnectionManager extends EventEmitter<ConnectionManagerEvents> implem
     return this.connections
   }
 
-  async openConnection (peerId: PeerId) {
+  async openConnection (peerId: PeerId | Multiaddr) {
     if (this.components == null) {
       throw errCode(new Error('Not initialized'), 'ERR_NOT_INITIALIZED')
+    }
+
+    if (isMultiaddr(peerId)) {
+      throw errCode(new Error('Dialing multiaddrs not supported'), 'ERR_NOT_SUPPORTED')
     }
 
     const existingConnections = this.getConnections(peerId)


### PR DESCRIPTION
This has been in libp2p for ages but was missed on the interface.