### PR TITLE
fix!: remove dialer interface from interface connection manager

### DIFF
--- a/packages/interface-connection-manager/src/index.ts
+++ b/packages/interface-connection-manager/src/index.ts
@@ -78,20 +78,3 @@ export interface ConnectionManager extends EventEmitter<ConnectionManagerEvents>
    */
   afterUpgradeInbound: () => void
 }
-
-export interface Dialer {
-  /**
-   * Dial a peer or multiaddr, or multiple multiaddrs and return the promise of a connection
-   */
-  dial: (peer: PeerId | Multiaddr | Multiaddr[], options?: AbortOptions) => Promise<Connection>
-
-  /**
-   * Request `num` dial tokens. Only the returned number of dials may be attempted.
-   */
-  getTokens: (num: number) => number[]
-
-  /**
-   * After a dial attempt succeeds or fails, return the passed token to the pool
-   */
-  releaseToken: (token: number) => void
-}


### PR DESCRIPTION
The connection manager is how components open and close connections, the dialer is an internal implementation detail of libp2p so remove it from the interface.

BREAKING CHANGE: the Dialer interface has been removed