### PR TITLE
fix: reject promise with error not string

### DIFF
--- a/packages/interface-pubsub-compliance-tests/src/two-nodes.ts
+++ b/packages/interface-pubsub-compliance-tests/src/two-nodes.ts
@@ -162,7 +162,7 @@ export default (common: TestSetup<PubSub, PubSubArgs>): void => {
       psA.subscribe(topic)
 
       psB.topicValidators.set(topic, (peer, message) => {
-        if (peer.equals(componentsA.peerId)) {
+        if (!peer.equals(componentsA.peerId)) {
           defer.reject(new Error('Invalid peer id in topic validator fn'))
           return TopicValidatorResult.Reject
         }

--- a/packages/interface-pubsub-compliance-tests/src/two-nodes.ts
+++ b/packages/interface-pubsub-compliance-tests/src/two-nodes.ts
@@ -163,12 +163,12 @@ export default (common: TestSetup<PubSub, PubSubArgs>): void => {
 
       psB.topicValidators.set(topic, (peer, message) => {
         if (peer.equals(componentsA.peerId)) {
-          defer.reject('Invalid peer id in topic validator fn')
+          defer.reject(new Error('Invalid peer id in topic validator fn'))
           return TopicValidatorResult.Reject
         }
 
         if (uint8ArrayToString(message.data) !== 'hey') {
-          defer.reject('Invalid message in topic validator fn')
+          defer.reject(new Error('Invalid message in topic validator fn'))
           return TopicValidatorResult.Reject
         }
 


### PR DESCRIPTION
Promises should be rejected with an error not a string, otherwise the wrong type is thrown