### PR TITLE
fix!: remove getPublicKey method

### DIFF
--- a/packages/interface-libp2p/src/index.ts
+++ b/packages/interface-libp2p/src/index.ts
@@ -469,10 +469,4 @@ export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
    * ```
    */
   fetch: (peer: PeerId | Multiaddr, key: string, options?: AbortOptions) => Promise<Uint8Array | null>
-
-  /**
-   * Returns the public key for the passed PeerId. If the PeerId is of the 'RSA' type
-   * this may mean searching the DHT if the key is not present in the KeyStore.
-   */
-  getPublicKey: (peer: PeerId, options?: AbortOptions) => Promise<Uint8Array>
 }


### PR DESCRIPTION
The getPublicKey method can be used to fetch the public key of a peer that uses an RSA peer id.

The same thing can be accomplished by using content routing to look up the value for the `/pk` key.  E.g

```js
const peerKey = uint8ArrayConcat([
  uint8ArrayFromString('/pk/'),
  peerId.multihash.digest
])

const key = await node.contentRouting.get(peerKey)
```

BREAKING CHANGE: the getPublicKey method has been removed