### PR TITLE
feat: Update Connection Manager and Dialler Interfaces and Configs.

### DIFF
--- a/packages/interface-connection-manager/package.json
+++ b/packages/interface-connection-manager/package.json
@@ -133,6 +133,7 @@
   },
   "dependencies": {
     "@libp2p/interface-connection": "^3.0.0",
+    "@libp2p/interface-connection-gater": "^1.0.0",
     "@libp2p/interface-metrics": "^4.0.5",
     "@libp2p/interface-peer-id": "^2.0.0",
     "@libp2p/interface-peer-store": "^1.2.8",

--- a/packages/interface-connection-manager/package.json
+++ b/packages/interface-connection-manager/package.json
@@ -133,7 +133,10 @@
   },
   "dependencies": {
     "@libp2p/interface-connection": "^3.0.0",
+    "@libp2p/interface-metrics": "^4.0.5",
     "@libp2p/interface-peer-id": "^2.0.0",
+    "@libp2p/interface-peer-store": "^1.2.8",
+    "@libp2p/interface-transport": "^2.1.1",
     "@libp2p/interfaces": "^3.0.0",
     "@multiformats/multiaddr": "^11.0.0"
   },

--- a/packages/interface-connection-manager/src/index.ts
+++ b/packages/interface-connection-manager/src/index.ts
@@ -1,8 +1,75 @@
 import type { AbortOptions } from '@libp2p/interfaces'
 import type { EventEmitter } from '@libp2p/interfaces/events'
-import type { Connection, MultiaddrConnection } from '@libp2p/interface-connection'
+import type { Connection, ConnectionGater, MultiaddrConnection } from '@libp2p/interface-connection'
 import type { PeerId } from '@libp2p/interface-peer-id'
-import type { Multiaddr } from '@multiformats/multiaddr'
+import type { Multiaddr, Resolver } from '@multiformats/multiaddr'
+import type { Metrics } from '@libp2p/interface-metrics'
+import type { AddressSorter, PeerStore } from '@libp2p/interface-peer-store'
+import type { TransportManager, Upgrader } from '@libp2p/interface-transport'
+export interface ConnectionManagerComponents {
+  peerId: PeerId
+  metrics?: Metrics
+  upgrader: Upgrader
+  peerStore: PeerStore
+  dialer: Dialer
+}
+
+export interface ConnectionManagerConfig {
+  /**
+   * The maximum number of connections libp2p is willing to have before it starts disconnecting. Defaults to `Infinity`
+   */
+  maxConnections: number
+
+  /**
+   * The minimum number of connections below which libp2p not activate preemptive disconnections. Defaults to `0`.
+   */
+  minConnections: number
+
+  /**
+   * Sets the maximum event loop delay (measured in milliseconds) this node is willing to endure before it starts disconnecting peers. Defaults to `Infinity`.
+   */
+  maxEventLoopDelay?: number
+
+  /**
+   * Sets the poll interval (in milliseconds) for assessing the current state and determining if this peer needs to force a disconnect. Defaults to `2000` (2 seconds).
+   */
+  pollInterval?: number
+
+  /**
+   * Multiaddr resolvers to use when dialing
+   */
+  resolvers?: Record<string, Resolver>
+
+  /**
+   * On startup we try to dial any peer that has previously been
+   * tagged with KEEP_ALIVE up to this timeout in ms. (default: 60000)
+   */
+  startupReconnectTimeout?: number
+
+  /**
+   * A list of multiaddrs that will always be allowed (except if they are in the
+   * deny list) to open connections to this node even if we've reached maxConnections
+   */
+  allow?: string[]
+
+  /**
+   * A list of multiaddrs that will never be allowed to open connections to
+   * this node under any circumstances
+   */
+  deny?: string[]
+
+  /**
+   * If more than this many connections are opened per second by a single
+   * host, reject subsequent connections
+   */
+  inboundConnectionThreshold?: number
+
+  /**
+   * The maximum number of parallel incoming connections allowed that have yet to
+   * complete the connection upgrade - e.g. choosing connection encryption, muxer, etc
+   */
+  maxIncomingPendingConnections?: number
+}
 
 export interface ConnectionManagerEvents {
   /**
@@ -88,6 +155,73 @@ export interface ConnectionManager extends EventEmitter<ConnectionManagerEvents>
    * Invoked after upgrading a multiaddr connection has finished
    */
   afterUpgradeInbound: () => void
+
+  /**
+   * Return the components of the connection manager
+   */
+  getComponents: () => ConnectionManagerComponents
+
+  /**
+   * Return the configuration of the connection manager
+   */
+  getConfig: () => ConnectionManagerConfig
+}
+
+export interface DialerConfig {
+  /**
+   * Sort the known addresses of a peer before trying to dial
+   */
+  addressSorter?: AddressSorter
+
+  /**
+   * If true, try to connect to all discovered peers up to the connection manager limit
+   */
+  autoDial?: boolean
+
+  /**
+   * How long to wait between attempting to keep our number of concurrent connections
+   * above minConnections
+   */
+  autoDialInterval: number
+
+  /**
+   * How long a dial attempt is allowed to take
+   */
+  dialTimeout?: number
+
+  /**
+   * When a new inbound connection is opened, the upgrade process (e.g. protect,
+   * encrypt, multiplex etc) must complete within this number of ms.
+   */
+  inboundUpgradeTimeout: number
+
+  /**
+   * Number of max concurrent dials
+   */
+  maxParallelDials?: number
+
+  /**
+   * Number of max addresses to dial for a given peer
+   */
+  maxAddrsToDial?: number
+
+  /**
+   * Number of max concurrent dials per peer
+   */
+  maxDialsPerPeer?: number
+
+  /**
+   * Multiaddr resolvers to use when dialing
+   */
+  resolvers?: Record<string, Resolver>
+}
+
+export interface DialerComponents {
+  peerId: PeerId
+  metrics?: Metrics
+  peerStore: PeerStore
+  transportManager: TransportManager
+  connectionGater: ConnectionGater
 }
 
 export interface Dialer {
@@ -115,4 +249,14 @@ export interface Dialer {
    * Returns true if the peer id is in the pending dials
    */
   hasPendingDial: (peer: PeerId | Multiaddr) => boolean
+
+  /**
+   * Return the components of the dialer
+   */
+  getComponents: () => DialerComponents
+
+  /**
+   * Return the configuration of the dialer
+   */
+  getConfig: () => DialerConfig
 }

--- a/packages/interface-connection-manager/src/index.ts
+++ b/packages/interface-connection-manager/src/index.ts
@@ -1,6 +1,7 @@
 import type { AbortOptions } from '@libp2p/interfaces'
 import type { EventEmitter } from '@libp2p/interfaces/events'
-import type { Connection, ConnectionGater, MultiaddrConnection } from '@libp2p/interface-connection'
+import type { Connection, MultiaddrConnection } from '@libp2p/interface-connection'
+import type { ConnectionGater } from '@libp2p/interface-connection-gater'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Metrics } from '@libp2p/interface-metrics'

--- a/packages/interface-connection-manager/src/index.ts
+++ b/packages/interface-connection-manager/src/index.ts
@@ -114,5 +114,5 @@ export interface Dialer {
   /**
    * Returns true if the peer id is in the pending dials
    */
-  isPendingDial: (peer: PeerId | Multiaddr) => boolean
+  hasPendingDial: (peer: PeerId | Multiaddr) => boolean
 }

--- a/packages/interface-connection-manager/src/index.ts
+++ b/packages/interface-connection-manager/src/index.ts
@@ -58,7 +58,7 @@ export interface ConnectionManager extends EventEmitter<ConnectionManagerEvents>
    * const connectionsMap = libp2p.connectionManager.getConnectionsMap()
    * ```
    */
-  getConnectionsMap: () =>  Map<string, Connection[]>
+  getConnectionsMap: () => Map<string, Connection[]>
 
   /**
    * Open a connection to a remote peer

--- a/packages/interface-connection-manager/src/index.ts
+++ b/packages/interface-connection-manager/src/index.ts
@@ -109,7 +109,7 @@ export interface Dialer {
   /**
    * Get the current dial targets which are pending
    */
-  getPendingDialTargets: () => Map<string, AbortOptions>
+  getPendingDialTargets: () => Map<string, AbortController>
 
   /**
    * Returns true if the peer id is in the pending dials

--- a/packages/interface-connection-manager/src/index.ts
+++ b/packages/interface-connection-manager/src/index.ts
@@ -69,6 +69,11 @@ export interface ConnectionManagerConfig {
    * complete the connection upgrade - e.g. choosing connection encryption, muxer, etc
    */
   maxIncomingPendingConnections?: number
+
+  /**
+   * The abort signal to use for timeouts when opening connections to peers
+   */
+  outgoingDialTimeout?: number
 }
 
 export interface ConnectionManagerEvents {

--- a/packages/interface-connection-manager/src/index.ts
+++ b/packages/interface-connection-manager/src/index.ts
@@ -50,6 +50,17 @@ export interface ConnectionManager extends EventEmitter<ConnectionManagerEvents>
   getConnections: (peerId?: PeerId) => Connection[]
 
   /**
+   * Return a map of all connections with their associated PeerIds
+   *
+   * @example
+   *
+   * ```js
+   * const connectionsMap = libp2p.connectionManager.getConnectionsMap()
+   * ```
+   */
+  getConnectionsMap: () =>  Map<string, Connection[]>
+
+  /**
    * Open a connection to a remote peer
    *
    * @example

--- a/packages/interface-connection-manager/src/index.ts
+++ b/packages/interface-connection-manager/src/index.ts
@@ -105,4 +105,14 @@ export interface Dialer {
    * After a dial attempt succeeds or fails, return the passed token to the pool
    */
   releaseToken: (token: number) => void
+
+  /**
+   * Get the current dial targets which are pending
+   */
+  getPendingDialTargets: () => Map<string, AbortOptions>
+
+  /**
+   * Returns true if the peer id is in the pending dials
+   */
+  isPendingDial: (peer: PeerId | Multiaddr) => boolean
 }

--- a/packages/interface-connection-manager/src/index.ts
+++ b/packages/interface-connection-manager/src/index.ts
@@ -2,9 +2,9 @@ import type { AbortOptions } from '@libp2p/interfaces'
 import type { EventEmitter } from '@libp2p/interfaces/events'
 import type { Connection, ConnectionGater, MultiaddrConnection } from '@libp2p/interface-connection'
 import type { PeerId } from '@libp2p/interface-peer-id'
-import type { Multiaddr, Resolver } from '@multiformats/multiaddr'
+import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Metrics } from '@libp2p/interface-metrics'
-import type { AddressSorter, PeerStore } from '@libp2p/interface-peer-store'
+import type { PeerStore } from '@libp2p/interface-peer-store'
 import type { TransportManager, Upgrader } from '@libp2p/interface-transport'
 export interface ConnectionManagerComponents {
   peerId: PeerId
@@ -12,68 +12,6 @@ export interface ConnectionManagerComponents {
   upgrader: Upgrader
   peerStore: PeerStore
   dialer: Dialer
-}
-
-export interface ConnectionManagerConfig {
-  /**
-   * The maximum number of connections libp2p is willing to have before it starts disconnecting. Defaults to `Infinity`
-   */
-  maxConnections: number
-
-  /**
-   * The minimum number of connections below which libp2p not activate preemptive disconnections. Defaults to `0`.
-   */
-  minConnections: number
-
-  /**
-   * Sets the maximum event loop delay (measured in milliseconds) this node is willing to endure before it starts disconnecting peers. Defaults to `Infinity`.
-   */
-  maxEventLoopDelay?: number
-
-  /**
-   * Sets the poll interval (in milliseconds) for assessing the current state and determining if this peer needs to force a disconnect. Defaults to `2000` (2 seconds).
-   */
-  pollInterval?: number
-
-  /**
-   * Multiaddr resolvers to use when dialing
-   */
-  resolvers?: Record<string, Resolver>
-
-  /**
-   * On startup we try to dial any peer that has previously been
-   * tagged with KEEP_ALIVE up to this timeout in ms. (default: 60000)
-   */
-  startupReconnectTimeout?: number
-
-  /**
-   * A list of multiaddrs that will always be allowed (except if they are in the
-   * deny list) to open connections to this node even if we've reached maxConnections
-   */
-  allow?: string[]
-
-  /**
-   * A list of multiaddrs that will never be allowed to open connections to
-   * this node under any circumstances
-   */
-  deny?: string[]
-
-  /**
-   * If more than this many connections are opened per second by a single
-   * host, reject subsequent connections
-   */
-  inboundConnectionThreshold?: number
-
-  /**
-   * The maximum number of parallel incoming connections allowed that have yet to
-   * complete the connection upgrade - e.g. choosing connection encryption, muxer, etc
-   */
-  maxIncomingPendingConnections?: number
-
-  /**
-   * The abort signal to use for timeouts when opening connections to peers
-   */
-  outgoingDialTimeout?: number
 }
 
 export interface ConnectionManagerEvents {
@@ -165,60 +103,6 @@ export interface ConnectionManager extends EventEmitter<ConnectionManagerEvents>
    * Return the components of the connection manager
    */
   getComponents: () => ConnectionManagerComponents
-
-  /**
-   * Return the configuration of the connection manager
-   */
-  getConfig: () => ConnectionManagerConfig
-}
-
-export interface DialerConfig {
-  /**
-   * Sort the known addresses of a peer before trying to dial
-   */
-  addressSorter?: AddressSorter
-
-  /**
-   * If true, try to connect to all discovered peers up to the connection manager limit
-   */
-  autoDial?: boolean
-
-  /**
-   * How long to wait between attempting to keep our number of concurrent connections
-   * above minConnections
-   */
-  autoDialInterval: number
-
-  /**
-   * How long a dial attempt is allowed to take
-   */
-  dialTimeout?: number
-
-  /**
-   * When a new inbound connection is opened, the upgrade process (e.g. protect,
-   * encrypt, multiplex etc) must complete within this number of ms.
-   */
-  inboundUpgradeTimeout: number
-
-  /**
-   * Number of max concurrent dials
-   */
-  maxParallelDials?: number
-
-  /**
-   * Number of max addresses to dial for a given peer
-   */
-  maxAddrsToDial?: number
-
-  /**
-   * Number of max concurrent dials per peer
-   */
-  maxDialsPerPeer?: number
-
-  /**
-   * Multiaddr resolvers to use when dialing
-   */
-  resolvers?: Record<string, Resolver>
 }
 
 export interface DialerComponents {
@@ -259,9 +143,4 @@ export interface Dialer {
    * Return the components of the dialer
    */
   getComponents: () => DialerComponents
-
-  /**
-   * Return the configuration of the dialer
-   */
-  getConfig: () => DialerConfig
 }

--- a/packages/interface-mocks/package.json
+++ b/packages/interface-mocks/package.json
@@ -146,6 +146,7 @@
     "@libp2p/interface-peer-discovery": "^1.0.0",
     "@libp2p/interface-peer-id": "^2.0.0",
     "@libp2p/interface-peer-info": "^1.0.0",
+    "@libp2p/interface-peer-store": "^1.2.8",
     "@libp2p/interface-pubsub": "^3.0.0",
     "@libp2p/interface-registrar": "^2.0.0",
     "@libp2p/interface-stream-muxer": "^3.0.0",

--- a/packages/interface-mocks/src/connection-manager.ts
+++ b/packages/interface-mocks/src/connection-manager.ts
@@ -64,7 +64,8 @@ class MockConnectionManager extends EventEmitter<ConnectionManagerEvents> implem
     this.components = components
     this.config = config
   }
-  getComponents(): ConnectionManagerComponents {
+
+  getComponents (): ConnectionManagerComponents {
     return this.components
   }
 

--- a/packages/interface-mocks/src/connection-manager.ts
+++ b/packages/interface-mocks/src/connection-manager.ts
@@ -62,15 +62,12 @@ export interface MockConnectionManagerComponents {
 }
 
 class MockConnectionManager extends EventEmitter<ConnectionManagerEvents> implements ConnectionManager, Startable {
-
   private readonly connections: Map<string, Connection[]> = new Map()
   private readonly components: MockConnectionManagerComponents
   private started = false
 
-
   constructor (components: MockConnectionManagerComponents) {
     super()
-
     this.components = components
   }
 

--- a/packages/interface-pubsub-compliance-tests/src/utils.ts
+++ b/packages/interface-pubsub-compliance-tests/src/utils.ts
@@ -19,7 +19,13 @@ export async function createComponents (): Promise<MockNetworkComponents> {
     peerId: await createEd25519PeerId(),
     registrar: mockRegistrar()
   }
-  components.connectionManager = mockConnectionManager(components)
+
+  const config: any = {
+     maxConnections: 10,
+     minConnections: 10
+  }
+
+  components.connectionManager = mockConnectionManager(components, config)
 
   mockNetwork.addNode(components)
 

--- a/packages/interface-pubsub-compliance-tests/src/utils.ts
+++ b/packages/interface-pubsub-compliance-tests/src/utils.ts
@@ -20,12 +20,7 @@ export async function createComponents (): Promise<MockNetworkComponents> {
     registrar: mockRegistrar()
   }
 
-  const config: any = {
-    maxConnections: 10,
-    minConnections: 10
-  }
-
-  components.connectionManager = mockConnectionManager(components, config)
+  components.connectionManager = mockConnectionManager(components)
 
   mockNetwork.addNode(components)
 

--- a/packages/interface-pubsub-compliance-tests/src/utils.ts
+++ b/packages/interface-pubsub-compliance-tests/src/utils.ts
@@ -21,8 +21,8 @@ export async function createComponents (): Promise<MockNetworkComponents> {
   }
 
   const config: any = {
-     maxConnections: 10,
-     minConnections: 10
+    maxConnections: 10,
+    minConnections: 10
   }
 
   components.connectionManager = mockConnectionManager(components, config)


### PR DESCRIPTION
In order to avoid creating wrapper functions to extract a map of the connections from a default `ConnectionManager` implementation (as mentioned in https://github.com/libp2p/js-libp2p/issues/1567) , we should allow that field to be made accessible. 

Now whilst the `getConnections` function could achieve this, it adds [additional runtime logic which coulda affect performance](https://github.com/ChainSafe/lodestar/pull/5097#pullrequestreview-1282144695).