### PR TITLE
feat: split connection gater out into module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,9 @@
-**/node_modules/
-**/*.log
-
-# Coverage directory used by tools like istanbul
-.nyc_output
-
+node_modules
 build
 dist
 .docs
-
-# Dependency directory
-# https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
+.coverage
 node_modules
-# Lock files
 package-lock.json
 yarn.lock
 .vscode

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - [`/packages/interface-connection-compliance-tests`](./packages/interface-connection-compliance-tests) Compliance tests for implementations of the libp2p Connection interface
 - [`/packages/interface-connection-encrypter`](./packages/interface-connection-encrypter) Connection Encrypter interface for libp2p
 - [`/packages/interface-connection-encrypter-compliance-tests`](./packages/interface-connection-encrypter-compliance-tests) Compliance tests for implementations of the libp2p Connection Encrypter interface
+- [`/packages/interface-connection-gater`](./packages/interface-connection-gater) Connection gater interface for libp2p
 - [`/packages/interface-connection-manager`](./packages/interface-connection-manager) Connection Manager interface for libp2p
 - [`/packages/interface-content-routing`](./packages/interface-content-routing) Content routing interface for libp2p
 - [`/packages/interface-dht`](./packages/interface-dht) DHT interface for libp2p

--- a/packages/interface-connection-gater/LICENSE
+++ b/packages/interface-connection-gater/LICENSE
@@ -1,0 +1,4 @@
+This project is dual licensed under MIT and Apache-2.0.
+
+MIT: https://www.opensource.org/licenses/mit
+Apache-2.0: https://www.apache.org/licenses/license-2.0

--- a/packages/interface-connection-gater/LICENSE-APACHE
+++ b/packages/interface-connection-gater/LICENSE-APACHE
@@ -1,0 +1,5 @@
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/packages/interface-connection-gater/LICENSE-MIT
+++ b/packages/interface-connection-gater/LICENSE-MIT
@@ -1,0 +1,19 @@
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/interface-connection-gater/README.md
+++ b/packages/interface-connection-gater/README.md
@@ -17,12 +17,12 @@
 ## Install
 
 ```console
-$ npm i @libp2p/interface-connection
+$ npm i @libp2p/interface-connection-gater
 ```
 
 ## API Docs
 
-- <https://libp2p.github.io/js-libp2p-interfaces/modules/_libp2p_interface_connection.html>
+- <https://libp2p.github.io/js-libp2p-interfaces/modules/_libp2p_interface_connection_gater.html>
 
 ## License
 

--- a/packages/interface-connection-gater/README.md
+++ b/packages/interface-connection-gater/README.md
@@ -1,0 +1,36 @@
+# @libp2p/interface-connection-gater <!-- omit in toc -->
+
+[![libp2p.io](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
+[![Discuss](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg?style=flat-square)](https://discuss.libp2p.io)
+[![codecov](https://img.shields.io/codecov/c/github/libp2p/js-libp2p-interfaces.svg?style=flat-square)](https://codecov.io/gh/libp2p/js-libp2p-interfaces)
+[![CI](https://img.shields.io/github/actions/workflow/status/libp2p/js-libp2p-interfaces/js-test-and-release.yml?branch=master\&style=flat-square)](https://github.com/libp2p/js-libp2p-interfaces/actions/workflows/js-test-and-release.yml?query=branch%3Amaster)
+
+> Connection gater interface for libp2p
+
+## Table of contents <!-- omit in toc -->
+
+- [Install](#install)
+- [API Docs](#api-docs)
+- [License](#license)
+- [Contribution](#contribution)
+
+## Install
+
+```console
+$ npm i @libp2p/interface-connection
+```
+
+## API Docs
+
+- <https://libp2p.github.io/js-libp2p-interfaces/modules/_libp2p_interface_connection.html>
+
+## License
+
+Licensed under either of
+
+- Apache 2.0, ([LICENSE-APACHE](LICENSE-APACHE) / <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT ([LICENSE-MIT](LICENSE-MIT) / <http://opensource.org/licenses/MIT>)
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/packages/interface-connection-gater/package.json
+++ b/packages/interface-connection-gater/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "Connection gater interface for libp2p",
   "license": "Apache-2.0 OR MIT",
-  "homepage": "https://github.com/libp2p/js-libp2p-interfaces/tree/master/packages/interface-connection#readme",
+  "homepage": "https://github.com/libp2p/js-libp2p-interfaces/tree/master/packages/interface-connection-gater#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/libp2p/js-libp2p-interfaces.git"
@@ -47,10 +47,6 @@
     ".": {
       "types": "./dist/src/index.d.ts",
       "import": "./dist/src/index.js"
-    },
-    "./status": {
-      "types": "./dist/src/status.d.ts",
-      "import": "./dist/src/status.js"
     }
   },
   "eslintConfig": {

--- a/packages/interface-connection-gater/package.json
+++ b/packages/interface-connection-gater/package.json
@@ -1,0 +1,168 @@
+{
+  "name": "@libp2p/interface-connection-gater",
+  "version": "0.0.0",
+  "description": "Connection gater interface for libp2p",
+  "license": "Apache-2.0 OR MIT",
+  "homepage": "https://github.com/libp2p/js-libp2p-interfaces/tree/master/packages/interface-connection#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/libp2p/js-libp2p-interfaces.git"
+  },
+  "bugs": {
+    "url": "https://github.com/libp2p/js-libp2p-interfaces/issues"
+  },
+  "keywords": [
+    "interface",
+    "libp2p"
+  ],
+  "engines": {
+    "node": ">=16.0.0",
+    "npm": ">=7.0.0"
+  },
+  "type": "module",
+  "types": "./dist/src/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "*",
+        "dist/*",
+        "dist/src/*",
+        "dist/src/*/index"
+      ],
+      "src/*": [
+        "*",
+        "dist/*",
+        "dist/src/*",
+        "dist/src/*/index"
+      ]
+    }
+  },
+  "files": [
+    "src",
+    "dist",
+    "!dist/test",
+    "!**/*.tsbuildinfo"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js"
+    },
+    "./status": {
+      "types": "./dist/src/status.d.ts",
+      "import": "./dist/src/status.js"
+    }
+  },
+  "eslintConfig": {
+    "extends": "ipfs",
+    "parserOptions": {
+      "sourceType": "module"
+    }
+  },
+  "release": {
+    "branches": [
+      "master"
+    ],
+    "plugins": [
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "preset": "conventionalcommits",
+          "releaseRules": [
+            {
+              "breaking": true,
+              "release": "major"
+            },
+            {
+              "revert": true,
+              "release": "patch"
+            },
+            {
+              "type": "feat",
+              "release": "minor"
+            },
+            {
+              "type": "fix",
+              "release": "patch"
+            },
+            {
+              "type": "docs",
+              "release": "patch"
+            },
+            {
+              "type": "test",
+              "release": "patch"
+            },
+            {
+              "type": "deps",
+              "release": "patch"
+            },
+            {
+              "scope": "no-release",
+              "release": false
+            }
+          ]
+        }
+      ],
+      [
+        "@semantic-release/release-notes-generator",
+        {
+          "preset": "conventionalcommits",
+          "presetConfig": {
+            "types": [
+              {
+                "type": "feat",
+                "section": "Features"
+              },
+              {
+                "type": "fix",
+                "section": "Bug Fixes"
+              },
+              {
+                "type": "chore",
+                "section": "Trivial Changes"
+              },
+              {
+                "type": "docs",
+                "section": "Documentation"
+              },
+              {
+                "type": "deps",
+                "section": "Dependencies"
+              },
+              {
+                "type": "test",
+                "section": "Tests"
+              }
+            ]
+          }
+        }
+      ],
+      "@semantic-release/changelog",
+      "@semantic-release/npm",
+      "@semantic-release/github",
+      "@semantic-release/git"
+    ]
+  },
+  "scripts": {
+    "clean": "aegir clean",
+    "lint": "aegir lint",
+    "dep-check": "aegir dep-check",
+    "build": "aegir build",
+    "release": "aegir release"
+  },
+  "dependencies": {
+    "@libp2p/interface-connection": "^3.0.0",
+    "@libp2p/interface-peer-id": "^2.0.0",
+    "@libp2p/interfaces": "^3.0.0",
+    "@multiformats/multiaddr": "^11.0.0",
+    "it-stream-types": "^1.0.4",
+    "uint8arraylist": "^2.1.2"
+  },
+  "devDependencies": {
+    "aegir": "^38.1.0"
+  },
+  "typedoc": {
+    "entryPoint": "./src/index.ts"
+  }
+}

--- a/packages/interface-connection-gater/src/index.ts
+++ b/packages/interface-connection-gater/src/index.ts
@@ -1,0 +1,127 @@
+import type { Multiaddr } from '@multiformats/multiaddr'
+import type { PeerId } from '@libp2p/interface-peer-id'
+
+export interface ConnectionGater {
+  /**
+   * denyDialMultiaddr tests whether we're permitted to Dial the
+   * specified peer.
+   *
+   * This is called by the dialer.connectToPeer implementation before
+   * dialling a peer.
+   *
+   * Return true to prevent dialing the passed peer.
+   */
+  denyDialPeer?: (peerId: PeerId) => Promise<boolean>
+
+  /**
+   * denyDialMultiaddr tests whether we're permitted to dial the specified
+   * multiaddr for the given peer.
+   *
+   * This is called by the dialer.connectToPeer implementation after it has
+   * resolved the peer's addrs, and prior to dialling each.
+   *
+   * Return true to prevent dialing the passed peer on the passed multiaddr.
+   */
+  denyDialMultiaddr?: (peerId: PeerId, multiaddr: Multiaddr) => Promise<boolean>
+
+  /**
+   * denyInboundConnection tests whether an incipient inbound connection is allowed.
+   *
+   * This is called by the upgrader, or by the transport directly (e.g. QUIC,
+   * Bluetooth), straight after it has accepted a connection from its socket.
+   *
+   * Return true to deny the incoming passed connection.
+   */
+  denyInboundConnection?: (maConn: MultiaddrConnection) => Promise<boolean>
+
+  /**
+   * denyOutboundConnection tests whether an incipient outbound connection is allowed.
+   *
+   * This is called by the upgrader, or by the transport directly (e.g. QUIC,
+   * Bluetooth), straight after it has created a connection with its socket.
+   *
+   * Return true to deny the incoming passed connection.
+   */
+  denyOutboundConnection?: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
+
+  /**
+   * denyInboundEncryptedConnection tests whether a given connection, now encrypted,
+   * is allowed.
+   *
+   * This is called by the upgrader, after it has performed the security
+   * handshake, and before it negotiates the muxer, or by the directly by the
+   * transport, at the exact same checkpoint.
+   *
+   * Return true to deny the passed secured connection.
+   */
+  denyInboundEncryptedConnection?: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
+
+  /**
+   * denyOutboundEncryptedConnection tests whether a given connection, now encrypted,
+   * is allowed.
+   *
+   * This is called by the upgrader, after it has performed the security
+   * handshake, and before it negotiates the muxer, or by the directly by the
+   * transport, at the exact same checkpoint.
+   *
+   * Return true to deny the passed secured connection.
+   */
+  denyOutboundEncryptedConnection?: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
+
+  /**
+   * denyInboundUpgradedConnection tests whether a fully capable connection is allowed.
+   *
+   * This is called after encryption has been negotiated and the connection has been
+   * multiplexed, if a multiplexer is configured.
+   *
+   * Return true to deny the passed upgraded connection.
+   */
+  denyInboundUpgradedConnection?: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
+
+  /**
+   * denyOutboundUpgradedConnection tests whether a fully capable connection is allowed.
+   *
+   * This is called after encryption has been negotiated and the connection has been
+   * multiplexed, if a multiplexer is configured.
+   *
+   * Return true to deny the passed upgraded connection.
+   */
+  denyOutboundUpgradedConnection?: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
+
+  /**
+   * denyInboundRelayReservation tests whether a remote peer is allowed make a
+   * relay reservation on this node.
+   *
+   * Return true to deny the relay reservation.
+   */
+  denyInboundRelayReservation?: (source: PeerId) => Promise<boolean>
+
+  /**
+   * denyOutboundRelayedConnection tests whether a remote peer is allowed to open a relayed
+   * connection to the destination node.
+   *
+   * This is invoked on the relay server when a source client with a reservation instructs
+   * the server to relay a connection to a destination peer.
+   *
+   * Return true to deny the relayed connection.
+   */
+  denyOutboundRelayedConnection?: (source: PeerId, destination: PeerId) => Promise<boolean>
+
+  /**
+   * denyInboundRelayedConnection tests whether a remote peer is allowed to open a relayed
+   * connection to this node.
+   *
+   * This is invoked on the relay client when a remote relay has received an instruction to
+   * relay a connection to the client.
+   *
+   * Return true to deny the relayed connection.
+   */
+  denyInboundRelayedConnection?: (relay: PeerId, remotePeer: PeerId) => Promise<boolean>
+
+  /**
+   * Used by the address book to filter passed addresses.
+   *
+   * Return true to allow storing the passed multiaddr for the passed peer.
+   */
+  filterMultiaddrForPeer?: (peer: PeerId, multiaddr: Multiaddr) => Promise<boolean>
+}

--- a/packages/interface-connection-gater/src/index.ts
+++ b/packages/interface-connection-gater/src/index.ts
@@ -1,5 +1,6 @@
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { PeerId } from '@libp2p/interface-peer-id'
+import type { MultiaddrConnection } from '@libp2p/interface-connection'
 
 export interface ConnectionGater {
   /**

--- a/packages/interface-connection-gater/tsconfig.json
+++ b/packages/interface-connection-gater/tsconfig.json
@@ -8,6 +8,9 @@
   ],
   "references": [
     {
+      "path": "../interface-connection"
+    },
+    {
       "path": "../interface-peer-id"
     },
     {

--- a/packages/interface-connection-gater/tsconfig.json
+++ b/packages/interface-connection-gater/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "aegir/src/config/tsconfig.aegir.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../interface-peer-id"
+    },
+    {
+      "path": "../interfaces"
+    }
+  ]
+}

--- a/packages/interface-connection/src/index.ts
+++ b/packages/interface-connection/src/index.ts
@@ -172,7 +172,7 @@ export interface ConnectionGater {
    *
    * Return true to prevent dialing the passed peer.
    */
-  denyDialPeer: (peerId: PeerId) => Promise<boolean>
+  denyDialPeer?: (peerId: PeerId) => Promise<boolean>
 
   /**
    * denyDialMultiaddr tests whether we're permitted to dial the specified
@@ -183,7 +183,7 @@ export interface ConnectionGater {
    *
    * Return true to prevent dialing the passed peer on the passed multiaddr.
    */
-  denyDialMultiaddr: (peerId: PeerId, multiaddr: Multiaddr) => Promise<boolean>
+  denyDialMultiaddr?: (peerId: PeerId, multiaddr: Multiaddr) => Promise<boolean>
 
   /**
    * denyInboundConnection tests whether an incipient inbound connection is allowed.
@@ -193,7 +193,7 @@ export interface ConnectionGater {
    *
    * Return true to deny the incoming passed connection.
    */
-  denyInboundConnection: (maConn: MultiaddrConnection) => Promise<boolean>
+  denyInboundConnection?: (maConn: MultiaddrConnection) => Promise<boolean>
 
   /**
    * denyOutboundConnection tests whether an incipient outbound connection is allowed.
@@ -203,7 +203,7 @@ export interface ConnectionGater {
    *
    * Return true to deny the incoming passed connection.
    */
-  denyOutboundConnection: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
+  denyOutboundConnection?: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
 
   /**
    * denyInboundEncryptedConnection tests whether a given connection, now encrypted,
@@ -215,7 +215,7 @@ export interface ConnectionGater {
    *
    * Return true to deny the passed secured connection.
    */
-  denyInboundEncryptedConnection: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
+  denyInboundEncryptedConnection?: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
 
   /**
    * denyOutboundEncryptedConnection tests whether a given connection, now encrypted,
@@ -227,7 +227,7 @@ export interface ConnectionGater {
    *
    * Return true to deny the passed secured connection.
    */
-  denyOutboundEncryptedConnection: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
+  denyOutboundEncryptedConnection?: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
 
   /**
    * denyInboundUpgradedConnection tests whether a fully capable connection is allowed.
@@ -237,7 +237,7 @@ export interface ConnectionGater {
    *
    * Return true to deny the passed upgraded connection.
    */
-  denyInboundUpgradedConnection: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
+  denyInboundUpgradedConnection?: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
 
   /**
    * denyOutboundUpgradedConnection tests whether a fully capable connection is allowed.
@@ -247,14 +247,44 @@ export interface ConnectionGater {
    *
    * Return true to deny the passed upgraded connection.
    */
-  denyOutboundUpgradedConnection: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
+  denyOutboundUpgradedConnection?: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
+
+  /**
+   * denyInboundRelayReservation tests whether a remote peer is allowed make a
+   * relay reservation on this node.
+   *
+   * Return true to deny the relay reservation.
+   */
+  denyInboundRelayReservation?: (source: PeerId) => Promise<boolean>
+
+  /**
+   * denyOutboundRelayedConnection tests whether a remote peer is allowed to open a relayed
+   * connection to the destination node.
+   *
+   * This is invoked on the relay server when a source client with a reservation instructs
+   * the server to relay a connection to a destination peer.
+   *
+   * Return true to deny the relayed connection.
+   */
+  denyOutboundRelayedConnection?: (source: PeerId, destination: PeerId) => Promise<boolean>
+
+  /**
+   * denyInboundRelayedConnection tests whether a remote peer is allowed to open a relayed
+   * connection to this node.
+   *
+   * This is invoked on the relay client when a remote relay has received an instruction to
+   * relay a connection to the client.
+   *
+   * Return true to deny the relayed connection.
+   */
+  denyInboundRelayedConnection?: (relay: PeerId, remotePeer: PeerId) => Promise<boolean>
 
   /**
    * Used by the address book to filter passed addresses.
    *
    * Return true to allow storing the passed multiaddr for the passed peer.
    */
-  filterMultiaddrForPeer: (peer: PeerId, multiaddr: Multiaddr) => Promise<boolean>
+  filterMultiaddrForPeer?: (peer: PeerId, multiaddr: Multiaddr) => Promise<boolean>
 }
 
 export interface ConnectionProtector {

--- a/packages/interface-connection/src/index.ts
+++ b/packages/interface-connection/src/index.ts
@@ -162,6 +162,9 @@ export function isConnection (other: any): other is Connection {
   return other != null && Boolean(other[symbol])
 }
 
+/**
+ * @deprecated Please use the version from @libp2p/interface-connection-gater instead, this will be removed in a future release
+ */
 export interface ConnectionGater {
   /**
    * denyDialMultiaddr tests whether we're permitted to Dial the
@@ -172,7 +175,7 @@ export interface ConnectionGater {
    *
    * Return true to prevent dialing the passed peer.
    */
-  denyDialPeer?: (peerId: PeerId) => Promise<boolean>
+  denyDialPeer: (peerId: PeerId) => Promise<boolean>
 
   /**
    * denyDialMultiaddr tests whether we're permitted to dial the specified
@@ -183,7 +186,7 @@ export interface ConnectionGater {
    *
    * Return true to prevent dialing the passed peer on the passed multiaddr.
    */
-  denyDialMultiaddr?: (peerId: PeerId, multiaddr: Multiaddr) => Promise<boolean>
+  denyDialMultiaddr: (peerId: PeerId, multiaddr: Multiaddr) => Promise<boolean>
 
   /**
    * denyInboundConnection tests whether an incipient inbound connection is allowed.
@@ -193,7 +196,7 @@ export interface ConnectionGater {
    *
    * Return true to deny the incoming passed connection.
    */
-  denyInboundConnection?: (maConn: MultiaddrConnection) => Promise<boolean>
+  denyInboundConnection: (maConn: MultiaddrConnection) => Promise<boolean>
 
   /**
    * denyOutboundConnection tests whether an incipient outbound connection is allowed.
@@ -203,7 +206,7 @@ export interface ConnectionGater {
    *
    * Return true to deny the incoming passed connection.
    */
-  denyOutboundConnection?: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
+  denyOutboundConnection: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
 
   /**
    * denyInboundEncryptedConnection tests whether a given connection, now encrypted,
@@ -215,7 +218,7 @@ export interface ConnectionGater {
    *
    * Return true to deny the passed secured connection.
    */
-  denyInboundEncryptedConnection?: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
+  denyInboundEncryptedConnection: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
 
   /**
    * denyOutboundEncryptedConnection tests whether a given connection, now encrypted,
@@ -227,7 +230,7 @@ export interface ConnectionGater {
    *
    * Return true to deny the passed secured connection.
    */
-  denyOutboundEncryptedConnection?: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
+  denyOutboundEncryptedConnection: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
 
   /**
    * denyInboundUpgradedConnection tests whether a fully capable connection is allowed.
@@ -237,7 +240,7 @@ export interface ConnectionGater {
    *
    * Return true to deny the passed upgraded connection.
    */
-  denyInboundUpgradedConnection?: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
+  denyInboundUpgradedConnection: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
 
   /**
    * denyOutboundUpgradedConnection tests whether a fully capable connection is allowed.
@@ -247,44 +250,14 @@ export interface ConnectionGater {
    *
    * Return true to deny the passed upgraded connection.
    */
-  denyOutboundUpgradedConnection?: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
-
-  /**
-   * denyInboundRelayReservation tests whether a remote peer is allowed make a
-   * relay reservation on this node.
-   *
-   * Return true to deny the relay reservation.
-   */
-  denyInboundRelayReservation?: (source: PeerId) => Promise<boolean>
-
-  /**
-   * denyOutboundRelayedConnection tests whether a remote peer is allowed to open a relayed
-   * connection to the destination node.
-   *
-   * This is invoked on the relay server when a source client with a reservation instructs
-   * the server to relay a connection to a destination peer.
-   *
-   * Return true to deny the relayed connection.
-   */
-  denyOutboundRelayedConnection?: (source: PeerId, destination: PeerId) => Promise<boolean>
-
-  /**
-   * denyInboundRelayedConnection tests whether a remote peer is allowed to open a relayed
-   * connection to this node.
-   *
-   * This is invoked on the relay client when a remote relay has received an instruction to
-   * relay a connection to the client.
-   *
-   * Return true to deny the relayed connection.
-   */
-  denyInboundRelayedConnection?: (relay: PeerId, remotePeer: PeerId) => Promise<boolean>
+  denyOutboundUpgradedConnection: (peerId: PeerId, maConn: MultiaddrConnection) => Promise<boolean>
 
   /**
    * Used by the address book to filter passed addresses.
    *
    * Return true to allow storing the passed multiaddr for the passed peer.
    */
-  filterMultiaddrForPeer?: (peer: PeerId, multiaddr: Multiaddr) => Promise<boolean>
+  filterMultiaddrForPeer: (peer: PeerId, multiaddr: Multiaddr) => Promise<boolean>
 }
 
 export interface ConnectionProtector {

--- a/packages/interface-connection/src/index.ts
+++ b/packages/interface-connection/src/index.ts
@@ -163,7 +163,7 @@ export function isConnection (other: any): other is Connection {
 }
 
 /**
- * @deprecated Please use the version from @libp2p/interface-connection-gater instead, this will be removed in a future release
+ * @deprecated Please use the version from `@libp2p/interface-connection-gater` instead, this will be removed in a future release
  */
 export interface ConnectionGater {
   /**

--- a/packages/interface-mocks/package.json
+++ b/packages/interface-mocks/package.json
@@ -141,6 +141,7 @@
   "dependencies": {
     "@libp2p/interface-connection": "^3.0.0",
     "@libp2p/interface-connection-encrypter": "^3.0.0",
+    "@libp2p/interface-connection-gater": "^0.0.0",
     "@libp2p/interface-connection-manager": "^1.0.0",
     "@libp2p/interface-metrics": "^4.0.0",
     "@libp2p/interface-peer-discovery": "^1.0.0",

--- a/packages/interface-mocks/src/connection-gater.ts
+++ b/packages/interface-mocks/src/connection-gater.ts
@@ -1,4 +1,4 @@
-import type { ConnectionGater } from '@libp2p/interface-connection'
+import type { ConnectionGater } from '@libp2p/interface-connection-gater'
 
 export function mockConnectionGater (): ConnectionGater {
   return {

--- a/packages/interface-mocks/src/connection-gater.ts
+++ b/packages/interface-mocks/src/connection-gater.ts
@@ -10,6 +10,9 @@ export function mockConnectionGater (): ConnectionGater {
     denyOutboundEncryptedConnection: async () => await Promise.resolve(false),
     denyInboundUpgradedConnection: async () => await Promise.resolve(false),
     denyOutboundUpgradedConnection: async () => await Promise.resolve(false),
+    denyInboundRelayReservation: async () => await Promise.resolve(false),
+    denyOutboundRelayedConnection: async () => await Promise.resolve(false),
+    denyInboundRelayedConnection: async () => await Promise.resolve(false),
     filterMultiaddrForPeer: async () => await Promise.resolve(true)
   }
 }


### PR DESCRIPTION
Deprecates use of connection gater from `@libp2p/interface-connection` as it's not part of the maconn/connection/stream group and instead is a cross-cuttuing security concern.

Non breaking for now, we can remove the original gater interface at a later date.