### PR TITLE
feat: add content and peer routing progress events

### DIFF
--- a/packages/interface-content-routing/package.json
+++ b/packages/interface-content-routing/package.json
@@ -134,7 +134,8 @@
   "dependencies": {
     "@libp2p/interface-peer-info": "^1.0.0",
     "@libp2p/interfaces": "^3.0.0",
-    "multiformats": "^11.0.0"
+    "multiformats": "^11.0.0",
+    "progress-events": "^1.0.0"
   },
   "devDependencies": {
     "aegir": "^38.1.0"

--- a/packages/interface-content-routing/src/index.ts
+++ b/packages/interface-content-routing/src/index.ts
@@ -1,8 +1,14 @@
 import type { CID } from 'multiformats/cid'
 import type { AbortOptions } from '@libp2p/interfaces'
 import type { PeerInfo } from '@libp2p/interface-peer-info'
+import type { ProgressEvent, ProgressOptions } from 'progress-events'
 
-export interface ContentRouting {
+export interface ContentRouting<
+  ProvideProgressEvents extends ProgressEvent = ProgressEvent,
+  FindProvidersProgressEvents extends ProgressEvent = ProgressEvent,
+  PutProgressEvents extends ProgressEvent = ProgressEvent,
+  GetProgressEvents extends ProgressEvent = ProgressEvent
+> {
   /**
    * The implementation of this method should ensure that network peers know the
    * caller can provide content that corresponds to the passed CID.
@@ -14,7 +20,7 @@ export interface ContentRouting {
    * await contentRouting.provide(cid)
    * ```
    */
-  provide: (cid: CID, options?: AbortOptions) => Promise<void>
+  provide: (cid: CID, options?: AbortOptions & ProgressOptions<ProvideProgressEvents>) => Promise<void>
 
   /**
    * Find the providers of the passed CID.
@@ -28,7 +34,7 @@ export interface ContentRouting {
    * }
    * ```
    */
-  findProviders: (cid: CID, options?: AbortOptions) => AsyncIterable<PeerInfo>
+  findProviders: (cid: CID, options?: AbortOptions & ProgressOptions<FindProvidersProgressEvents>) => AsyncIterable<PeerInfo>
 
   /**
    * Puts a value corresponding to the passed key in a way that can later be
@@ -44,7 +50,7 @@ export interface ContentRouting {
    * await contentRouting.put(key, value)
    * ```
    */
-  put: (key: Uint8Array, value: Uint8Array, options?: AbortOptions) => Promise<void>
+  put: (key: Uint8Array, value: Uint8Array, options?: AbortOptions & ProgressOptions<PutProgressEvents>) => Promise<void>
 
   /**
    * Retrieves a value from the network corresponding to the passed key.
@@ -58,5 +64,5 @@ export interface ContentRouting {
    * const value = await contentRouting.get(key)
    * ```
    */
-  get: (key: Uint8Array, options?: AbortOptions) => Promise<Uint8Array>
+  get: (key: Uint8Array, options?: AbortOptions & ProgressOptions<GetProgressEvents>) => Promise<Uint8Array>
 }

--- a/packages/interface-libp2p/package.json
+++ b/packages/interface-libp2p/package.json
@@ -144,7 +144,8 @@
     "@libp2p/interface-pubsub": "^3.0.0",
     "@libp2p/interface-registrar": "^2.0.0",
     "@libp2p/interfaces": "^3.0.0",
-    "@multiformats/multiaddr": "^12.0.0"
+    "@multiformats/multiaddr": "^12.0.0",
+    "progress-events": "^1.0.0"
   },
   "devDependencies": {
     "aegir": "^38.1.0"

--- a/packages/interface-libp2p/src/index.ts
+++ b/packages/interface-libp2p/src/index.ts
@@ -29,6 +29,7 @@ import type { StreamHandler, StreamHandlerOptions, Topology } from '@libp2p/inte
 import type { Metrics } from '@libp2p/interface-metrics'
 import type { PeerInfo } from '@libp2p/interface-peer-info'
 import type { KeyChain } from '@libp2p/interface-keychain'
+import type { ProgressEvent } from 'progress-events'
 
 /**
  * Once you have a libp2p instance, you can listen to several events it emits, so that you can be notified of relevant network events.
@@ -87,7 +88,14 @@ export interface LookupFunction {
 /**
  * Libp2p nodes implement this interface.
  */
-export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
+export interface Libp2p<
+  FindPeerProgressEvents extends ProgressEvent = ProgressEvent,
+  GetClosestPeersProgressEvents extends ProgressEvent = ProgressEvent,
+  ProvideProgressEvents extends ProgressEvent = ProgressEvent,
+  FindProvidersProgressEvents extends ProgressEvent = ProgressEvent,
+  PutProgressEvents extends ProgressEvent = ProgressEvent,
+  GetProgressEvents extends ProgressEvent = ProgressEvent
+> extends Startable, EventEmitter<Libp2pEvents> {
   /**
    * The PeerId is a unique identifier for a node on the network.
    *
@@ -138,7 +146,7 @@ export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
    * }
    * ```
    */
-  peerRouting: PeerRouting
+  peerRouting: PeerRouting<FindPeerProgressEvents, GetClosestPeersProgressEvents>
 
   /**
    * The content routing subsystem allows the user to find providers for content,
@@ -154,7 +162,7 @@ export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
    * }
    * ```
    */
-  contentRouting: ContentRouting
+  contentRouting: ContentRouting<ProvideProgressEvents, FindProvidersProgressEvents, PutProgressEvents, GetProgressEvents>
 
   /**
    * The keychain contains the keys used by the current node, and can create new

--- a/packages/interface-peer-routing/package.json
+++ b/packages/interface-peer-routing/package.json
@@ -134,7 +134,8 @@
   "dependencies": {
     "@libp2p/interface-peer-id": "^2.0.0",
     "@libp2p/interface-peer-info": "^1.0.0",
-    "@libp2p/interfaces": "^3.0.0"
+    "@libp2p/interfaces": "^3.0.0",
+    "progress-events": "^1.0.0"
   },
   "devDependencies": {
     "aegir": "^38.1.0"

--- a/packages/interface-peer-routing/src/index.ts
+++ b/packages/interface-peer-routing/src/index.ts
@@ -1,8 +1,12 @@
 import type { PeerId } from '@libp2p/interface-peer-id'
 import type { PeerInfo } from '@libp2p/interface-peer-info'
 import type { AbortOptions } from '@libp2p/interfaces'
+import type { ProgressEvent, ProgressOptions } from 'progress-events'
 
-export interface PeerRouting {
+export interface PeerRouting<
+  FindPeerProgressEvents extends ProgressEvent = ProgressEvent,
+  GetClosestPeersProgressEvents extends ProgressEvent = ProgressEvent,
+> {
   /**
    * Searches the network for peer info corresponding to the passed peer id.
    *
@@ -13,7 +17,7 @@ export interface PeerRouting {
    * const peer = await peerRouting.findPeer(peerId, options)
    * ```
    */
-  findPeer: (peerId: PeerId, options?: AbortOptions) => Promise<PeerInfo>
+  findPeer: (peerId: PeerId, options?: AbortOptions & ProgressOptions<FindPeerProgressEvents>) => Promise<PeerInfo>
 
   /**
    * Search the network for peers that are closer to the passed key. Peer
@@ -28,5 +32,5 @@ export interface PeerRouting {
    * }
    * ```
    */
-  getClosestPeers: (key: Uint8Array, options?: AbortOptions) => AsyncIterable<PeerInfo>
+  getClosestPeers: (key: Uint8Array, options?: AbortOptions & ProgressOptions<GetClosestPeersProgressEvents>) => AsyncIterable<PeerInfo>
 }


### PR DESCRIPTION
These are added as optional generics so this change should be non-breaking.