### PR TITLE
feat: add closeRead and closeWrite to stream timeline properties

### DIFF
--- a/packages/interface-connection/src/index.ts
+++ b/packages/interface-connection/src/index.ts
@@ -44,8 +44,22 @@ export interface ConnectionStat {
 }
 
 export interface StreamTimeline {
+  /**
+   * A timestamp of when the stream was opened
+   */
   open: number
+  /**
+   * A timestamp of when the stream was closed for both reading and writing
+   */
   close?: number
+  /**
+   * A timestamp of when the stream was closed for reading
+   */
+  closeRead?: number
+  /**
+   * A timestamp of when the stream was closed for writing
+   */
+  closeWrite?: number
 }
 
 export interface StreamStat {

--- a/packages/interface-connection/src/index.ts
+++ b/packages/interface-connection/src/index.ts
@@ -48,18 +48,26 @@ export interface StreamTimeline {
    * A timestamp of when the stream was opened
    */
   open: number
+
   /**
    * A timestamp of when the stream was closed for both reading and writing
    */
   close?: number
+
   /**
    * A timestamp of when the stream was closed for reading
    */
   closeRead?: number
+
   /**
    * A timestamp of when the stream was closed for writing
    */
   closeWrite?: number
+
+  /**
+   * A timestamp of when the stream was reset
+   */
+  reset?: number
 }
 
 export interface StreamStat {


### PR DESCRIPTION
Since streams can be closed for reading independently of being closed for writing, add separate optional keys for these events in the stream timeline interface.