### PR TITLE
feat: add routing symbols

### DIFF
--- a/packages/interface-content-routing/src/index.ts
+++ b/packages/interface-content-routing/src/index.ts
@@ -2,6 +2,27 @@ import type { CID } from 'multiformats/cid'
 import type { AbortOptions } from '@libp2p/interfaces'
 import type { PeerInfo } from '@libp2p/interface-peer-info'
 
+/**
+ * Any object that implements this Symbol as a property should return a
+ * ContentRouting instance as the property value, similar to how
+ * `Symbol.Iterable` can be used to return an `Iterable` from an `Iterator`.
+ *
+ * @example
+ *
+ * ```js
+ * import { symbol, ContentRouting } from '@libp2p/content-routing'
+ *
+ * class MyContentRouter implements ContentRouting {
+ *   get [symbol] () {
+ *     return this
+ *   }
+ *
+ *   // ...other methods
+ * }
+ * ```
+ */
+export const symbol = Symbol.for('@libp2p/content-routing')
+
 export interface ContentRouting {
   /**
    * The implementation of this method should ensure that network peers know the

--- a/packages/interface-peer-routing/src/index.ts
+++ b/packages/interface-peer-routing/src/index.ts
@@ -2,6 +2,27 @@ import type { PeerId } from '@libp2p/interface-peer-id'
 import type { PeerInfo } from '@libp2p/interface-peer-info'
 import type { AbortOptions } from '@libp2p/interfaces'
 
+/**
+ * Any object that implements this Symbol as a property should return a
+ * PeerRouting instance as the property value, similar to how
+ * `Symbol.Iterable` can be used to return an `Iterable` from an `Iterator`.
+ *
+ * @example
+ *
+ * ```js
+ * import { symbol, PeerRouting } from '@libp2p/peer-routing'
+ *
+ * class MyPeerRouter implements PeerRouting {
+ *   get [symbol] () {
+ *     return this
+ *   }
+ *
+ *   // ...other methods
+ * }
+ * ```
+ */
+export const symbol = Symbol.for('@libp2p/peer-routing')
+
 export interface PeerRouting {
   /**
    * Searches the network for peer info corresponding to the passed peer id.


### PR DESCRIPTION
When libp2p is [configured with arbitrary services](https://github.com/libp2p/js-libp2p/pull/1563) some of those services may be content routers or peer routers or both.  An example of this is the `@libp2p/kad-dht` module.

In order to communicate to libp2p that they can provide content/peer routing cabapiliy, add well-known symbols that libp2p can use to get references to the routing implementations.