### PR TITLE
fix: added promise to PendingDial interface

### DIFF
--- a/packages/interface-connection-manager/src/index.ts
+++ b/packages/interface-connection-manager/src/index.ts
@@ -12,6 +12,7 @@ export interface PendingDial {
   status: PendingDialStatus
   peerId?: PeerId
   multiaddrs: Multiaddr[]
+  promise: Promise<Connection>
 }
 
 export interface ConnectionManagerEvents {


### PR DESCRIPTION
Given that [getDialQueue](https://github.com/libp2p/js-libp2p/blob/master/src/libp2p.ts#L348) calls the internal connection manager's [getDialQueue](https://github.com/libp2p/js-libp2p/blob/master/src/connection-manager/index.ts#L602) method, which would return the current `pendingDials`,  it's expected this would include an array of `PendingDials` containing the [promises of connections](https://github.com/libp2p/js-libp2p/blob/master/src/connection-manager/dial-queue.ts#L36) , this updates the interface to reflect that.