### PR TITLE
fix: expose getListeners method from the transport manager

### DIFF
--- a/packages/interface-transport/src/index.ts
+++ b/packages/interface-transport/src/index.ts
@@ -105,6 +105,7 @@ export interface TransportManager {
   dial: (ma: Multiaddr, options?: any) => Promise<Connection>
   getAddrs: () => Multiaddr[]
   getTransports: () => Transport[]
+  getListeners: () => Listener[]
   transportForMultiaddr: (ma: Multiaddr) => Transport | undefined
   listen: (addrs: Multiaddr[]) => Promise<void>
   remove: (key: string) => Promise<void>


### PR DESCRIPTION
To make transports that piggy-back on top of other transports able to report their multiaddrs more reliably, expose the getListeners function implemented by the transport manager.