### PR TITLE
fix: removed connection methods #356

### DIFF
--- a/packages/interface-connection/src/index.ts
+++ b/packages/interface-connection/src/index.ts
@@ -180,11 +180,6 @@ export interface Connection {
   remotePeer: PeerId
   tags: string[]
   streams: Stream[]
-
-  newStream: (multicodecs: string | string[], options?: NewStreamOptions) => Promise<Stream>
-  addStream: (stream: Stream) => void
-  removeStream: (id: string) => void
-  close: () => Promise<void>
 }
 
 export const symbol = Symbol.for('@libp2p/connection')


### PR DESCRIPTION
the muxer should be responsible for managing and storing references to streams, not the connection.