### PR TITLE
fix: update query event naming 

### DIFF
--- a/packages/interface-dht/src/index.ts
+++ b/packages/interface-dht/src/index.ts
@@ -8,14 +8,14 @@ import type { CID } from 'multiformats/cid'
  * The types of events emitted during DHT queries
  */
 export enum EventTypes {
-  SENDING_QUERY = 0,
+  SEND_QUERY = 0,
   PEER_RESPONSE,
   FINAL_PEER,
   QUERY_ERROR,
   PROVIDER,
   VALUE,
-  ADDING_PEER,
-  DIALING_PEER
+  ADD_PEER,
+  DIAL_PEER
 }
 
 /**
@@ -45,10 +45,10 @@ export interface QueryOptions extends AbortOptions {
 /**
  * Emitted when sending queries to remote peers
  */
-export interface SendingQueryEvent {
+export interface SendQueryEvent {
   to: PeerId
-  type: EventTypes.SENDING_QUERY
-  name: 'SENDING_QUERY'
+  type: EventTypes.SEND_QUERY
+  name: 'SEND_QUERY'
   messageName: keyof typeof MessageType
   messageType: MessageType
 }
@@ -111,22 +111,22 @@ export interface ValueEvent {
 /**
  * Emitted when peers are added to a query
  */
-export interface AddingPeerEvent {
-  type: EventTypes.ADDING_PEER
-  name: 'ADDING_PEER'
+export interface AddPeerEvent {
+  type: EventTypes.ADD_PEER
+  name: 'ADD_PEER'
   peer: PeerId
 }
 
 /**
  * Emitted when peers are dialled as part of a query
  */
-export interface DialingPeerEvent {
+export interface DialPeerEvent {
   peer: PeerId
-  type: EventTypes.DIALING_PEER
-  name: 'DIALING_PEER'
+  type: EventTypes.DIAL_PEER
+  name: 'DIAL_PEER'
 }
 
-export type QueryEvent = SendingQueryEvent | PeerResponseEvent | FinalPeerEvent | QueryErrorEvent | ProviderEvent | ValueEvent | AddingPeerEvent | DialingPeerEvent
+export type QueryEvent = SendQueryEvent | PeerResponseEvent | FinalPeerEvent | QueryErrorEvent | ProviderEvent | ValueEvent | AddPeerEvent | DialPeerEvent
 
 export interface RoutingTable {
   size: number


### PR DESCRIPTION
Closes #409