### PR TITLE
fix: downgrade @interface/connection in modules without a major

### DIFF
--- a/packages/interface-connection-manager/package.json
+++ b/packages/interface-connection-manager/package.json
@@ -132,7 +132,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/interface-connection": "^5.0.0",
+    "@libp2p/interface-connection": "^4.0.0",
     "@libp2p/interface-peer-id": "^2.0.0",
     "@libp2p/interfaces": "^3.0.0",
     "@libp2p/peer-collections": "^3.0.1",

--- a/packages/interface-libp2p/package.json
+++ b/packages/interface-libp2p/package.json
@@ -132,7 +132,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/interface-connection": "^5.0.0",
+    "@libp2p/interface-connection": "^4.0.0",
     "@libp2p/interface-content-routing": "^2.0.0",
     "@libp2p/interface-dht": "^2.0.0",
     "@libp2p/interface-keychain": "^2.0.0",

--- a/packages/interface-metrics/package.json
+++ b/packages/interface-metrics/package.json
@@ -132,7 +132,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/interface-connection": "^5.0.0"
+    "@libp2p/interface-connection": "^4.0.0"
   },
   "devDependencies": {
     "aegir": "^38.1.0"

--- a/packages/interface-registrar/package.json
+++ b/packages/interface-registrar/package.json
@@ -132,7 +132,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/interface-connection": "^5.0.0",
+    "@libp2p/interface-connection": "^4.0.0",
     "@libp2p/interface-peer-id": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updating to new stream types has broken a few consumers as the transient dep update should have been a major.

Downgrade those affected modules and re-release the upgrade as a major later.