### PR TITLE
fix: update interface stream muxer config

### DIFF
--- a/packages/interface-stream-muxer/package.json
+++ b/packages/interface-stream-muxer/package.json
@@ -21,6 +21,22 @@
   },
   "type": "module",
   "types": "./dist/src/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "*",
+        "dist/*",
+        "dist/src/*",
+        "dist/src/*/index"
+      ],
+      "src/*": [
+        "*",
+        "dist/*",
+        "dist/src/*",
+        "dist/src/*/index"
+      ]
+    }
+  },
   "files": [
     "src",
     "dist",


### PR DESCRIPTION
Allows typescript to find the typedefs for the stream.js file.