### PR TITLE
fix: add maxOutboundStreams option to connection.newStream

### DIFF
--- a/packages/interface-connection/src/index.ts
+++ b/packages/interface-connection/src/index.ts
@@ -158,6 +158,15 @@ export interface Stream extends Duplex<AsyncGenerator<Uint8ArrayList>, Source<Ui
   metadata: Record<string, any>
 }
 
+export interface NewStreamOptions extends AbortOptions {
+  /**
+   * If specified, and no handler has been registered with the registrar for the
+   * successfully negotiated protocol, use this as the max outbound stream limit
+   * for the protocol
+   */
+  maxOutboundStreams?: number
+}
+
 /**
  * A Connection is a high-level representation of a connection
  * to a remote peer that may have been secured by encryption and
@@ -172,7 +181,7 @@ export interface Connection {
   tags: string[]
   streams: Stream[]
 
-  newStream: (multicodecs: string | string[], options?: AbortOptions) => Promise<Stream>
+  newStream: (multicodecs: string | string[], options?: NewStreamOptions) => Promise<Stream>
   addStream: (stream: Stream) => void
   removeStream: (id: string) => void
   close: () => Promise<void>


### PR DESCRIPTION
When no handler has been registered for a protocol, the upgrader falls back to the default limit of 64 streams for the protocol on the current connection.

This PR adds a `maxOutboundStreams` option to `connection.newStream` that gives the user a way to override the default outgoing stream count without having to register a dummy handler.