### PR TITLE
feat: add getAddresses function to return detailed address info

### DIFF
--- a/packages/interface-libp2p/src/index.ts
+++ b/packages/interface-libp2p/src/index.ts
@@ -47,6 +47,34 @@ export interface PeerUpdate {
 }
 
 /**
+ * A address this node knows about
+ */
+export interface NodeAddress {
+  /**
+   * This address as a multiaddr
+   */
+  multiaddr: Multiaddr
+
+  /**
+   * If `true`, this address is advertised to the network via peer records and the
+   * Identify protocols
+   */
+  announce?: boolean
+
+  /**
+   * If `true`, this address was observed by remote peers and communicated back to
+   * this node via the AutoNAT protocol
+   */
+  observed?: boolean
+
+  /**
+   * Only set on `observed` addresses - if `true` the node has confidence that this
+   * address is publicly routable and remote peers can dial it
+   */
+  confidence?: boolean
+}
+
+/**
  * Once you have a libp2p instance, you can listen to several events it emits,
  * so that you can be notified of relevant network events.
  *
@@ -403,6 +431,22 @@ export interface Libp2p extends Startable, EventEmitter<Libp2pEvents> {
    * ```
    */
   getMultiaddrs: () => Multiaddr[]
+
+  /**
+   * Returns a list of address this node is listening on and the status
+   * of those addresses
+   *
+   * @example
+   *
+   * ```js
+   * const listenMa = libp2p.getAddresses()
+   * // [{
+   * //   multiaddr: <Multiaddr 047f00000106f9ba - /ip4/127.0.0.1/tcp/63930>
+   * //   announce: true
+   * // }]
+   * ```
+   */
+  getAddresses: () => NodeAddress[]
 
   /**
    * Returns a list of supported protocols


### PR DESCRIPTION
Returning a plain list of multiaddrs isn't enough to know what is going on with the state of a node's addresses.

This PR adds a `getAddresses` function that returns detailed info about the addresses - are they being announced, was it an observed address, are we confident that the observed address is publicly routable, etc.