### PR TITLE
docs: update content/peer routing interface comments

### DIFF
--- a/packages/interface-content-routing/src/index.ts
+++ b/packages/interface-content-routing/src/index.ts
@@ -4,7 +4,8 @@ import type { PeerInfo } from '@libp2p/interface-peer-info'
 
 export interface ContentRouting {
   /**
-   * Iterates over all content routers in parallel, in order to notify it is a provider of the given key.
+   * The implementation of this method should ensure that network peers know the
+   * caller can provide content that corresponds to the passed CID.
    *
    * @example
    *
@@ -16,9 +17,7 @@ export interface ContentRouting {
   provide: (cid: CID, options?: AbortOptions) => Promise<void>
 
   /**
-   * Iterates over all content routers in series to find providers of the given key.
-   *
-   * Once a content router succeeds, the iteration will stop. If the DHT is enabled, it will be queried first.
+   * Find the providers of the passed CID.
    *
    * @example
    *
@@ -32,7 +31,8 @@ export interface ContentRouting {
   findProviders: (cid: CID, options?: AbortOptions) => AsyncIterable<PeerInfo>
 
   /**
-   * Writes a value to a key in the DHT.
+   * Puts a value corresponding to the passed key in a way that can later be
+   * retrieved by another network peer using the get method.
    *
    * @example
    *
@@ -47,7 +47,7 @@ export interface ContentRouting {
   put: (key: Uint8Array, value: Uint8Array, options?: AbortOptions) => Promise<void>
 
   /**
-   * Queries the DHT for a value stored for a given key.
+   * Retrieves a value from the network corresponding to the passed key.
    *
    * @example
    *

--- a/packages/interface-peer-routing/src/index.ts
+++ b/packages/interface-peer-routing/src/index.ts
@@ -4,7 +4,7 @@ import type { AbortOptions } from '@libp2p/interfaces'
 
 export interface PeerRouting {
   /**
-   * Iterates over all peer routers in series to find the given peer. If the DHT is enabled, it will be tried first.
+   * Searches the network for peer info corresponding to the passed peer id.
    *
    * @example
    *
@@ -16,9 +16,8 @@ export interface PeerRouting {
   findPeer: (peerId: PeerId, options?: AbortOptions) => Promise<PeerInfo>
 
   /**
-   * Iterates over all peer routers in series to get the closest peers of the given key.
-   *
-   * Once a content router succeeds, the iteration will stop. If the DHT is enabled, it will be queried first.
+   * Search the network for peers that are closer to the passed key. Peer
+   * info should be yielded in ever-increasing closeness to the key.
    *
    * @example
    *


### PR DESCRIPTION
Remove references to other strategies, just say what the method implementation is supposed to do.