### PR TITLE
feat!: rename peer discovery symbol to peerDiscovery

### DIFF
--- a/packages/interface-mocks/src/peer-discovery.ts
+++ b/packages/interface-mocks/src/peer-discovery.ts
@@ -1,4 +1,4 @@
-import { symbol } from '@libp2p/interface-peer-discovery'
+import { peerDiscovery } from '@libp2p/interface-peer-discovery'
 import { EventEmitter } from '@libp2p/interfaces/events'
 import * as PeerIdFactory from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
@@ -24,9 +24,7 @@ export class MockDiscovery extends EventEmitter<PeerDiscoveryEvents> implements 
     this._isRunning = false
   }
 
-  readonly [symbol] = true
-
-  readonly [Symbol.toStringTag] = 'MockDiscovery'
+  readonly [peerDiscovery] = this
 
   start (): void {
     this._isRunning = true

--- a/packages/interface-peer-discovery/src/index.ts
+++ b/packages/interface-peer-discovery/src/index.ts
@@ -22,24 +22,8 @@ import type { EventEmitter } from '@libp2p/interfaces/events'
  */
 export const peerDiscovery = Symbol.for('@libp2p/peer-discovery')
 
-export const symbol = Symbol.for('@libp2p/peer-discovery')
-
 export interface PeerDiscoveryEvents {
   'peer': CustomEvent<PeerInfo>
 }
 
-export interface PeerDiscovery extends EventEmitter<PeerDiscoveryEvents> {
-  /**
-   * Used to identify the peer discovery mechanism
-   */
-  [Symbol.toStringTag]: string
-
-  /**
-   * Used by the isPeerDiscovery function
-   */
-  [symbol]: true
-}
-
-export function isPeerDiscovery (other: any): other is PeerDiscovery {
-  return other != null && Boolean(other[symbol])
-}
+export type PeerDiscovery = EventEmitter<PeerDiscoveryEvents>

--- a/packages/interface-peer-discovery/src/index.ts
+++ b/packages/interface-peer-discovery/src/index.ts
@@ -26,4 +26,4 @@ export interface PeerDiscoveryEvents {
   'peer': CustomEvent<PeerInfo>
 }
 
-export type PeerDiscovery = EventEmitter<PeerDiscoveryEvents>
+export interface PeerDiscovery extends EventEmitter<PeerDiscoveryEvents> {}


### PR DESCRIPTION
The export `symbol` from the `@libp2p/interface-peer-discovery` is too generic to use with modules that might implement peer discovery and something else so it's been renamed to `peerDiscovery`.

Objects with `peerDiscovery` symbol properties getters should return `PeerDiscovery` instances instead of `boolean` values.

BREAKING CHANGE: the `symbol` export is now named `peerDiscovery`