### PR TITLE
feat: add start/stop events to libp2p interface

### DIFF
--- a/packages/interface-libp2p/src/index.ts
+++ b/packages/interface-libp2p/src/index.ts
@@ -303,7 +303,7 @@ export interface PendingDial {
 /**
  * Libp2p nodes implement this interface.
  */
-export interface Libp2p<T extends ServiceMap = Record<string, unknown>> extends Startable, EventEmitter<Libp2pEvents<T>> {
+export interface Libp2p<T extends ServiceMap = ServiceMap> extends Startable, EventEmitter<Libp2pEvents<T>> {
   /**
    * The PeerId is a unique identifier for a node on the network.
    *


### PR DESCRIPTION
To let observers know a node has started or stopped, dispatch start
and stop events at the relevant times.