### PR TITLE
feat: expose get connection map method of connection manager

### DIFF
--- a/packages/interface-connection-manager/package.json
+++ b/packages/interface-connection-manager/package.json
@@ -135,6 +135,7 @@
     "@libp2p/interface-connection": "^4.0.0",
     "@libp2p/interface-peer-id": "^2.0.0",
     "@libp2p/interfaces": "^3.0.0",
+    "@libp2p/peer-collections": "^3.0.1",
     "@multiformats/multiaddr": "^12.0.0"
   },
   "devDependencies": {

--- a/packages/interface-connection-manager/src/index.ts
+++ b/packages/interface-connection-manager/src/index.ts
@@ -3,6 +3,7 @@ import type { EventEmitter } from '@libp2p/interfaces/events'
 import type { Connection, MultiaddrConnection } from '@libp2p/interface-connection'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import type { Multiaddr } from '@multiformats/multiaddr'
+import type { PeerMap } from '@libp2p/peer-collections'
 
 export interface ConnectionManagerEvents {
   /**
@@ -64,6 +65,17 @@ export interface ConnectionManager extends EventEmitter<ConnectionManagerEvents>
    * ```
    */
   getConnections: (peerId?: PeerId) => Connection[]
+
+  /**
+   * Return a map of all connections with their associated PeerIds
+   *
+   * @example
+   *
+   * ```js
+   * const connectionsMap = libp2p.connectionManager.getConnectionsMap()
+   * ```
+   */
+  getConnectionsMap: () => PeerMap<Connection[]>
 
   /**
    * Open a connection to a remote peer

--- a/packages/interface-mocks/package.json
+++ b/packages/interface-mocks/package.json
@@ -154,6 +154,7 @@
     "@libp2p/interfaces": "^3.0.0",
     "@libp2p/logger": "^2.0.0",
     "@libp2p/multistream-select": "^3.0.0",
+    "@libp2p/peer-collections": "^3.0.1",
     "@libp2p/peer-id": "^2.0.0",
     "@libp2p/peer-id-factory": "^2.0.0",
     "@multiformats/multiaddr": "^12.0.0",

--- a/packages/interface-mocks/src/connection-manager.ts
+++ b/packages/interface-mocks/src/connection-manager.ts
@@ -90,7 +90,7 @@ class MockConnectionManager extends EventEmitter<ConnectionManagerEvents> implem
   getConnectionsMap (): PeerMap<Connection[]> {
     const map = new PeerMap<Connection[]>()
 
-    for (let conn of this.connections) {
+    for (const conn of this.connections) {
       const conns: Connection[] = map.get(conn.remotePeer) ?? []
       conns.push(conn)
 

--- a/packages/interface-mocks/src/connection-manager.ts
+++ b/packages/interface-mocks/src/connection-manager.ts
@@ -9,6 +9,7 @@ import type { Registrar } from '@libp2p/interface-registrar'
 import type { PubSub } from '@libp2p/interface-pubsub'
 import { isMultiaddr, Multiaddr } from '@multiformats/multiaddr'
 import { peerIdFromString } from '@libp2p/peer-id'
+import { PeerMap } from '@libp2p/peer-collections'
 
 export interface MockNetworkComponents {
   peerId: PeerId
@@ -84,6 +85,19 @@ class MockConnectionManager extends EventEmitter<ConnectionManagerEvents> implem
     }
 
     return this.connections
+  }
+
+  getConnectionsMap (): PeerMap<Connection[]> {
+    const map = new PeerMap<Connection[]>()
+
+    for (let conn of this.connections) {
+      const conns: Connection[] = map.get(conn.remotePeer) ?? []
+      conns.push(conn)
+
+      map.set(conn.remotePeer, conns)
+    }
+
+    return map
   }
 
   async openConnection (peerId: PeerId | Multiaddr | Multiaddr[]): Promise<Connection> {


### PR DESCRIPTION
Exposes the collection of managed connections as a peer map.