### PR TITLE
fix: handle thrown errors

### DIFF
--- a/packages/interface-stream-muxer-compliance-tests/src/close-test.ts
+++ b/packages/interface-stream-muxer-compliance-tests/src/close-test.ts
@@ -124,7 +124,7 @@ export default (common: TestSetup<StreamMuxerFactory>): void => {
         direction: 'inbound',
         onIncomingStream: (stream) => {
           openedStreams++
-          void pipe(stream, stream)
+          void pipe(stream, stream).catch(() => {})
         }
       })
 
@@ -193,7 +193,7 @@ export default (common: TestSetup<StreamMuxerFactory>): void => {
       const listener = listenerFactory.createStreamMuxer({
         direction: 'inbound',
         onIncomingStream: (stream) => {
-          void pipe(stream, stream)
+          void pipe(stream, stream).catch(() => {})
         }
       })
 

--- a/packages/interface-stream-muxer-compliance-tests/src/close-test.ts
+++ b/packages/interface-stream-muxer-compliance-tests/src/close-test.ts
@@ -81,7 +81,7 @@ export default (common: TestSetup<StreamMuxerFactory>): void => {
         direction: 'inbound',
         onIncomingStream: (stream) => {
           openedStreams++
-          void pipe(stream, stream)
+          void pipe(stream, stream).catch(err => {})
         }
       })
 

--- a/packages/interface-stream-muxer-compliance-tests/src/close-test.ts
+++ b/packages/interface-stream-muxer-compliance-tests/src/close-test.ts
@@ -81,7 +81,7 @@ export default (common: TestSetup<StreamMuxerFactory>): void => {
         direction: 'inbound',
         onIncomingStream: (stream) => {
           openedStreams++
-          void pipe(stream, stream).catch(err => {})
+          void pipe(stream, stream).catch(() => {})
         }
       })
 


### PR DESCRIPTION
The pipe can throw when errors occur so handle the errors.