### PR TITLE
fix: specify stream sink return type

### DIFF
--- a/packages/interface-connection/src/index.ts
+++ b/packages/interface-connection/src/index.ts
@@ -72,7 +72,7 @@ export interface StreamStat {
  * It may be encrypted and multiplexed depending on the
  * configuration of the nodes.
  */
-export interface Stream extends Duplex<AsyncGenerator<Uint8ArrayList>, Source<Uint8ArrayList | Uint8Array>> {
+export interface Stream extends Duplex<AsyncGenerator<Uint8ArrayList>, Source<Uint8ArrayList | Uint8Array>, Promise<void>> {
   /**
    * Closes the stream for **reading** *and* **writing**.
    *

--- a/packages/interface-mocks/package.json
+++ b/packages/interface-mocks/package.json
@@ -153,7 +153,7 @@
     "@libp2p/interface-transport": "^3.0.0",
     "@libp2p/interfaces": "^3.0.0",
     "@libp2p/logger": "^2.0.0",
-    "@libp2p/multistream-select": "^3.1.6",
+    "@libp2p/multistream-select": "^3.1.7",
     "@libp2p/peer-collections": "^3.0.1",
     "@libp2p/peer-id": "^2.0.0",
     "@libp2p/peer-id-factory": "^2.0.0",

--- a/packages/interface-mocks/src/connection.ts
+++ b/packages/interface-mocks/src/connection.ts
@@ -170,7 +170,7 @@ export function mockConnection (maConn: MultiaddrConnection, opts: MockConnectio
   return connection
 }
 
-export function mockStream (stream: Duplex<AsyncGenerator<Uint8ArrayList>, Source<Uint8ArrayList | Uint8Array>>): Stream {
+export function mockStream (stream: Duplex<AsyncGenerator<Uint8ArrayList>, Source<Uint8ArrayList | Uint8Array>, Promise<void>>): Stream {
   return {
     ...stream,
     close: () => {},


### PR DESCRIPTION
To let tsc handle return types properly and avoid the `unknown` type.