### PR TITLE
fix: filter closed connections properly

### DIFF
--- a/packages/interface-mocks/src/connection-manager.ts
+++ b/packages/interface-mocks/src/connection-manager.ts
@@ -150,7 +150,7 @@ class MockConnectionManager extends EventEmitter<ConnectionManagerEvents> implem
       await conn.close()
     }
 
-    this.connections = this.connections.filter(c => c.remotePeer.equals(peerId))
+    this.connections = this.connections.filter(c => !c.remotePeer.equals(peerId))
 
     await componentsB.connectionManager?.closeConnections(this.components.peerId)
   }


### PR DESCRIPTION
When closing all connections to a peer, the resulting connection list should be all connnections not to that peer.