### PR TITLE
deps: update any-signal to 4.x.x

### DIFF
--- a/packages/interface-mocks/package.json
+++ b/packages/interface-mocks/package.json
@@ -158,7 +158,7 @@
     "@libp2p/peer-id-factory": "^2.0.0",
     "@multiformats/multiaddr": "^12.0.0",
     "abortable-iterator": "^4.0.2",
-    "any-signal": "^3.0.1",
+    "any-signal": "^4.1.1",
     "it-handshake": "^4.0.0",
     "it-map": "^2.0.0",
     "it-ndjson": "^1.0.0",

--- a/packages/interface-mocks/src/connection-encrypter.ts
+++ b/packages/interface-mocks/src/connection-encrypter.ts
@@ -33,7 +33,7 @@ export function mockConnectionEncrypter (): ConnectionEncrypter {
       const remotePeer = peerIdFromBytes(remoteId.slice())
       shake.rest()
 
-      if (expectedPeer != null && !expectedPeer.equals(remotePeer)) {
+      if (expectedPeer?.equals(remotePeer) === false) {
         throw new UnexpectedPeerError()
       }
 

--- a/packages/interface-mocks/src/muxer.ts
+++ b/packages/interface-mocks/src/muxer.ts
@@ -128,11 +128,13 @@ class MuxedStream {
           throw new CodeError('stream closed for writing', 'ERR_SINK_ENDED')
         }
 
-        source = abortableSource(source, anySignal([
+        const signal = anySignal([
           this.abortController.signal,
           this.resetController.signal,
           this.closeController.signal
-        ]))
+        ])
+
+        source = abortableSource(source, signal)
 
         try {
           if (this.type === 'initiator') {
@@ -195,6 +197,8 @@ class MuxedStream {
           this.input.end(err)
           onSinkEnd(err)
           return
+        } finally {
+          signal.clear()
         }
 
         this.log('sink ended')


### PR DESCRIPTION
`any-signal@4.x.x` adds a `.clear` method that removes `'abort'` listeners which can be a cause of memory leaks.