### PR TITLE
feat: add peer:prune event to connection manager

### DIFF
--- a/packages/interface-connection-manager/src/index.ts
+++ b/packages/interface-connection-manager/src/index.ts
@@ -6,7 +6,7 @@ import type { Multiaddr } from '@multiformats/multiaddr'
 
 export interface ConnectionManagerEvents {
   /**
-   * This event will be triggered anytime a new Connection is established to another peer.
+   * This event will be triggered any time a new Connection is established to another peer.
    *
    * @example
    *
@@ -20,7 +20,7 @@ export interface ConnectionManagerEvents {
   'peer:connect': CustomEvent<Connection>
 
   /**
-   * This event will be triggered anytime we are disconnected from another peer, regardless of
+   * This event will be triggered any time we are disconnected from another peer, regardless of
    * the circumstances of that disconnection. If we happen to have multiple connections to a
    * peer, this event will **only** be triggered when the last connection is closed.
    *
@@ -34,6 +34,22 @@ export interface ConnectionManagerEvents {
    * ```
    */
   'peer:disconnect': CustomEvent<Connection>
+
+  /**
+   * This event will be triggered when the connection manager has more connections than the
+   * configured limit. The event detail contains the list of PeerIds from the connections
+   * that were closed to bring the node back under the max connections limit.
+   *
+   * @example
+   *
+   * ```js
+   * libp2p.connectionManager.addEventListener('peer:prune', (event) => {
+   *   const connection = event.detail
+   *   // ...
+   * })
+   * ```
+   */
+  'peer:prune': CustomEvent<PeerId[]>
 }
 
 export interface ConnectionManager extends EventEmitter<ConnectionManagerEvents> {


### PR DESCRIPTION
Adds a `peer:prune` event to the connection manager which can be emitted when connections are pruned.